### PR TITLE
Reformat using black formatting

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,11 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'RosettaSciIO'
-copyright = '2022, HyperSpy Developers'
-author = 'HyperSpy Developers'
+project = "RosettaSciIO"
+copyright = "2022, HyperSpy Developers"
+author = "HyperSpy Developers"
 
 
 # -- General configuration ---------------------------------------------------
@@ -28,9 +28,9 @@ author = 'HyperSpy Developers'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.githubpages',
-    'sphinx.ext.intersphinx',
-    'sphinxcontrib.towncrier',
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+    "sphinxcontrib.towncrier",
 ]
 
 intersphinx_mapping = {
@@ -40,12 +40,12 @@ intersphinx_mapping = {
 }
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -53,12 +53,12 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_theme_options = {
     "icon_links": [
@@ -81,7 +81,7 @@ html_theme_options = {
             "icon": "",
             # The type of image to be used (see below for details)
             "type": "local",
-        }
+        },
     ],
     "logo": {
         "text": "RosettaSciIO",
@@ -104,7 +104,7 @@ html_sidebars = {
 # -- Options for towncrier_draft extension -----------------------------------
 
 # Options: draft/sphinx-version/sphinx-release
-towncrier_draft_autoversion_mode = 'draft'
+towncrier_draft_autoversion_mode = "draft"
 towncrier_draft_include_empty = False
 towncrier_draft_working_directory = ".."
 

--- a/rsciio/__init__.py
+++ b/rsciio/__init__.py
@@ -30,9 +30,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 for sub, _, _ in os.walk(here):
     specsf = os.path.join(sub, "specifications.yaml")
     if os.path.isfile(specsf):
-        with open(specsf, 'r') as stream:
+        with open(specsf, "r") as stream:
             specs = yaml.safe_load(stream)
             specs["api"] = "rsciio.%s.api" % os.path.split(sub)[1]
             IO_PLUGINS.append(specs)
-
-

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -15,10 +15,9 @@ version = "3.1"
 
 default_version = Version(version)
 
-not_valid_format = 'The file is not a valid HyperSpy hdf5 file'
+not_valid_format = "The file is not a valid HyperSpy hdf5 file"
 
 _logger = logging.getLogger(__name__)
-
 
 
 def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
@@ -45,11 +44,10 @@ def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
     # largely based on the guess_chunk in h5py
     bytes_per_signal = np.prod([shape[i] for i in signal_axes]) * typesize
     signals_per_chunk = int(np.floor_divide(target_size, bytes_per_signal))
-    navigation_axes = tuple(i for i in range(len(shape)) if i not in
-                            signal_axes)
+    navigation_axes = tuple(i for i in range(len(shape)) if i not in signal_axes)
     num_nav_axes = len(navigation_axes)
     num_signals = np.prod([shape[i] for i in navigation_axes])
-    if signals_per_chunk < 2 or num_nav_axes==0:
+    if signals_per_chunk < 2 or num_nav_axes == 0:
         # signal is larger than chunk max
         chunks = [s if i in signal_axes else 1 for i, s in enumerate(shape)]
         return tuple(chunks)
@@ -69,13 +67,24 @@ def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
             # than some axes sizes. If that is the case, the value must be
             # recomputed at the next iteration after having added the "offending"
             # axes to `small_idx`
-            nav_axes_chunks = int(np.floor((signals_per_chunk / np.prod(small_sizes))**(1 / (num_nav_axes - len(small_sizes)))))
+            nav_axes_chunks = int(
+                np.floor(
+                    (signals_per_chunk / np.prod(small_sizes))
+                    ** (1 / (num_nav_axes - len(small_sizes)))
+                )
+            )
             for index, size in enumerate(shape):
-                if index not in (list(signal_axes) + small_idx) and size < nav_axes_chunks:
+                if (
+                    index not in (list(signal_axes) + small_idx)
+                    and size < nav_axes_chunks
+                ):
                     small_idx.append(index)
                     small_sizes.append(size)
                     iterate = True
-        chunks = [s if i in signal_axes or i in small_idx else nav_axes_chunks for i, s in enumerate(shape)]
+        chunks = [
+            s if i in signal_axes or i in small_idx else nav_axes_chunks
+            for i, s in enumerate(shape)
+        ]
         return tuple(int(x) for x in chunks)
 
 
@@ -104,7 +113,8 @@ class HierarchicalReader:
                 "This file was written using a newer version of the "
                 f"HyperSpy {self._file_type} file format. I will attempt to "
                 "load it, but, if I fail, it is likely that I will be more "
-                "successful at this and other tasks if you upgrade me.")
+                "successful at this and other tasks if you upgrade me."
+            )
 
     def get_format_version(self):
         """Return the format version."""
@@ -148,37 +158,35 @@ class HierarchicalReader:
         models_with_signals = []
         standalone_models = []
 
-        if 'Analysis/models' in self.file:
+        if "Analysis/models" in self.file:
             try:
-                m_gr = self.file['Analysis/models']
+                m_gr = self.file["Analysis/models"]
                 for model_name in m_gr:
-                    if '_signal' in m_gr[model_name].attrs:
-                        key = m_gr[model_name].attrs['_signal']
+                    if "_signal" in m_gr[model_name].attrs:
+                        key = m_gr[model_name].attrs["_signal"]
                         # del m_gr[model_name].attrs['_signal']
-                        res = self._group2dict(
-                            m_gr[model_name],
-                            lazy=lazy)
-                        del res['_signal']
+                        res = self._group2dict(m_gr[model_name], lazy=lazy)
+                        del res["_signal"]
                         models_with_signals.append((key, {model_name: res}))
                     else:
                         standalone_models.append(
-                            {model_name: self._group2dict(
-                                m_gr[model_name], lazy=lazy)})
+                            {model_name: self._group2dict(m_gr[model_name], lazy=lazy)}
+                        )
             except TypeError:
                 raise IOError(not_valid_format)
 
         experiments = []
         exp_dict_list = []
 
-        if 'Experiments' in self.file:
-            for ds in self.file['Experiments']:
-                if isinstance(self.file['Experiments'][ds], self.Group):
-                    if 'data' in self.file['Experiments'][ds]:
+        if "Experiments" in self.file:
+            for ds in self.file["Experiments"]:
+                if isinstance(self.file["Experiments"][ds], self.Group):
+                    if "data" in self.file["Experiments"][ds]:
                         experiments.append(ds)
             # Parse the file
             for experiment in experiments:
 
-                exg = self.file['Experiments'][experiment]
+                exg = self.file["Experiments"][experiment]
                 exp = self.group2signaldict(exg, lazy)
                 # assign correct models, if found:
                 _tmp = {}
@@ -186,7 +194,7 @@ class HierarchicalReader:
                     if key == exg.name:
                         _tmp.update(_dict)
                         models_with_signals.remove((key, _dict))
-                exp['models'] = _tmp
+                exp["models"] = _tmp
 
                 exp_dict_list.append(exp)
 
@@ -196,7 +204,7 @@ class HierarchicalReader:
         exp_dict_list.extend(standalone_models)
 
         if not len(exp_dict_list):
-            raise IOError(f'This is not a valid {self._file_type} file.')
+            raise IOError(f"This is not a valid {self._file_type} file.")
 
         return exp_dict_list
 
@@ -225,11 +233,10 @@ class HierarchicalReader:
             metadata = "metadata"
             original_metadata = "original_metadata"
 
-        exp = {'metadata': self._group2dict(
-            group[metadata], lazy=lazy),
-            'original_metadata': self._group2dict(
-                group[original_metadata], lazy=lazy),
-            'attributes': {}
+        exp = {
+            "metadata": self._group2dict(group[metadata], lazy=lazy),
+            "original_metadata": self._group2dict(group[original_metadata], lazy=lazy),
+            "attributes": {},
         }
         if "package" in group.attrs:
             # HyperSpy version is >= 1.5
@@ -242,7 +249,7 @@ class HierarchicalReader:
             exp["package"] = ""
             exp["package_version"] = ""
 
-        data = group['data']
+        data = group["data"]
         try:
             ragged_shape = group["ragged_shapes"]
             new_data = np.empty(shape=data.shape, dtype=object)
@@ -253,14 +260,14 @@ class HierarchicalReader:
             pass
         if lazy:
             data = da.from_array(data, chunks=data.chunks)
-            exp['attributes']['_lazy'] = True
+            exp["attributes"]["_lazy"] = True
         else:
             data = np.asanyarray(data)
-        exp['data'] = data
+        exp["data"] = data
         axes = []
-        for i in range(len(exp['data'].shape)):
+        for i in range(len(exp["data"].shape)):
             try:
-                axes.append(self._group2dict(group[f'axis-{i}']))
+                axes.append(self._group2dict(group[f"axis-{i}"]))
                 axis = axes[-1]
                 for key, item in axis.items():
                     if isinstance(item, np.bool_):
@@ -269,80 +276,89 @@ class HierarchicalReader:
                         axis[key] = ensure_unicode(item)
             except KeyError:
                 break
-        if len(axes) != len(exp['data'].shape):  # broke from the previous loop
+        if len(axes) != len(exp["data"].shape):  # broke from the previous loop
             try:
-                axes = [i for k, i in sorted(iter(self._group2dict(
-                    group['_list_' + str(len(exp['data'].shape)) + '_axes'],
-                    lazy=lazy).items()))]
+                axes = [
+                    i
+                    for k, i in sorted(
+                        iter(
+                            self._group2dict(
+                                group["_list_" + str(len(exp["data"].shape)) + "_axes"],
+                                lazy=lazy,
+                            ).items()
+                        )
+                    )
+                ]
             except KeyError:
                 raise IOError(not_valid_format)
-        exp['axes'] = axes
-        if 'learning_results' in group.keys():
-            exp['attributes']['learning_results'] = \
-                self._group2dict(
-                    group['learning_results'],
-                    lazy=lazy)
-        if 'peak_learning_results' in group.keys():
-            exp['attributes']['peak_learning_results'] = \
-                self._group2dict(
-                    group['peak_learning_results'],
-                    lazy=lazy)
+        exp["axes"] = axes
+        if "learning_results" in group.keys():
+            exp["attributes"]["learning_results"] = self._group2dict(
+                group["learning_results"], lazy=lazy
+            )
+        if "peak_learning_results" in group.keys():
+            exp["attributes"]["peak_learning_results"] = self._group2dict(
+                group["peak_learning_results"], lazy=lazy
+            )
 
         # If the title was not defined on writing the Experiment is
         # then called __unnamed__. The next "if" simply sets the title
         # back to the empty string
         if "General" in exp["metadata"] and "title" in exp["metadata"]["General"]:
-            if '__unnamed__' == exp['metadata']['General']['title']:
-                exp['metadata']["General"]['title'] = ''
+            if "__unnamed__" == exp["metadata"]["General"]["title"]:
+                exp["metadata"]["General"]["title"] = ""
 
         if self.version < Version("1.1"):
             # Load the decomposition results written with the old name,
             # mva_results
-            if 'mva_results' in group.keys():
-                exp['attributes']['learning_results'] = self._group2dict(
-                    group['mva_results'], lazy=lazy)
-            if 'peak_mva_results' in group.keys():
-                exp['attributes']['peak_learning_results'] = self._group2dict(
-                    group['peak_mva_results'], lazy=lazy)
+            if "mva_results" in group.keys():
+                exp["attributes"]["learning_results"] = self._group2dict(
+                    group["mva_results"], lazy=lazy
+                )
+            if "peak_mva_results" in group.keys():
+                exp["attributes"]["peak_learning_results"] = self._group2dict(
+                    group["peak_mva_results"], lazy=lazy
+                )
             # Replace the old signal and name keys with their current names
-            if 'signal' in exp['metadata']:
+            if "signal" in exp["metadata"]:
                 if "Signal" not in exp["metadata"]:
                     exp["metadata"]["Signal"] = {}
-                exp['metadata']["Signal"]['signal_type'] = \
-                    exp['metadata']['signal']
-                del exp['metadata']['signal']
+                exp["metadata"]["Signal"]["signal_type"] = exp["metadata"]["signal"]
+                del exp["metadata"]["signal"]
 
-            if 'name' in exp['metadata']:
+            if "name" in exp["metadata"]:
                 if "General" not in exp["metadata"]:
                     exp["metadata"]["General"] = {}
-                exp['metadata']['General']['title'] = \
-                    exp['metadata']['name']
-                del exp['metadata']['name']
+                exp["metadata"]["General"]["title"] = exp["metadata"]["name"]
+                del exp["metadata"]["name"]
 
         if self.version < Version("1.2"):
-            if '_internal_parameters' in exp['metadata']:
-                exp['metadata']['_HyperSpy'] = \
-                    exp['metadata']['_internal_parameters']
-                del exp['metadata']['_internal_parameters']
-                if 'stacking_history' in exp['metadata']['_HyperSpy']:
-                    exp['metadata']['_HyperSpy']["Stacking_history"] = \
-                        exp['metadata']['_HyperSpy']['stacking_history']
-                    del exp['metadata']['_HyperSpy']["stacking_history"]
-                if 'folding' in exp['metadata']['_HyperSpy']:
-                    exp['metadata']['_HyperSpy']["Folding"] = \
-                        exp['metadata']['_HyperSpy']['folding']
-                    del exp['metadata']['_HyperSpy']["folding"]
-            if 'Variance_estimation' in exp['metadata']:
+            if "_internal_parameters" in exp["metadata"]:
+                exp["metadata"]["_HyperSpy"] = exp["metadata"]["_internal_parameters"]
+                del exp["metadata"]["_internal_parameters"]
+                if "stacking_history" in exp["metadata"]["_HyperSpy"]:
+                    exp["metadata"]["_HyperSpy"]["Stacking_history"] = exp["metadata"][
+                        "_HyperSpy"
+                    ]["stacking_history"]
+                    del exp["metadata"]["_HyperSpy"]["stacking_history"]
+                if "folding" in exp["metadata"]["_HyperSpy"]:
+                    exp["metadata"]["_HyperSpy"]["Folding"] = exp["metadata"][
+                        "_HyperSpy"
+                    ]["folding"]
+                    del exp["metadata"]["_HyperSpy"]["folding"]
+            if "Variance_estimation" in exp["metadata"]:
                 if "Noise_properties" not in exp["metadata"]:
                     exp["metadata"]["Noise_properties"] = {}
-                exp['metadata']['Noise_properties']["Variance_linear_model"] = \
-                    exp['metadata']['Variance_estimation']
-                del exp['metadata']['Variance_estimation']
+                exp["metadata"]["Noise_properties"]["Variance_linear_model"] = exp[
+                    "metadata"
+                ]["Variance_estimation"]
+                del exp["metadata"]["Variance_estimation"]
             if "TEM" in exp["metadata"]:
                 if "Acquisition_instrument" not in exp["metadata"]:
                     exp["metadata"]["Acquisition_instrument"] = {}
-                exp["metadata"]["Acquisition_instrument"]["TEM"] = \
-                    exp["metadata"]["TEM"]
+                exp["metadata"]["Acquisition_instrument"]["TEM"] = exp["metadata"][
+                    "TEM"
+                ]
                 del exp["metadata"]["TEM"]
                 tem = exp["metadata"]["Acquisition_instrument"]["TEM"]
                 if "EELS" in tem:
@@ -373,8 +389,9 @@ class HierarchicalReader:
             if "SEM" in exp["metadata"]:
                 if "Acquisition_instrument" not in exp["metadata"]:
                     exp["metadata"]["Acquisition_instrument"] = {}
-                exp["metadata"]["Acquisition_instrument"]["SEM"] = \
-                    exp["metadata"]["SEM"]
+                exp["metadata"]["Acquisition_instrument"]["SEM"] = exp["metadata"][
+                    "SEM"
+                ]
                 del exp["metadata"]["SEM"]
                 sem = exp["metadata"]["Acquisition_instrument"]["SEM"]
                 if "EDS" in sem:
@@ -386,10 +403,13 @@ class HierarchicalReader:
                     del sem["EDS"]
                 del sem
 
-            if "Sample" in exp["metadata"] and "Xray_lines" in exp[
-                    "metadata"]["Sample"]:
-                exp["metadata"]["Sample"]["xray_lines"] = exp[
-                    "metadata"]["Sample"]["Xray_lines"]
+            if (
+                "Sample" in exp["metadata"]
+                and "Xray_lines" in exp["metadata"]["Sample"]
+            ):
+                exp["metadata"]["Sample"]["xray_lines"] = exp["metadata"]["Sample"][
+                    "Xray_lines"
+                ]
                 del exp["metadata"]["Sample"]["Xray_lines"]
 
             for key in ["title", "date", "time", "original_filename"]:
@@ -424,8 +444,7 @@ class HierarchicalReader:
                         exposure = "exposure_time"
                     if exposure is not None:
                         if "Detector" not in tem:
-                            tem["Detector"] = {"Camera": {
-                                "exposure": tem[exposure]}}
+                            tem["Detector"] = {"Camera": {"exposure": tem[exposure]}}
                         tem["Detector"]["Camera"] = {"exposure": tem[exposure]}
                         del tem[exposure]
                 # Move tilt_stage to Stage.tilt_alpha
@@ -444,7 +463,7 @@ class HierarchicalReader:
             if isinstance(value, bytes):
                 value = value.decode()
             if isinstance(value, (np.string_, str)):
-                if value == '_None_':
+                if value == "_None_":
                     value = None
             elif isinstance(value, np.bool_):
                 value = bool(value)
@@ -454,38 +473,37 @@ class HierarchicalReader:
                 if value.dtype.str.endswith("U1"):
                     value = value.tolist()
             # skip signals - these are handled below.
-            if key.startswith('_sig_'):
+            if key.startswith("_sig_"):
                 pass
-            elif key.startswith('_list_empty_'):
-                dictionary[key[len('_list_empty_'):]] = []
-            elif key.startswith('_tuple_empty_'):
-                dictionary[key[len('_tuple_empty_'):]] = ()
-            elif key.startswith('_bs_'):
-                dictionary[key[len('_bs_'):]] = value.tobytes()
+            elif key.startswith("_list_empty_"):
+                dictionary[key[len("_list_empty_") :]] = []
+            elif key.startswith("_tuple_empty_"):
+                dictionary[key[len("_tuple_empty_") :]] = ()
+            elif key.startswith("_bs_"):
+                dictionary[key[len("_bs_") :]] = value.tobytes()
             # The following two elif stataments enable reading date and time from
             # v < 2 of HyperSpy's metadata specifications
-            elif key.startswith('_datetime_date'):
+            elif key.startswith("_datetime_date"):
                 date_iso = datetime.date(
-                    *ast.literal_eval(value[value.index("("):])).isoformat()
+                    *ast.literal_eval(value[value.index("(") :])
+                ).isoformat()
                 dictionary[key.replace("_datetime_", "")] = date_iso
-            elif key.startswith('_datetime_time'):
+            elif key.startswith("_datetime_time"):
                 date_iso = datetime.time(
-                    *ast.literal_eval(value[value.index("("):])).isoformat()
+                    *ast.literal_eval(value[value.index("(") :])
+                ).isoformat()
                 dictionary[key.replace("_datetime_", "")] = date_iso
             else:
                 dictionary[key] = value
         if not isinstance(group, self.Dataset):
             for key in group.keys():
-                if key.startswith('_sig_'):
-                    dictionary[key] = (
-                        self.group2signaldict(
-                            group[key]))
+                if key.startswith("_sig_"):
+                    dictionary[key] = self.group2signaldict(group[key])
                 elif isinstance(group[key], self.Dataset):
                     dat = group[key]
                     kn = key
                     if key.startswith("_list_"):
-                        if (h5py.check_string_dtype(dat.dtype) and
-                                hasattr(dat, 'asstr')):
+                        if h5py.check_string_dtype(dat.dtype) and hasattr(dat, "asstr"):
                             # h5py 3.0 and newer
                             # https://docs.h5py.org/en/3.0.0/strings.html
                             dat = dat.asstr()[:]
@@ -510,28 +528,32 @@ class HierarchicalReader:
                     else:
                         ans = np.array(dat)
                     dictionary[kn] = ans
-                elif key.startswith('_hspy_AxesManager_'):
+                elif key.startswith("_hspy_AxesManager_"):
                     dictionary[key] = [
-                            i for k, i in sorted(
-                                iter(self._group2dict(group[key], lazy=lazy).items()))]
-                elif key.startswith('_list_'):
-                    dictionary[key[7 + key[6:].find('_'):]] = \
-                        [i for k, i in sorted(iter(
-                            self._group2dict(
-                                group[key], lazy=lazy).items()
-                        ))]
-                elif key.startswith('_tuple_'):
-                    dictionary[key[8 + key[7:].find('_'):]] = tuple(
-                        [i for k, i in sorted(iter(
-                            self._group2dict(
-                                group[key], lazy=lazy).items()
-                        ))])
+                        i
+                        for k, i in sorted(
+                            iter(self._group2dict(group[key], lazy=lazy).items())
+                        )
+                    ]
+                elif key.startswith("_list_"):
+                    dictionary[key[7 + key[6:].find("_") :]] = [
+                        i
+                        for k, i in sorted(
+                            iter(self._group2dict(group[key], lazy=lazy).items())
+                        )
+                    ]
+                elif key.startswith("_tuple_"):
+                    dictionary[key[8 + key[7:].find("_") :]] = tuple(
+                        [
+                            i
+                            for k, i in sorted(
+                                iter(self._group2dict(group[key], lazy=lazy).items())
+                            )
+                        ]
+                    )
                 else:
                     dictionary[key] = {}
-                    self._group2dict(
-                        group[key],
-                        dictionary[key],
-                        lazy=lazy)
+                    self._group2dict(group[key], dictionary[key], lazy=lazy)
 
         return dictionary
 
@@ -541,6 +563,7 @@ class HierarchicalWriter:
     An object used to simplify and organize the process for writing a
     Hierarchical signal, such as hspy/zspy format.
     """
+
     target_size = 1e6
 
     def __init__(self, file, signal, group, **kwds):
@@ -568,17 +591,14 @@ class HierarchicalWriter:
 
     @staticmethod
     def _get_object_dset(*args, **kwargs):  # pragma: no cover
-        raise NotImplementedError(
-            "This method must be implemented by subclasses.")
+        raise NotImplementedError("This method must be implemented by subclasses.")
 
     @staticmethod
     def _store_data(*arg):  # pragma: no cover
-        raise NotImplementedError(
-            "This method must be implemented by subclasses.")
+        raise NotImplementedError("This method must be implemented by subclasses.")
 
     @classmethod
-    def overwrite_dataset(cls, group, data, key, signal_axes=None,
-                          chunks=None, **kwds):
+    def overwrite_dataset(cls, group, data, key, signal_axes=None, chunks=None, **kwds):
         """
         Overwrites a dataset into a hierarchical structure following the h5py
         API.
@@ -612,23 +632,26 @@ class HierarchicalWriter:
                 # optimise the chunking to contain at least one signal per chunk
                 chunks = get_signal_chunks(
                     data.shape, data.dtype, signal_axes, cls.target_size
-                    )
-        if np.issubdtype(data.dtype, np.dtype('U')):
+                )
+        if np.issubdtype(data.dtype, np.dtype("U")):
             # Saving numpy unicode type is not supported in h5py
-            data = data.astype(np.dtype('S'))
+            data = data.astype(np.dtype("S"))
 
-        if data.dtype == np.dtype('O'):
+        if data.dtype == np.dtype("O"):
             dset = cls._get_object_dset(group, data, key, chunks, **kwds)
         else:
             got_data = False
             while not got_data:
                 try:
                     these_kwds = kwds.copy()
-                    these_kwds.update(dict(shape=data.shape,
-                                           dtype=data.dtype,
-                                           exact=True,
-                                           chunks=chunks,
-                                           ))
+                    these_kwds.update(
+                        dict(
+                            shape=data.shape,
+                            dtype=data.dtype,
+                            exact=True,
+                            chunks=chunks,
+                        )
+                    )
 
                     # If chunks is True, the `chunks` attribute of `dset` below
                     # contains the chunk shape guessed by h5py
@@ -640,30 +663,31 @@ class HierarchicalWriter:
                     del group[key]
 
         _logger.info(f"Chunks used for saving: {chunks}")
-        if data.dtype == np.dtype('O'):
+        if data.dtype == np.dtype("O"):
             new_data = np.empty(shape=data.shape, dtype=object)
             shapes = np.empty(shape=data.shape, dtype=object)
             for i in np.ndindex(data.shape):
                 new_data[i] = data[i].ravel()
                 shapes[i] = np.array(data[i].shape)
-            shape_dset = cls._get_object_dset(group, shapes, "ragged_shapes", shapes.shape, **kwds)
-            cls._store_data(shapes, shape_dset, group, 'ragged_shapes', chunks=shapes.shape)
+            shape_dset = cls._get_object_dset(
+                group, shapes, "ragged_shapes", shapes.shape, **kwds
+            )
+            cls._store_data(
+                shapes, shape_dset, group, "ragged_shapes", chunks=shapes.shape
+            )
             cls._store_data(new_data, dset, group, key, chunks)
         else:
             cls._store_data(data, dset, group, key, chunks)
 
     def write(self):
-        self.write_signal(self.signal,
-                          self.group,
-                          **self.kwds)
+        self.write_signal(self.signal, self.group, **self.kwds)
 
-    def write_signal(self, signal, group, write_dataset=True, chunks=None,
-                     **kwds):
+    def write_signal(self, signal, group, write_dataset=True, chunks=None, **kwds):
         "Writes a hyperspy signal to a hdf5 group"
         group.attrs.update(signal["package_info"])
 
         for i, axis_dict in enumerate(signal["axes"]):
-            group_name = f'axis-{i}'
+            group_name = f"axis-{i}"
             # delete existing group in case the file have been open in 'a' mode
             # and we are saving a different type of axis, to avoid having
             # incompatible axis attributes from previously saved axis.
@@ -679,30 +703,30 @@ class HierarchicalWriter:
             self.overwrite_dataset(
                 group,
                 signal["data"],
-                'data',
-                signal_axes=[idx for idx, axis in enumerate(signal["axes"]) if not axis["navigate"]],
+                "data",
+                signal_axes=[
+                    idx
+                    for idx, axis in enumerate(signal["axes"])
+                    if not axis["navigate"]
+                ],
                 chunks=chunks,
-                **kwds
-                )
+                **kwds,
+            )
 
         if default_version < Version("1.2"):
-            metadata_dict["_internal_parameters"] = \
-                metadata_dict.pop("_HyperSpy")
+            metadata_dict["_internal_parameters"] = metadata_dict.pop("_HyperSpy")
 
         self.dict2group(metadata_dict, mapped_par, **kwds)
         original_par = group.require_group("original_metadata")
-        self.dict2group(signal["original_metadata"], original_par,
-                      **kwds)
-        learning_results = group.require_group('learning_results')
-        self.dict2group(signal["learning_results"],
-                      learning_results, **kwds)
+        self.dict2group(signal["original_metadata"], original_par, **kwds)
+        learning_results = group.require_group("learning_results")
+        self.dict2group(signal["learning_results"], learning_results, **kwds)
 
         if signal["models"]:
-            model_group = self.file.require_group('Analysis/models')
-            self.dict2group(signal["models"],
-                          model_group, **kwds)
+            model_group = self.file.require_group("Analysis/models")
+            self.dict2group(signal["models"], model_group, **kwds)
             for model in model_group.values():
-                model.attrs['_signal'] = group.name
+                model.attrs["_signal"] = group.name
 
     def dict2group(self, dictionary, group, **kwds):
         "Recursive writer of dicts and signals"
@@ -714,14 +738,14 @@ class HierarchicalWriter:
                 self.overwrite_dataset(group, value, key, **kwds)
 
             elif value is None:
-                group.attrs[key] = '_None_'
+                group.attrs[key] = "_None_"
 
             elif isinstance(value, bytes):
                 try:
                     # binary string if has any null characters (otherwise not
                     # supported by hdf5)
-                    value.index(b'\x00')
-                    group.attrs['_bs_' + key] = np.void(value)
+                    value.index(b"\x00")
+                    group.attrs["_bs_" + key] = np.void(value)
                 except ValueError:
                     group.attrs[key] = value.decode()
 
@@ -730,15 +754,15 @@ class HierarchicalWriter:
 
             elif isinstance(value, list):
                 if len(value):
-                    self.parse_structure(key, group, value, '_list_', **kwds)
+                    self.parse_structure(key, group, value, "_list_", **kwds)
                 else:
-                    group.attrs['_list_empty_' + key] = '_None_'
+                    group.attrs["_list_empty_" + key] = "_None_"
 
             elif isinstance(value, tuple):
                 if len(value):
-                    self.parse_structure(key, group, value, '_tuple_', **kwds)
+                    self.parse_structure(key, group, value, "_tuple_", **kwds)
                 else:
-                    group.attrs['_tuple_empty_' + key] = '_None_'
+                    group.attrs["_tuple_empty_" + key] = "_None_"
 
             else:
                 try:
@@ -746,7 +770,8 @@ class HierarchicalWriter:
                 except BaseException:
                     _logger.exception(
                         "The writer could not write the following "
-                        f"information in the file: {key} : {value}")
+                        f"information in the file: {key} : {value}"
+                    )
 
     def parse_structure(self, key, group, value, _type, **kwds):
         try:
@@ -760,22 +785,20 @@ class HierarchicalWriter:
         except ValueError:
             tmp = np.array([[0]])
 
-        if tmp.dtype == np.dtype('O') or tmp.ndim != 1:
-            self.dict2group(dict(zip(
-                [str(i) for i in range(len(value))], value)),
-                group.require_group(_type + str(len(value)) + '_' + key),
-                **kwds)
+        if tmp.dtype == np.dtype("O") or tmp.ndim != 1:
+            self.dict2group(
+                dict(zip([str(i) for i in range(len(value))], value)),
+                group.require_group(_type + str(len(value)) + "_" + key),
+                **kwds,
+            )
         elif tmp.dtype.type is np.unicode_:
             if _type + key in group:
                 del group[_type + key]
-            group.create_dataset(_type + key,
-                                 shape=tmp.shape,
-                                 **self.unicode_kwds,
-                                 **kwds)
+            group.create_dataset(
+                _type + key, shape=tmp.shape, **self.unicode_kwds, **kwds
+            )
             group[_type + key][:] = tmp[:]
         else:
             if _type + key in group:
                 del group[_type + key]
-            group.create_dataset(_type + key,
-                                 data=tmp,
-                                 **kwds)
+            group.create_dataset(_type + key, data=tmp, **kwds)

--- a/rsciio/blockfile/api.py
+++ b/rsciio/blockfile/api.py
@@ -238,7 +238,7 @@ def file_reader(filename, endianess="<", mmap_mode=None, lazy=False, **kwds):
     if header["SDP"]:
         SDP = 100.0 / header["SDP"]
     else:
-        SDP = 1 #  Set default scale to 1
+        SDP = 1  #  Set default scale to 1
     original_metadata = {"blockfile_header": header}
 
     # Get data:
@@ -367,7 +367,7 @@ def file_writer(filename, signal, **kwds):
     elif scale_strategy == "minmax":
         minimum = signal["data"].min()
         maximum = signal["data"].max()
-        if signal['attributes']['_lazy']:
+        if signal["attributes"]["_lazy"]:
             minimum, maximum = dask.compute(minimum, maximum)
         original_scale = (minimum, maximum)
     elif scale_strategy == "crop":
@@ -422,7 +422,11 @@ def file_writer(filename, signal, **kwds):
         file_location = f.tell()
 
     if scale_strategy is not None:
-        array_data = rescale_intensity(signal["data"], in_range=original_scale, out_range=np.uint8,)
+        array_data = rescale_intensity(
+            signal["data"],
+            in_range=original_scale,
+            out_range=np.uint8,
+        )
     else:
         array_data = signal["data"]
     array_data = array_data.astype(endianess + "u1")
@@ -442,7 +446,7 @@ def file_writer(filename, signal, **kwds):
     )
     file_memmap["MAGIC"] = magics
     file_memmap["ID"] = ids
-    if signal['attributes']['_lazy']:
+    if signal["attributes"]["_lazy"]:
         cm = ProgressBar if show_progressbar else dummy_context_manager
         with cm():
             array_data.store(file_memmap["IMG"])

--- a/rsciio/edax/api.py
+++ b/rsciio/edax/api.py
@@ -31,11 +31,11 @@ from rsciio.utils.elements import atomic_number2name
 _logger = logging.getLogger(__name__)
 
 
-spd_extensions = ('spd', 'SPD', 'Spd')
-spc_extensions = ('spc', 'SPC', 'Spc')
+spd_extensions = ("spd", "SPD", "Spd")
+spc_extensions = ("spc", "SPC", "Spc")
 
 
-def get_spd_dtype_list(endianess='<'):
+def get_spd_dtype_list(endianess="<"):
     """
     Get the data type list for an SPD map.
     Further information about the file format is available `here
@@ -66,20 +66,19 @@ def get_spd_dtype_list(endianess='<'):
         read an SPD file header.
     """
     end = endianess
-    dtype_list = \
-        [
-            ('tag', '16i1'),
-            ('version', end + 'i4'),
-            ('nSpectra', end + 'i4'),
-            ('nPoints', end + 'i4'),
-            ('nLines', end + 'u4'),
-            ('nChannels', end + 'u4'),
-            ('countBytes', end + 'u4'),
-            ('dataOffset', end + 'u4'),
-            ('nFrames', end + 'u4'),
-            ('fName', end + '120i1'),
-            ('filler', end + 'V900'),
-        ]
+    dtype_list = [
+        ("tag", "16i1"),
+        ("version", end + "i4"),
+        ("nSpectra", end + "i4"),
+        ("nPoints", end + "i4"),
+        ("nLines", end + "u4"),
+        ("nChannels", end + "u4"),
+        ("countBytes", end + "u4"),
+        ("dataOffset", end + "u4"),
+        ("nFrames", end + "u4"),
+        ("fName", end + "120i1"),
+        ("filler", end + "V900"),
+    ]
     return dtype_list
 
 
@@ -103,25 +102,24 @@ def __get_spc_header(f, endianess, load_all_spc):
     spc_header : np.ndarray
         Array containing the binary information read from the .spc file
     """
-    version = np.fromfile(f,
-                          dtype=[('version', '{}f4'.format(endianess))],
-                          count=1)
+    version = np.fromfile(f, dtype=[("version", "{}f4".format(endianess))], count=1)
     version = round(float(version.item()[0]), 2)  # convert to scalar
     f.seek(0)
 
-    spc_header = np.fromfile(f,
-                             dtype=get_spc_dtype_list(
-                                 load_all=load_all_spc,
-                                 endianess=endianess,
-                                 version=version),
-                             count=1)
+    spc_header = np.fromfile(
+        f,
+        dtype=get_spc_dtype_list(
+            load_all=load_all_spc, endianess=endianess, version=version
+        ),
+        count=1,
+    )
 
-    _logger.debug(' .spc version is {}'.format(version))
+    _logger.debug(" .spc version is {}".format(version))
 
     return spc_header
 
 
-def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
+def get_spc_dtype_list(load_all=False, endianess="<", version=0.61):
     """
     Get the data type list for an SPC spectrum.
     Further information about the file format is available `here
@@ -317,218 +315,179 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
     end = endianess
     # important parameters are marked by "**" in comment
     if load_all:
-        dtype_list = \
-            [  # data offset (bytes)
-                ('fVersion', end + 'f4'),  # 0
-                ('aVersion', end + 'f4'),  # 4
-                ('fileName', '8i1'),  # 8
-                ('collectDateYear', end + 'i2'),  # 16
-                ('collectDateDay', end + 'i1'),  # 17
-                ('collectDateMon', end + 'i1'),
-                ('collectTimeMin', end + 'i1'),
-                ('collectTimeHour', end + 'i1'),
-                ('collectTimeHund', end + 'i1'),
-                ('collectTimeSec', end + 'i1'),
-                ('fileSize', end + 'i4'),  # 24
-                ('dataStart', end + 'i4'),  # 28
-                ('numPts', end + 'i2'),  # 32
-                ('intersectingDist', end + 'i2'),  # 34
-                ('workingDist', end + 'i2'),  # 36
-                ('scaleSetting', end + 'i2'),  # 38
-
-                ('filler1', 'V24'),  # 40
-
-                ('spectrumLabel', '256i1'),  # 64
-                ('imageFilename', '8i1'),  # 320
-                ('spotX', end + 'i2'),  # 328
-                ('spotY', end + 'i2'),  # 330
-                ('imageADC', end + 'i2'),  # 332
-                ('discrValues', end + '5i4'),  # 334
-                ('discrEnabled', end + '5i1'),  # 354
-                ('pileupProcessed', end + 'i1'),  # 359
-                ('fpgaVersion', end + 'i4'),  # 360
-                ('pileupProcVersion', end + 'i4'),  # 364
-                ('NB5000CFG', end + 'i4'),  # 368
-
-                ('filler2', 'V12'),  # 380
-
-                ('evPerChan', end + 'i4'),  # 384 **
-                ('ADCTimeConstant', end + 'i2'),  # 388
-                ('analysisType', end + 'i2'),  # 390
-                ('preset', end + 'f4'),  # 392
-                ('maxp', end + 'i4'),  # 396
-                ('maxPeakCh', end + 'i4'),  # 400
-                ('xRayTubeZ', end + 'i2'),  # 404
-                ('filterZ', end + 'i2'),  # 406
-                ('current', end + 'f4'),  # 408
-                ('sampleCond', end + 'i2'),  # 412
-                ('sampleType', end + 'i2'),  # 414
-                ('xrayCollimator', end + 'u2'),  # 416
-                ('xrayCapilaryType', end + 'u2'),  # 418
-                ('xrayCapilarySize', end + 'u2'),  # 420
-                ('xrayFilterThickness', end + 'u2'),  # 422
-                ('spectrumSmoothed', end + 'u2'),  # 424
-                ('detector_Size_SiLi', end + 'u2'),  # 426
-                ('spectrumReCalib', end + 'u2'),  # 428
-                ('eagleSystem', end + 'u2'),  # 430
-                ('sumPeakRemoved', end + 'u2'),  # 432
-                ('edaxSoftwareType', end + 'u2'),  # 434
-
-                ('filler3', 'V6'),  # 436
-
-                ('escapePeakRemoved', end + 'u2'),  # 442
-                ('analyzerType', end + 'u4'),  # 444
-                ('startEnergy', end + 'f4'),  # 448 **
-                ('endEnergy', end + 'f4'),  # 452
-                ('liveTime', end + 'f4'),  # 456 **
-                ('tilt', end + 'f4'),  # 460 **
-                ('takeoff', end + 'f4'),  # 464
-                ('beamCurFact', end + 'f4'),  # 468
-                ('detReso', end + 'f4'),  # 472 **
-                ('detectType', end + 'u4'),  # 476
-                ('parThick', end + 'f4'),  # 480
-                ('alThick', end + 'f4'),  # 484
-                ('beWinThick', end + 'f4'),  # 488
-                ('auThick', end + 'f4'),  # 492
-                ('siDead', end + 'f4'),  # 496
-                ('siLive', end + 'f4'),  # 500
-                ('xrayInc', end + 'f4'),  # 504
-                ('azimuth', end + 'f4'),  # 508 **
-                ('elevation', end + 'f4'),  # 512 **
-                ('bCoeff', end + 'f4'),  # 516
-                ('cCoeff', end + 'f4'),  # 520
-                ('tailMax', end + 'f4'),  # 524
-                ('tailHeight', end + 'f4'),  # 528
-                ('kV', end + 'f4'),  # 532 **
-                ('apThick', end + 'f4'),  # 536
-                ('xTilt', end + 'f4'),  # 540
-                ('yTilt', end + 'f4'),  # 544
-                ('yagStatus', end + 'u4'),  # 548
-
-                ('filler4', 'V24'),  # 552
-
-                ('rawDataType', end + 'u2'),  # 576
-                ('totalBkgdCount', end + 'f4'),  # 578
-                ('totalSpectralCount', end + 'u4'),  # 582
-                ('avginputCount', end + 'f4'),  # 586
-                ('stdDevInputCount', end + 'f4'),  # 590
-                ('peakToBack', end + 'u2'),  # 594
-                ('peakToBackValue', end + 'f4'),  # 596
-
-                ('filler5', 'V38'),  # 600
-
-                ('numElem', end + 'i2'),  # 638 **
-                ('at', end + '48u2'),  # 640 **
-                ('line', end + '48u2'),  # 736
-                ('energy', end + '48f4'),  # 832
-                ('height', end + '48u4'),  # 1024
-                ('spkht', end + '48i2'),  # 1216
-
-                ('filler5_1', 'V30'),  # 1312
-
-                ('numRois', end + 'i2'),  # 1342
-                ('st', end + '48i2'),  # 1344
-                ('end', end + '48i2'),  # 1440
-                ('roiEnable', end + '48i2'),  # 1536
-                ('roiNames', '(24,8)i1'),  # 1632
-
-                ('filler5_2', 'V1'),  # 1824
-
-                ('userID', '80i1'),  # 1825
-
-                ('filler5_3', 'V111'),  # 1905
-
-                ('sRoi', end + '48i2'),  # 2016
-                ('scaNum', end + '48i2'),  # 2112
-
-                ('filler6', 'V12'),  # 2208
-
-                ('backgrdWidth', end + 'i2'),  # 2220
-                ('manBkgrdPerc', end + 'f4'),  # 2222
-                ('numBkgrdPts', end + 'i2'),  # 2226
-                ('backMethod', end + 'u4'),  # 2228
-                ('backStEng', end + 'f4'),  # 2232
-                ('backEndEng', end + 'f4'),  # 2236
-                ('bg', end + '64i2'),  # 2240
-                ('bgType', end + 'u4'),  # 2368
-                ('concenKev1', end + 'f4'),  # 2372
-                ('concenKev2', end + 'f4'),  # 2376
-                ('concenMethod', end + 'i2'),  # 2380
-                ('jobFilename', end + '32i1'),  # 2382
-
-                ('filler7', 'V16'),  # 2414
-
-                ('numLabels', end + 'i2'),  # 2430
-                ('label', end + '(10,32)i1'),  # 2432
-                ('labelx', end + '10i2'),  # 2752
-                ('labely', end + '10i4'),  # 2772
-                ('zListFlag', end + 'i4'),  # 2812
-                ('bgPercents', end + '64f4'),  # 2816
-                ('IswGBg', end + 'i2'),  # 3072
-                ('BgPoints', end + '5f4'),  # 3074
-                ('IswGConc', end + 'i2'),  # 3094
-                ('numConcen', end + 'i2'),  # 3096
-                ('ZList', end + '24i2'),  # 3098
-                ('GivenConc', end + '24f4'),  # 3146
-
-                ('filler8', 'V598'),  # 3242
-
-                ('s', end + '4096i4'),  # 3840
-                ('longFileName', end + '256i1'),  # 20224
-                ('longImageFileName', end + '256i1'),  # 20480
-            ]
+        dtype_list = [  # data offset (bytes)
+            ("fVersion", end + "f4"),  # 0
+            ("aVersion", end + "f4"),  # 4
+            ("fileName", "8i1"),  # 8
+            ("collectDateYear", end + "i2"),  # 16
+            ("collectDateDay", end + "i1"),  # 17
+            ("collectDateMon", end + "i1"),
+            ("collectTimeMin", end + "i1"),
+            ("collectTimeHour", end + "i1"),
+            ("collectTimeHund", end + "i1"),
+            ("collectTimeSec", end + "i1"),
+            ("fileSize", end + "i4"),  # 24
+            ("dataStart", end + "i4"),  # 28
+            ("numPts", end + "i2"),  # 32
+            ("intersectingDist", end + "i2"),  # 34
+            ("workingDist", end + "i2"),  # 36
+            ("scaleSetting", end + "i2"),  # 38
+            ("filler1", "V24"),  # 40
+            ("spectrumLabel", "256i1"),  # 64
+            ("imageFilename", "8i1"),  # 320
+            ("spotX", end + "i2"),  # 328
+            ("spotY", end + "i2"),  # 330
+            ("imageADC", end + "i2"),  # 332
+            ("discrValues", end + "5i4"),  # 334
+            ("discrEnabled", end + "5i1"),  # 354
+            ("pileupProcessed", end + "i1"),  # 359
+            ("fpgaVersion", end + "i4"),  # 360
+            ("pileupProcVersion", end + "i4"),  # 364
+            ("NB5000CFG", end + "i4"),  # 368
+            ("filler2", "V12"),  # 380
+            ("evPerChan", end + "i4"),  # 384 **
+            ("ADCTimeConstant", end + "i2"),  # 388
+            ("analysisType", end + "i2"),  # 390
+            ("preset", end + "f4"),  # 392
+            ("maxp", end + "i4"),  # 396
+            ("maxPeakCh", end + "i4"),  # 400
+            ("xRayTubeZ", end + "i2"),  # 404
+            ("filterZ", end + "i2"),  # 406
+            ("current", end + "f4"),  # 408
+            ("sampleCond", end + "i2"),  # 412
+            ("sampleType", end + "i2"),  # 414
+            ("xrayCollimator", end + "u2"),  # 416
+            ("xrayCapilaryType", end + "u2"),  # 418
+            ("xrayCapilarySize", end + "u2"),  # 420
+            ("xrayFilterThickness", end + "u2"),  # 422
+            ("spectrumSmoothed", end + "u2"),  # 424
+            ("detector_Size_SiLi", end + "u2"),  # 426
+            ("spectrumReCalib", end + "u2"),  # 428
+            ("eagleSystem", end + "u2"),  # 430
+            ("sumPeakRemoved", end + "u2"),  # 432
+            ("edaxSoftwareType", end + "u2"),  # 434
+            ("filler3", "V6"),  # 436
+            ("escapePeakRemoved", end + "u2"),  # 442
+            ("analyzerType", end + "u4"),  # 444
+            ("startEnergy", end + "f4"),  # 448 **
+            ("endEnergy", end + "f4"),  # 452
+            ("liveTime", end + "f4"),  # 456 **
+            ("tilt", end + "f4"),  # 460 **
+            ("takeoff", end + "f4"),  # 464
+            ("beamCurFact", end + "f4"),  # 468
+            ("detReso", end + "f4"),  # 472 **
+            ("detectType", end + "u4"),  # 476
+            ("parThick", end + "f4"),  # 480
+            ("alThick", end + "f4"),  # 484
+            ("beWinThick", end + "f4"),  # 488
+            ("auThick", end + "f4"),  # 492
+            ("siDead", end + "f4"),  # 496
+            ("siLive", end + "f4"),  # 500
+            ("xrayInc", end + "f4"),  # 504
+            ("azimuth", end + "f4"),  # 508 **
+            ("elevation", end + "f4"),  # 512 **
+            ("bCoeff", end + "f4"),  # 516
+            ("cCoeff", end + "f4"),  # 520
+            ("tailMax", end + "f4"),  # 524
+            ("tailHeight", end + "f4"),  # 528
+            ("kV", end + "f4"),  # 532 **
+            ("apThick", end + "f4"),  # 536
+            ("xTilt", end + "f4"),  # 540
+            ("yTilt", end + "f4"),  # 544
+            ("yagStatus", end + "u4"),  # 548
+            ("filler4", "V24"),  # 552
+            ("rawDataType", end + "u2"),  # 576
+            ("totalBkgdCount", end + "f4"),  # 578
+            ("totalSpectralCount", end + "u4"),  # 582
+            ("avginputCount", end + "f4"),  # 586
+            ("stdDevInputCount", end + "f4"),  # 590
+            ("peakToBack", end + "u2"),  # 594
+            ("peakToBackValue", end + "f4"),  # 596
+            ("filler5", "V38"),  # 600
+            ("numElem", end + "i2"),  # 638 **
+            ("at", end + "48u2"),  # 640 **
+            ("line", end + "48u2"),  # 736
+            ("energy", end + "48f4"),  # 832
+            ("height", end + "48u4"),  # 1024
+            ("spkht", end + "48i2"),  # 1216
+            ("filler5_1", "V30"),  # 1312
+            ("numRois", end + "i2"),  # 1342
+            ("st", end + "48i2"),  # 1344
+            ("end", end + "48i2"),  # 1440
+            ("roiEnable", end + "48i2"),  # 1536
+            ("roiNames", "(24,8)i1"),  # 1632
+            ("filler5_2", "V1"),  # 1824
+            ("userID", "80i1"),  # 1825
+            ("filler5_3", "V111"),  # 1905
+            ("sRoi", end + "48i2"),  # 2016
+            ("scaNum", end + "48i2"),  # 2112
+            ("filler6", "V12"),  # 2208
+            ("backgrdWidth", end + "i2"),  # 2220
+            ("manBkgrdPerc", end + "f4"),  # 2222
+            ("numBkgrdPts", end + "i2"),  # 2226
+            ("backMethod", end + "u4"),  # 2228
+            ("backStEng", end + "f4"),  # 2232
+            ("backEndEng", end + "f4"),  # 2236
+            ("bg", end + "64i2"),  # 2240
+            ("bgType", end + "u4"),  # 2368
+            ("concenKev1", end + "f4"),  # 2372
+            ("concenKev2", end + "f4"),  # 2376
+            ("concenMethod", end + "i2"),  # 2380
+            ("jobFilename", end + "32i1"),  # 2382
+            ("filler7", "V16"),  # 2414
+            ("numLabels", end + "i2"),  # 2430
+            ("label", end + "(10,32)i1"),  # 2432
+            ("labelx", end + "10i2"),  # 2752
+            ("labely", end + "10i4"),  # 2772
+            ("zListFlag", end + "i4"),  # 2812
+            ("bgPercents", end + "64f4"),  # 2816
+            ("IswGBg", end + "i2"),  # 3072
+            ("BgPoints", end + "5f4"),  # 3074
+            ("IswGConc", end + "i2"),  # 3094
+            ("numConcen", end + "i2"),  # 3096
+            ("ZList", end + "24i2"),  # 3098
+            ("GivenConc", end + "24f4"),  # 3146
+            ("filler8", "V598"),  # 3242
+            ("s", end + "4096i4"),  # 3840
+            ("longFileName", end + "256i1"),  # 20224
+            ("longImageFileName", end + "256i1"),  # 20480
+        ]
 
         if version >= 0.7:
-            dtype_list.extend([
-                ('ADCTimeConstantNew', end + 'f4'),  # 20736
-
-                ('filler9', 'V60'),  # 20740
-
-                ('numZElements', end + 'i2'),  # 20800
-                ('zAtoms', end + '48i2'),  # 20802
-                ('zShells', end + '48i2'),  # 20898
-            ])
+            dtype_list.extend(
+                [
+                    ("ADCTimeConstantNew", end + "f4"),  # 20736
+                    ("filler9", "V60"),  # 20740
+                    ("numZElements", end + "i2"),  # 20800
+                    ("zAtoms", end + "48i2"),  # 20802
+                    ("zShells", end + "48i2"),  # 20898
+                ]
+            )
 
     else:
-        dtype_list = \
-            [
-                ('filler1', 'V28'),  # 0
-
-                ('dataStart', end + 'i4'),  # 28
-                ('numPts', end + 'i2'),  # 32 **
-
-                ('filler1_1', 'V350'),  # 34
-
-                ('evPerChan', end + 'i4'),  # 384 **
-
-                ('filler2', 'V60'),  # 388
-
-                ('startEnergy', end + 'f4'),  # 448 **
-                ('endEnergy', end + 'f4'),  # 452
-                ('liveTime', end + 'f4'),  # 456 **
-                ('tilt', end + 'f4'),  # 460 **
-
-                ('filler3', 'V8'),  # 464
-
-                ('detReso', end + 'f4'),  # 472 **
-
-                ('filler4', 'V32'),  # 476
-
-                ('azimuth', end + 'f4'),  # 508 **
-                ('elevation', end + 'f4'),  # 512 **
-
-                ('filler5', 'V16'),  # 516
-
-                ('kV', end + 'f4'),  # 532 **
-
-                ('filler6', 'V102'),  # 536
-
-                ('numElem', end + 'i2'),  # 638 **
-                ('at', end + '48u2'),  # 640 **
-
-                ('filler7', 'V20004'),  # 736
-
-            ]
+        dtype_list = [
+            ("filler1", "V28"),  # 0
+            ("dataStart", end + "i4"),  # 28
+            ("numPts", end + "i2"),  # 32 **
+            ("filler1_1", "V350"),  # 34
+            ("evPerChan", end + "i4"),  # 384 **
+            ("filler2", "V60"),  # 388
+            ("startEnergy", end + "f4"),  # 448 **
+            ("endEnergy", end + "f4"),  # 452
+            ("liveTime", end + "f4"),  # 456 **
+            ("tilt", end + "f4"),  # 460 **
+            ("filler3", "V8"),  # 464
+            ("detReso", end + "f4"),  # 472 **
+            ("filler4", "V32"),  # 476
+            ("azimuth", end + "f4"),  # 508 **
+            ("elevation", end + "f4"),  # 512 **
+            ("filler5", "V16"),  # 516
+            ("kV", end + "f4"),  # 532 **
+            ("filler6", "V102"),  # 536
+            ("numElem", end + "i2"),  # 638 **
+            ("at", end + "48u2"),  # 640 **
+            ("filler7", "V20004"),  # 736
+        ]
     return dtype_list
 
 
@@ -549,23 +508,19 @@ def __get_ipr_header(f, endianess):
     ipr_header : np.ndarray
         Array containing the binary information read from the .ipr file
     """
-    version = np.fromfile(f,
-                          dtype=[('version', '{}i2'.format(endianess))],
-                          count=1)
+    version = np.fromfile(f, dtype=[("version", "{}i2".format(endianess))], count=1)
     version = version.item()[0]  # convert to scalar
     f.seek(0)
-    _logger.debug(' .ipr version is {}'.format(version))
+    _logger.debug(" .ipr version is {}".format(version))
 
-    ipr_header = np.fromfile(f,
-                             dtype=get_ipr_dtype_list(
-                                 endianess=endianess,
-                                 version=version),
-                             count=1)
+    ipr_header = np.fromfile(
+        f, dtype=get_ipr_dtype_list(endianess=endianess, version=version), count=1
+    )
 
     return ipr_header
 
 
-def get_ipr_dtype_list(endianess='<', version=333):
+def get_ipr_dtype_list(endianess="<", version=333):
     """
     Get the data type list for an IPR image description file.
     Further information about the file format is available `here
@@ -631,47 +586,49 @@ def get_ipr_dtype_list(endianess='<', version=333):
         read an IPR file.
     """
     end = endianess
-    dtype_list = \
-        [
-            ('version', end + 'u2'),
-            ('imageType', end + 'u2'),
-            ('label', end + 'a8'),
-            ('sMin', end + 'u2'),
-            ('sMax', end + 'u2'),
-            ('color', end + 'u2'),
-            ('presetMode', end + 'u2'),
-            ('presetTime', end + 'u4'),
-            ('dataType', end + 'u2'),
-            ('timeConstantOld', end + 'u2'),
-            ('reserved1', end + 'i2'),
-            ('roiStartChan', end + 'u2'),
-            ('roiEndChan', end + 'u2'),
-            ('userMin', end + 'i2'),
-            ('userMax', end + 'i2'),
-            ('iADC', end + 'u2'),
-            ('reserved2', end + 'i2'),
-            ('iBits', end + 'u2'),
-            ('nReads', end + 'u2'),
-            ('nFrames', end + 'u2'),
-            ('fDwell', end + 'f4'),
-            ('accV', end + 'u2'),
-            ('tilt', end + 'i2'),
-            ('takeoff', end + 'i2'),
-            ('mag', end + 'u4'),
-            ('wd', end + 'u2'),
-            ('mppX', end + 'f4'),
-            ('mppY', end + 'f4'),
-            ('nTextLines', end + 'u2'),
-            ('charText', end + '4a32'),
-            ('reserved3', end + '4f4'),
-            ('nOverlayElements', end + 'u2'),
-            ('overlayColors', end + '16u2')]
+    dtype_list = [
+        ("version", end + "u2"),
+        ("imageType", end + "u2"),
+        ("label", end + "a8"),
+        ("sMin", end + "u2"),
+        ("sMax", end + "u2"),
+        ("color", end + "u2"),
+        ("presetMode", end + "u2"),
+        ("presetTime", end + "u4"),
+        ("dataType", end + "u2"),
+        ("timeConstantOld", end + "u2"),
+        ("reserved1", end + "i2"),
+        ("roiStartChan", end + "u2"),
+        ("roiEndChan", end + "u2"),
+        ("userMin", end + "i2"),
+        ("userMax", end + "i2"),
+        ("iADC", end + "u2"),
+        ("reserved2", end + "i2"),
+        ("iBits", end + "u2"),
+        ("nReads", end + "u2"),
+        ("nFrames", end + "u2"),
+        ("fDwell", end + "f4"),
+        ("accV", end + "u2"),
+        ("tilt", end + "i2"),
+        ("takeoff", end + "i2"),
+        ("mag", end + "u4"),
+        ("wd", end + "u2"),
+        ("mppX", end + "f4"),
+        ("mppY", end + "f4"),
+        ("nTextLines", end + "u2"),
+        ("charText", end + "4a32"),
+        ("reserved3", end + "4f4"),
+        ("nOverlayElements", end + "u2"),
+        ("overlayColors", end + "16u2"),
+    ]
 
     if version >= 334:
-        dtype_list.extend([
-            ('timeConstantNew', end + 'f4'),
-            ('reserved4', end + '2f4'),
-        ])
+        dtype_list.extend(
+            [
+                ("timeConstantNew", end + "f4"),
+                ("reserved4", end + "2f4"),
+            ]
+        )
 
     return dtype_list
 
@@ -694,34 +651,38 @@ def _add_spc_metadata(metadata, spc_header):
     metadata : dict
         copy of original dictionary with spectral calibration added
     """
-    metadata['Acquisition_instrument'] = {
-        'SEM':
-            {'Detector':
-             {'EDS': {'azimuth_angle': spc_header['azimuth'],
-                      'elevation_angle': spc_header['elevation'],
-                      'energy_resolution_MnKa': spc_header['detReso'],
-                      'live_time': spc_header['liveTime']}},
-             'beam_energy': spc_header['kV'],
-             'Stage': {'tilt_alpha': spc_header['tilt']}}
+    metadata["Acquisition_instrument"] = {
+        "SEM": {
+            "Detector": {
+                "EDS": {
+                    "azimuth_angle": spc_header["azimuth"],
+                    "elevation_angle": spc_header["elevation"],
+                    "energy_resolution_MnKa": spc_header["detReso"],
+                    "live_time": spc_header["liveTime"],
+                }
+            },
+            "beam_energy": spc_header["kV"],
+            "Stage": {"tilt_alpha": spc_header["tilt"]},
+        }
     }
 
     # Get elements stored in spectrum:
-    num_elem = spc_header['numElem']
+    num_elem = spc_header["numElem"]
     if num_elem > 0:
-        element_list = sorted([atomic_number2name[i] for
-                               i in spc_header['at'][:num_elem]])
-        metadata['Sample'] = {'elements': element_list}
-        _logger.info(" Elemental information found in the spectral metadata "
-                     "was added to the signal.\n"
-                     "Elements found were: {}\n".format(element_list))
+        element_list = sorted(
+            [atomic_number2name[i] for i in spc_header["at"][:num_elem]]
+        )
+        metadata["Sample"] = {"elements": element_list}
+        _logger.info(
+            " Elemental information found in the spectral metadata "
+            "was added to the signal.\n"
+            "Elements found were: {}\n".format(element_list)
+        )
 
     return metadata
 
 
-def spc_reader(filename,
-               endianess='<',
-               load_all_spc=False,
-               **kwargs):
+def spc_reader(filename, endianess="<", load_all_spc=False, **kwargs):
     """
     Read data from an SPC spectrum specified by filename.
 
@@ -743,56 +704,69 @@ def spc_reader(filename,
         list with dictionary of signal information to be passed back to
         hyperspy.io.load_with_reader
     """
-    with open(filename, 'rb') as f:
-        _logger.debug(' Reading {}'.format(filename))
+    with open(filename, "rb") as f:
+        _logger.debug(" Reading {}".format(filename))
         spc_header = __get_spc_header(f, endianess, load_all_spc)
 
         spc_dict = sarray2dict(spc_header)
-        original_metadata = {'spc_header': spc_dict}
+        original_metadata = {"spc_header": spc_dict}
 
-        nz = original_metadata['spc_header']['numPts']
-        data_offset = original_metadata['spc_header']['dataStart']
+        nz = original_metadata["spc_header"]["numPts"]
+        data_offset = original_metadata["spc_header"]["dataStart"]
 
-        mode = kwargs.pop('mode', 'c')
-        lazy = kwargs.pop('lazy', False)
+        mode = kwargs.pop("mode", "c")
+        lazy = kwargs.pop("lazy", False)
         if lazy:
-            mode = 'r'
+            mode = "r"
 
         # Read data from file into a numpy memmap object
-        data = np.memmap(f, mode=mode, offset=data_offset,
-                         dtype='u4', shape=(1, nz), **kwargs).squeeze()
+        data = np.memmap(
+            f, mode=mode, offset=data_offset, dtype="u4", shape=(1, nz), **kwargs
+        ).squeeze()
 
     # create the energy axis dictionary:
     energy_axis = {
-        'size': data.shape[0],
-        'index_in_array': 0,
-        'name': 'Energy',
-        'scale': original_metadata['spc_header']['evPerChan'] / 1000.0,
-        'offset': original_metadata['spc_header']['startEnergy'],
-        'units': 'keV'
+        "size": data.shape[0],
+        "index_in_array": 0,
+        "name": "Energy",
+        "scale": original_metadata["spc_header"]["evPerChan"] / 1000.0,
+        "offset": original_metadata["spc_header"]["startEnergy"],
+        "units": "keV",
     }
 
     # Assign metadata for spectrum:
-    metadata = {'General': {'original_filename': os.path.split(filename)[1],
-                            'title': 'EDS Spectrum'},
-                "Signal": {'signal_type': "EDS_SEM",
-                           'record_by': 'spectrum', }, }
+    metadata = {
+        "General": {
+            "original_filename": os.path.split(filename)[1],
+            "title": "EDS Spectrum",
+        },
+        "Signal": {
+            "signal_type": "EDS_SEM",
+            "record_by": "spectrum",
+        },
+    }
     metadata = _add_spc_metadata(metadata, spc_dict)
 
-    dictionary = {'data': data,
-                  'axes': [energy_axis],
-                  'metadata': metadata,
-                  'original_metadata': original_metadata}
+    dictionary = {
+        "data": data,
+        "axes": [energy_axis],
+        "metadata": metadata,
+        "original_metadata": original_metadata,
+    }
 
-    return [dictionary, ]
+    return [
+        dictionary,
+    ]
 
 
-def spd_reader(filename,
-               endianess='<',
-               spc_fname=None,
-               ipr_fname=None,
-               load_all_spc=False,
-               **kwargs):
+def spd_reader(
+    filename,
+    endianess="<",
+    spc_fname=None,
+    ipr_fname=None,
+    load_all_spc=False,
+    **kwargs
+):
     """
     Read data from an SPD spectral map specified by filename.
 
@@ -828,51 +802,51 @@ def spd_reader(filename,
         list with dictionary of signal information to be passed back to
         hyperspy.io.load_with_reader
     """
-    with open(filename, 'rb') as f:
-        spd_header = np.fromfile(f,
-                                 dtype=get_spd_dtype_list(endianess),
-                                 count=1)
+    with open(filename, "rb") as f:
+        spd_header = np.fromfile(f, dtype=get_spd_dtype_list(endianess), count=1)
 
-        original_metadata = {'spd_header': sarray2dict(spd_header)}
+        original_metadata = {"spd_header": sarray2dict(spd_header)}
 
         # dimensions of map data:
-        nx = original_metadata['spd_header']['nPoints']
-        ny = original_metadata['spd_header']['nLines']
-        nz = original_metadata['spd_header']['nChannels']
-        data_offset = original_metadata['spd_header']['dataOffset']
-        data_type = {'1': 'u1',
-                     '2': 'u2',
-                     '4': 'u4'}[str(original_metadata['spd_header'][
-                         'countBytes'])]
-        lazy = kwargs.pop('lazy', False)
-        mode = kwargs.pop('mode', 'c')
+        nx = original_metadata["spd_header"]["nPoints"]
+        ny = original_metadata["spd_header"]["nLines"]
+        nz = original_metadata["spd_header"]["nChannels"]
+        data_offset = original_metadata["spd_header"]["dataOffset"]
+        data_type = {"1": "u1", "2": "u2", "4": "u4"}[
+            str(original_metadata["spd_header"]["countBytes"])
+        ]
+        lazy = kwargs.pop("lazy", False)
+        mode = kwargs.pop("mode", "c")
         if lazy:
-            mode = 'r'
+            mode = "r"
 
         # Read data from file into a numpy memmap object
-        data = np.memmap(f, mode=mode, offset=data_offset, dtype=data_type,
-                         **kwargs).squeeze().reshape((nz, nx, ny), order='F').T
+        data = (
+            np.memmap(f, mode=mode, offset=data_offset, dtype=data_type, **kwargs)
+            .squeeze()
+            .reshape((nz, nx, ny), order="F")
+            .T
+        )
 
     # Convert char arrays to strings:
-    original_metadata['spd_header']['tag'] = \
-        spd_header['tag'][0].view('S16')[0]
+    original_metadata["spd_header"]["tag"] = spd_header["tag"][0].view("S16")[0]
     # fName is the name of the .bmp (and .ipr) file of the map
-    original_metadata['spd_header']['fName'] = \
-        spd_header['fName'][0].view('S120')[0]
+    original_metadata["spd_header"]["fName"] = spd_header["fName"][0].view("S120")[0]
 
     # Get name of .spc file from the .spd map (if not explicitly given):
     if spc_fname is None:
         spc_path = os.path.dirname(filename)
-        spc_basename = os.path.splitext(os.path.basename(filename))[
-            0] + '.spc'
+        spc_basename = os.path.splitext(os.path.basename(filename))[0] + ".spc"
         spc_fname = os.path.join(spc_path, spc_basename)
 
     # Get name of .ipr file from bitmap image (if not explicitly given):
     if ipr_fname is None:
-        ipr_basename = os.path.splitext(
-            os.path.basename(
-                original_metadata['spd_header'][
-                    'fName']))[0].decode() + '.ipr'
+        ipr_basename = (
+            os.path.splitext(
+                os.path.basename(original_metadata["spd_header"]["fName"])
+            )[0].decode()
+            + ".ipr"
+        )
         ipr_path = os.path.dirname(filename)
         ipr_fname = os.path.join(ipr_path, ipr_basename)
 
@@ -882,76 +856,82 @@ def spd_reader(filename,
 
     # Read the .ipr header (if possible)
     if read_ipr:
-        with open(ipr_fname, 'rb') as f:
-            _logger.debug(' From .spd reader - '
-                          'reading .ipr {}'.format(ipr_fname))
+        with open(ipr_fname, "rb") as f:
+            _logger.debug(" From .spd reader - " "reading .ipr {}".format(ipr_fname))
             ipr_header = __get_ipr_header(f, endianess)
-            original_metadata['ipr_header'] = sarray2dict(ipr_header)
+            original_metadata["ipr_header"] = sarray2dict(ipr_header)
 
             # Workaround for type error when saving hdf5:
             # save as list of strings instead of numpy unicode array
             # see https://github.com/hyperspy/hyperspy/pull/2007 and
             #     https://github.com/h5py/h5py/issues/289 for context
-            original_metadata['ipr_header']['charText'] = \
-                [np.string_(i) for i in
-                 original_metadata['ipr_header']['charText']]
+            original_metadata["ipr_header"]["charText"] = [
+                np.string_(i) for i in original_metadata["ipr_header"]["charText"]
+            ]
     else:
-        _logger.warning('Could not find .ipr file named {}.\n'
-                        'No spatial calibration will be loaded.'
-                        '\n'.format(ipr_fname))
+        _logger.warning(
+            "Could not find .ipr file named {}.\n"
+            "No spatial calibration will be loaded."
+            "\n".format(ipr_fname)
+        )
 
     # Read the .spc header (if possible)
     if read_spc:
-        with open(spc_fname, 'rb') as f:
-            _logger.debug(' From .spd reader - '
-                          'reading .spc {}'.format(spc_fname))
+        with open(spc_fname, "rb") as f:
+            _logger.debug(" From .spd reader - " "reading .spc {}".format(spc_fname))
             spc_header = __get_spc_header(f, endianess, load_all_spc)
             spc_dict = sarray2dict(spc_header)
-            original_metadata['spc_header'] = spc_dict
+            original_metadata["spc_header"] = spc_dict
     else:
-        _logger.warning('Could not find .spc file named {}.\n'
-                        'No spectral metadata will be loaded.'
-                        '\n'.format(spc_fname))
+        _logger.warning(
+            "Could not find .spc file named {}.\n"
+            "No spectral metadata will be loaded."
+            "\n".format(spc_fname)
+        )
 
     # create the energy axis dictionary:
     energy_axis = {
-        'size': data.shape[2],
-        'index_in_array': 2,
-        'name': 'Energy',
-        'scale': original_metadata['spc_header']['evPerChan'] / 1000.0 if
-        read_spc else 1,
-        'offset': original_metadata['spc_header']['startEnergy'] if
-        read_spc else 1,
-        'units': 'keV' if read_spc else None,
+        "size": data.shape[2],
+        "index_in_array": 2,
+        "name": "Energy",
+        "scale": original_metadata["spc_header"]["evPerChan"] / 1000.0
+        if read_spc
+        else 1,
+        "offset": original_metadata["spc_header"]["startEnergy"] if read_spc else 1,
+        "units": "keV" if read_spc else None,
     }
 
-    nav_units = 'µm'
+    nav_units = "µm"
     # Create navigation axes dictionaries:
     x_axis = {
-        'size': data.shape[1],
-        'index_in_array': 1,
-        'name': 'x',
-        'scale': original_metadata['ipr_header']['mppX'] if read_ipr
-        else 1,
-        'offset': 0,
-        'units': nav_units if read_ipr else None,
+        "size": data.shape[1],
+        "index_in_array": 1,
+        "name": "x",
+        "scale": original_metadata["ipr_header"]["mppX"] if read_ipr else 1,
+        "offset": 0,
+        "units": nav_units if read_ipr else None,
     }
 
     y_axis = {
-        'size': data.shape[0],
-        'index_in_array': 0,
-        'name': 'y',
-        'scale': original_metadata['ipr_header']['mppY'] if read_ipr
-        else 1,
-        'offset': 0,
-        'units': nav_units if read_ipr else None,
+        "size": data.shape[0],
+        "index_in_array": 0,
+        "name": "y",
+        "scale": original_metadata["ipr_header"]["mppY"] if read_ipr else 1,
+        "offset": 0,
+        "units": nav_units if read_ipr else None,
     }
 
     # Assign metadata for spectrum image:
-    metadata = {'General': {'original_filename': os.path.split(filename)[1],
-                            'title': 'EDS Spectrum Image'},
-                "Signal": {'signal_type': "EDS_SEM",
-                           'record_by': 'spectrum', }, }
+    metadata = {
+        "General": {
+            "original_filename": os.path.split(filename)[1],
+            "title": "EDS Spectrum Image",
+        },
+        "Signal": {
+            "signal_type": "EDS_SEM",
+            "record_by": "spectrum",
+        },
+    }
 
     # Add spectral calibration and elements (if present):
     if read_spc:
@@ -960,18 +940,19 @@ def spd_reader(filename,
     # Define navigation and signal axes:
     axes = [y_axis, x_axis, energy_axis]
 
-    dictionary = {'data': data,
-                  'axes': axes,
-                  'metadata': metadata,
-                  'original_metadata': original_metadata}
+    dictionary = {
+        "data": data,
+        "axes": axes,
+        "metadata": metadata,
+        "original_metadata": original_metadata,
+    }
 
-    return [dictionary, ]
+    return [
+        dictionary,
+    ]
 
 
-def file_reader(filename,
-                record_by='spectrum',
-                endianess='<',
-                **kwargs):
+def file_reader(filename, record_by="spectrum", endianess="<", **kwargs):
     """
 
     Parameters
@@ -992,12 +973,8 @@ def file_reader(filename,
     """
     ext = os.path.splitext(filename)[1][1:]
     if ext in spd_extensions:
-        return spd_reader(filename,
-                          endianess,
-                          **kwargs)
+        return spd_reader(filename, endianess, **kwargs)
     elif ext in spc_extensions:
-        return spc_reader(filename,
-                          endianess,
-                          **kwargs)
+        return spc_reader(filename, endianess, **kwargs)
     else:
         raise IOError("Did not understand input file format.")

--- a/rsciio/empad/api.py
+++ b/rsciio/empad/api.py
@@ -31,21 +31,21 @@ _logger = logging.getLogger(__name__)
 
 def _read_raw(info, fp, lazy=False):
 
-    raw_height = info['raw_height']
-    width = info['width']
-    height = info['height']
+    raw_height = info["raw_height"]
+    width = info["width"]
+    height = info["height"]
 
     if lazy:
-        data = np.memmap(fp, dtype='<f4', mode='r')
+        data = np.memmap(fp, dtype="<f4", mode="r")
     else:
-        data = np.fromfile(fp, dtype='<f4')
+        data = np.fromfile(fp, dtype="<f4")
 
-    if 'series_count' in info.keys():   # stack of images
-        size = (info['series_count'], raw_height, width)
+    if "series_count" in info.keys():  # stack of images
+        size = (info["series_count"], raw_height, width)
         data = data.reshape(size)[..., :height, :]
 
     else:  # 2D x 2D
-        size = (info['scan_x'], info['scan_y'], raw_height, width)
+        size = (info["scan_x"], info["scan_y"], raw_height, width)
         data = data.reshape(size)[..., :height, :]
     return data
 
@@ -54,26 +54,33 @@ def _parse_xml(filename):
     tree = ET.parse(filename)
     om = convert_xml_to_dict(tree.getroot())
 
-    info = {'raw_filename': om.root.raw_file.filename,
-            'width':128,
-            'height':128,
-            'raw_height':130,
-            'record-by':'image'}
-    if om.has_item('root.scan_parameters.series_count'):
+    info = {
+        "raw_filename": om.root.raw_file.filename,
+        "width": 128,
+        "height": 128,
+        "raw_height": 130,
+        "record-by": "image",
+    }
+    if om.has_item("root.scan_parameters.series_count"):
         # Stack of images
-        info.update({'series_count':int(om.root.scan_parameters.series_count)})
-    elif om.has_item('root.pix_x') and om.has_item('root.pix_y'):
+        info.update({"series_count": int(om.root.scan_parameters.series_count)})
+    elif om.has_item("root.pix_x") and om.has_item("root.pix_y"):
         # 2D x 2D
-        info.update({'scan_x':int(om.root.pix_x),
-                     'scan_y':int(om.root.pix_y)})
+        info.update({"scan_x": int(om.root.pix_x), "scan_y": int(om.root.pix_y)})
     # in case root.pix_x and root.pix_y are not available
-    elif (om.has_item('root.scan_parameters.scan_resolution_x') and
-              om.has_item('root.scan_parameters.scan_resolution_y')):
-        info.update({'scan_x':int(om.root.scan_parameters.scan_resolution_x),
-                     'scan_y':int(om.root.scan_parameters.scan_resolution_y)})
+    elif om.has_item("root.scan_parameters.scan_resolution_x") and om.has_item(
+        "root.scan_parameters.scan_resolution_y"
+    ):
+        info.update(
+            {
+                "scan_x": int(om.root.scan_parameters.scan_resolution_x),
+                "scan_y": int(om.root.scan_parameters.scan_resolution_y),
+            }
+        )
     else:
-        raise IOError("Unsupported Empad file: the scan parameters cannot "
-                      "be imported.")
+        raise IOError(
+            "Unsupported Empad file: the scan parameters cannot " "be imported."
+        )
 
     return om, info
 
@@ -82,7 +89,7 @@ def _convert_scale_units(value, units, factor=1):
     v = float(value) * _UREG(units)
     converted_v = (factor * v).to_compact()
     converted_value = converted_v.magnitude / factor
-    converted_units = '{:~}'.format(converted_v.units)
+    converted_units = "{:~}".format(converted_v.units)
 
     return converted_value, converted_units
 
@@ -93,33 +100,39 @@ def file_reader(filename, lazy=False, **kwds):
     dname, fname = os.path.split(filename)
 
     md = {
-        'General': {'original_filename': fname,
-                    'title': os.path.splitext(fname)[0],
-                    },
-        "Signal": {'signal_type': 'electron_diffraction',
-                   'record_by': 'image'},
+        "General": {
+            "original_filename": fname,
+            "title": os.path.splitext(fname)[0],
+        },
+        "Signal": {"signal_type": "electron_diffraction", "record_by": "image"},
     }
 
-    if om.has_item('root.timestamp.isoformat'):
-        date, time = om.root.timestamp.isoformat.split('T')
-        md['General'].update({"date":date, "time":time})
+    if om.has_item("root.timestamp.isoformat"):
+        date, time = om.root.timestamp.isoformat.split("T")
+        md["General"].update({"date": date, "time": time})
 
-    units = [None, ] * 2
-    scales = [1, ] * 2
-    origins = [-64, ] * 2
+    units = [
+        None,
+    ] * 2
+    scales = [
+        1,
+    ] * 2
+    origins = [
+        -64,
+    ] * 2
     axes = []
     index_in_array = 0
-    names = ['height', 'width']
+    names = ["height", "width"]
 
-    if 'series_count' in info.keys():
-        names = ['series_count'] + names
-        units.insert(0, 'ms')
+    if "series_count" in info.keys():
+        names = ["series_count"] + names
+        units.insert(0, "ms")
         scales.insert(0, 1)
         origins.insert(0, 0)
     else:
-        names = ['scan_x', 'scan_y'] + names
-        units.insert(0, '')
-        units.insert(0, '')
+        names = ["scan_x", "scan_y"] + names
+        units.insert(0, "")
+        units.insert(0, "")
         scales.insert(0, 1)
         scales.insert(0, 1)
         origins.insert(0, 0)
@@ -127,45 +140,48 @@ def file_reader(filename, lazy=False, **kwds):
 
     sizes = [info[name] for name in names]
 
-    if not 'series_count' in info.keys():
+    if not "series_count" in info.keys():
         try:
             fov = ast.literal_eval(
-                om.root.iom_measurements.optics.get_full_scan_field_of_view)
+                om.root.iom_measurements.optics.get_full_scan_field_of_view
+            )
             for i in range(2):
                 value = fov[i] / sizes[i]
-                scales[i], units[i] = _convert_scale_units(value, 'm', sizes[i])
+                scales[i], units[i] = _convert_scale_units(value, "m", sizes[i])
         except BaseException:
             _logger.warning("The scale of the navigation axes cannot be read.")
 
     try:
-        pixel_size = float(om.root.iom_measurements.calibrated_pixelsize) * 1E9
+        pixel_size = float(om.root.iom_measurements.calibrated_pixelsize) * 1e9
         for i in [-1, -2]:
             scales[i] = pixel_size
-            units[i] = '1/nm'
+            units[i] = "1/nm"
     except BaseException:
         _logger.warning("The scale of the signal axes cannot be read.")
 
     for i in range(len(names)):
         if sizes[i] > 1:
-            axes.append({
-                'size': sizes[i],
-                'index_in_array': index_in_array,
-                'name': names[i],
-                'scale': scales[i],
-                'offset': origins[i] * scales[i],
-                'units': units[i],
-            })
+            axes.append(
+                {
+                    "size": sizes[i],
+                    "index_in_array": index_in_array,
+                    "name": names[i],
+                    "scale": scales[i],
+                    "offset": origins[i] * scales[i],
+                    "units": units[i],
+                }
+            )
             index_in_array += 1
 
-    data = _read_raw(info,
-                     os.path.join(dname, info['raw_filename']),
-                     lazy=lazy)
+    data = _read_raw(info, os.path.join(dname, info["raw_filename"]), lazy=lazy)
 
     dictionary = {
-        'data': data.squeeze(),
-        'axes': axes,
-        'metadata': md,
-        'original_metadata': om.to_dict()
+        "data": data.squeeze(),
+        "axes": axes,
+        "metadata": md,
+        "original_metadata": om.to_dict(),
     }
 
-    return [dictionary, ]
+    return [
+        dictionary,
+    ]

--- a/rsciio/exceptions.py
+++ b/rsciio/exceptions.py
@@ -1,15 +1,13 @@
-
 class MountainsMapFileError(Exception):
-
-    def __init__(self, msg = "Corrupt Mountainsmap file"):
-        self.error =  msg
+    def __init__(self, msg="Corrupt Mountainsmap file"):
+        self.error = msg
 
     def __str__(self):
         return repr(self.error)
 
-class ByteOrderError(Exception):
 
-    def __init__(self, order=''):
+class ByteOrderError(Exception):
+    def __init__(self, order=""):
         self.byte_order = order
 
     def __str__(self):
@@ -17,8 +15,7 @@ class ByteOrderError(Exception):
 
 
 class DM3FileVersionError(Exception):
-
-    def __init__(self, value=''):
+    def __init__(self, value=""):
         self.dm3_version = value
 
     def __str__(self):
@@ -26,8 +23,7 @@ class DM3FileVersionError(Exception):
 
 
 class DM3TagError(Exception):
-
-    def __init__(self, value=''):
+    def __init__(self, value=""):
         self.dm3_tag = value
 
     def __str__(self):
@@ -35,8 +31,7 @@ class DM3TagError(Exception):
 
 
 class DM3DataTypeError(Exception):
-
-    def __init__(self, value=''):
+    def __init__(self, value=""):
         self.dm3_dtype = value
 
     def __str__(self):
@@ -44,8 +39,7 @@ class DM3DataTypeError(Exception):
 
 
 class DM3TagTypeError(Exception):
-
-    def __init__(self, value=''):
+    def __init__(self, value=""):
         self.dm3_tagtype = value
 
     def __str__(self):
@@ -53,12 +47,12 @@ class DM3TagTypeError(Exception):
 
 
 class DM3TagIDError(Exception):
-
-    def __init__(self, value=''):
+    def __init__(self, value=""):
         self.dm3_tagID = value
 
     def __str__(self):
         return repr(self.dm3_tagID)
+
 
 class VisibleDeprecationWarning(UserWarning):
 
@@ -67,16 +61,17 @@ class VisibleDeprecationWarning(UserWarning):
     provides a visible one.
 
     """
+
     pass
 
-class LazyCupyConversion(Exception):
 
+class LazyCupyConversion(Exception):
     def __init__(self):
         self.error = (
             "Automatically converting data to cupy array is not supported "
             "for lazy signals. Read the corresponding section in the user "
             "guide for more information on how to use GPU with lazy signals."
-            )
+        )
 
     def __str__(self):
         return repr(self.error)

--- a/rsciio/fei/api.py
+++ b/rsciio/fei/api.py
@@ -34,18 +34,17 @@ from rsciio.utils.tools import DTBox
 _logger = logging.getLogger(__name__)
 
 
-
 data_types = {
-    '1': '<u1',
-    '2': '<u2',
-    '3': '<u4',
-    '4': '<i1',
-    '5': '<i2',
-    '6': '<i4',
-    '7': '<f4',
-    '8': '<f8',
-    '9': '<c8',
-    '10': '<c16',
+    "1": "<u1",
+    "2": "<u2",
+    "3": "<u4",
+    "4": "<i1",
+    "5": "<i2",
+    "6": "<i4",
+    "7": "<f4",
+    "8": "<f8",
+    "9": "<c8",
+    "10": "<c16",
 }
 
 XY_TAG_ID = 16706  # header contains XY calibration
@@ -54,19 +53,19 @@ XY_TAG_ID = 16706  # header contains XY calibration
 def readLELongLong(file):
     """Read 8 bytes as *little endian* integer in file"""
     read_bytes = file.read(8)
-    return struct.unpack('<Q', read_bytes)[0]
+    return struct.unpack("<Q", read_bytes)[0]
 
 
 def readLELong(file):
     """Read 4 bytes as *little endian* integer in file"""
     read_bytes = file.read(4)
-    return struct.unpack('<L', read_bytes)[0]
+    return struct.unpack("<L", read_bytes)[0]
 
 
 def readLEShort(file):
     """Read 2 bytes as *little endian* integer in file"""
     read_bytes = file.read(2)
-    return struct.unpack('<H', read_bytes)[0]
+    return struct.unpack("<H", read_bytes)[0]
 
 
 def dimension_array_dtype(n, DescriptionLength, UnitsLength):
@@ -101,10 +100,9 @@ def get_header_dtype_list(file):
         ("DataTypeID", "<u4"),
         ("TagTypeID", "<u4"),
         ("TotalNumberElements", "<u4"),
-        ("ValidNumberElements", "<u4")]
-    header1 = np.fromfile(file,
-                          dtype=np.dtype(header_list1),
-                          count=1)
+        ("ValidNumberElements", "<u4"),
+    ]
+    header1 = np.fromfile(file, dtype=np.dtype(header_list1), count=1)
     # Depending on the SeriesVersion, the OffsetArrayOffset is 4 or 8 bytes
     if header1["SeriesVersion"] <= 528:
         OffsetArrayOffset_dtype = "<u4"
@@ -116,24 +114,23 @@ def get_header_dtype_list(file):
     # Once we know the type of the OffsetArrayOffset, we can continue reading
     # the 2nd part of the header
     file.seek(22)
-    header_list2 = [("OffsetArrayOffset", OffsetArrayOffset_dtype),
-                    ("NumberDimensions", "<u4")]
-    header2 = np.fromfile(file,
-                          dtype=np.dtype(header_list2),
-                          count=1)
+    header_list2 = [
+        ("OffsetArrayOffset", OffsetArrayOffset_dtype),
+        ("NumberDimensions", "<u4"),
+    ]
+    header2 = np.fromfile(file, dtype=np.dtype(header_list2), count=1)
     header_list = header_list1 + header_list2
     # Go to the beginning of the dimension array section
     file.seek(beginning_dimension_array_section)
     for n in range(1, header2["NumberDimensions"][0] + 1):
         description_length, unit_length = get_lengths(file)
-        header_list += dimension_array_dtype(
-            n, description_length, unit_length)
+        header_list += dimension_array_dtype(n, description_length, unit_length)
     file.seek(0)
     return header_list
 
 
 def get_data_dtype_list(file, offset, record_by):
-    if record_by == 'spectrum':
+    if record_by == "spectrum":
         file.seek(offset + 20)
         data_type = readLEShort(file)
         array_size = readLELong(file)
@@ -145,8 +142,8 @@ def get_data_dtype_list(file, offset, record_by):
             ("ArrayLength", "<u4"),
             ("Array", (data_types[str(data_type)], array_size)),
         ]
-        shape = (array_size)
-    elif record_by == 'image':  # Untested
+        shape = array_size
+    elif record_by == "image":  # Untested
         file.seek(offset + 40)
         data_type = readLEShort(file)
         array_size_x = readLELong(file)
@@ -162,8 +159,7 @@ def get_data_dtype_list(file, offset, record_by):
             ("DataType", "<u2"),
             ("ArraySizeX", "<u4"),
             ("ArraySizeY", "<u4"),
-            ("Array",
-             (data_types[str(data_type)], (array_size_x, array_size_y))),
+            ("Array", (data_types[str(data_type)], (array_size_x, array_size_y))),
         ]
         shape = (array_size_x, array_size_y)
     return header, shape
@@ -174,7 +170,7 @@ def get_data_tag_dtype_list(data_type_id):
         header = [
             ("TagTypeID", ("<u2")),
             ("Unknown", ("<u2")),  # Not in Boothroyd description. = 0
-            ("Time", "<u4"),   # The precision is one second...
+            ("Time", "<u4"),  # The precision is one second...
             ("PositionX", "<f8"),
             ("PositionY", "<f8"),
         ]
@@ -183,15 +179,17 @@ def get_data_tag_dtype_list(data_type_id):
             ("TagTypeID", ("<u2")),
             # Not in Boothroyd description. = 0. Not tested.
             ("Unknown", ("<u2")),
-            ("Time", "<u4"),   # The precision is one second...
+            ("Time", "<u4"),  # The precision is one second...
         ]
     return header
 
 
 def log_struct_array_values(struct_array):
     for key in struct_array.dtype.names:
-        if not isinstance(struct_array[key], np.ndarray) or \
-                np.array(struct_array[key].shape).sum() == 1:
+        if (
+            not isinstance(struct_array[key], np.ndarray)
+            or np.array(struct_array[key].shape).sum() == 1
+        ):
             _logger.info("%s : %s", key, struct_array[key])
         else:
             _logger.info("%s : Array", key)
@@ -199,9 +197,9 @@ def log_struct_array_values(struct_array):
 
 def guess_record_by(record_by_id):
     if record_by_id == 16672:
-        return 'spectrum'
+        return "spectrum"
     else:
-        return 'image'
+        return "image"
 
 
 def parse_ExperimentalDescription(et, dictree):
@@ -216,8 +214,9 @@ def parse_ExperimentalDescription(et, dictree):
             # try to coerce value to decimal representation
             value = float(value) if units else value
         except ValueError:
-            _logger.warning(f'Expected decimal value for {label}, '
-                            f'but received {value} instead')
+            _logger.warning(
+                f"Expected decimal value for {label}, " f"but received {value} instead"
+            )
         dictree[item] = value
 
 
@@ -256,10 +255,10 @@ def emi_reader(filename, dump_xml=False, **kwds):
     filename = os.path.splitext(filename)[0]
     if dump_xml is True:
         for i, obj in enumerate(objects):
-            with open(filename + '-object-%s.xml' % i, 'w') as f:
+            with open(filename + "-object-%s.xml" % i, "w") as f:
                 f.write(obj)
 
-    ser_files = sorted(glob(filename + '_[0-9].ser'))
+    ser_files = sorted(glob(filename + "_[0-9].ser"))
     sers = []
     for f in ser_files:
         _logger.info("Opening %s", f)
@@ -269,72 +268,75 @@ def emi_reader(filename, dump_xml=False, **kwds):
             continue
 
         index = int(os.path.splitext(f)[0].split("_")[-1]) - 1
-        op = DTBox(sers[-1]['original_metadata'], box_dots=True)
+        op = DTBox(sers[-1]["original_metadata"], box_dots=True)
 
         # defend against condition where more ser files are present than object
         # metadata defined in emi
         if index < len(objects):
             emixml2dtb(ET.fromstring(objects[index]), op)
         else:
-            _logger.warning(f'{orig_fname} did not contain any metadata for '
-                            f'{f}, so only .ser header information was read')
-        sers[-1]['original_metadata'] = op.to_dict()
+            _logger.warning(
+                f"{orig_fname} did not contain any metadata for "
+                f"{f}, so only .ser header information was read"
+            )
+        sers[-1]["original_metadata"] = op.to_dict()
     return sers
 
 
 def file_reader(filename, *args, **kwds):
     ext = os.path.splitext(filename)[1][1:]
-    ser_extensions = ('ser', 'SER')
-    emi_extensions = ('emi', 'EMI')
+    ser_extensions = ("ser", "SER")
+    emi_extensions = ("emi", "EMI")
     if ext in ser_extensions:
-        return [ser_reader(filename, *args, **kwds), ]
+        return [
+            ser_reader(filename, *args, **kwds),
+        ]
     elif ext in emi_extensions:
         return emi_reader(filename, *args, **kwds)
 
 
 def load_ser_file(filename):
     _logger.info("Opening the file: %s", filename)
-    with open(filename, 'rb') as f:
-        header = np.fromfile(f,
-                             dtype=np.dtype(get_header_dtype_list(f)),
-                             count=1)
+    with open(filename, "rb") as f:
+        header = np.fromfile(f, dtype=np.dtype(get_header_dtype_list(f)), count=1)
         _logger.info("Header info:")
         log_struct_array_values(header[0])
 
-        if header['ValidNumberElements'] == 0:
+        if header["ValidNumberElements"] == 0:
             raise IOError(
                 "The file does not contains valid data. "
                 "If it is a single spectrum, the data is contained in the  "
                 ".emi file but HyperSpy cannot currently extract this "
-                "information.")
+                "information."
+            )
 
         # Read the first element of data offsets
         f.seek(header["OffsetArrayOffset"][0])
         # OffsetArrayOffset can contain 4 or 8 bytes integer depending if the
         # data have been acquired using a 32 or 64 bits platform.
-        if header['SeriesVersion'] <= 528:
+        if header["SeriesVersion"] <= 528:
             data_offset = readLELong(f)
-            data_offset_array = np.fromfile(f,
-                                            dtype="<u4",
-                                            count=header["ValidNumberElements"][0])
+            data_offset_array = np.fromfile(
+                f, dtype="<u4", count=header["ValidNumberElements"][0]
+            )
         else:
             data_offset = readLELongLong(f)
-            data_offset_array = np.fromfile(f,
-                                            dtype="<u8",
-                                            count=header["ValidNumberElements"][0])
+            data_offset_array = np.fromfile(
+                f, dtype="<u8", count=header["ValidNumberElements"][0]
+            )
         data_dtype_list, shape = get_data_dtype_list(
-            f,
-            data_offset,
-            guess_record_by(header['DataTypeID']))
-        tag_dtype_list = get_data_tag_dtype_list(header['TagTypeID'])
+            f, data_offset, guess_record_by(header["DataTypeID"])
+        )
+        tag_dtype_list = get_data_tag_dtype_list(header["TagTypeID"])
         f.seek(data_offset)
-        data = np.empty(header["ValidNumberElements"][0],
-                        dtype=np.dtype(data_dtype_list + tag_dtype_list))
+        data = np.empty(
+            header["ValidNumberElements"][0],
+            dtype=np.dtype(data_dtype_list + tag_dtype_list),
+        )
         for i, offset in enumerate(data_offset_array):
-            data[i] = np.fromfile(f,
-                                  dtype=np.dtype(
-                                      data_dtype_list + tag_dtype_list),
-                                  count=1)
+            data[i] = np.fromfile(
+                f, dtype=np.dtype(data_dtype_list + tag_dtype_list), count=1
+            )
             f.seek(offset)
         _logger.info("Data info:")
         log_struct_array_values(data[0])
@@ -342,15 +344,15 @@ def load_ser_file(filename):
 
 
 def get_xml_info_from_emi(emi_file):
-    with open(emi_file, 'rb') as f:
+    with open(emi_file, "rb") as f:
         tx = f.read()
     objects = []
     i_start = 0
     while i_start != -1:
         i_start += 1
-        i_start = tx.find(b'<ObjectInfo>', i_start)
-        i_end = tx.find(b'</ObjectInfo>', i_start)
-        objects.append(tx[i_start:i_end + 13].decode('utf-8'))
+        i_start = tx.find(b"<ObjectInfo>", i_start)
+        i_end = tx.find(b"</ObjectInfo>", i_start)
+        objects.append(tx[i_start : i_end + 13].decode("utf-8"))
     return objects[:-1]
 
 
@@ -402,64 +404,76 @@ def get_axes_from_position(header, data):
         ycal = get_calibration_from_position(data[b"PositionY"])
         if xcal[b"size"] == 0 and ycal[b"size"] != 0:
             # Vertical line scan
-            axes.append({
-                'name': "x",
-                'units': "meters",
-                'index_in_array': 0,
-            })
+            axes.append(
+                {
+                    "name": "x",
+                    "units": "meters",
+                    "index_in_array": 0,
+                }
+            )
             axes[-1].update(xcal)
             array_shape.append(axes[-1]["size"])
 
         elif xcal[b"size"] != 0 and ycal[b"size"] == 0:
             # Horizontal line scan
-            axes.append({
-                'name': "y",
-                'units': "meters",
-                'index_in_array': 0,
-            })
+            axes.append(
+                {
+                    "name": "y",
+                    "units": "meters",
+                    "index_in_array": 0,
+                }
+            )
             axes[-1].update(ycal)
             array_shape.append(axes[-1]["size"])
 
         elif xcal[b"size"] * ycal[b"size"] == array_size:
             # Signal2D
-            axes.append({
-                'name': "y",
-                'units': "meters",
-                'index_in_array': 0,
-            })
+            axes.append(
+                {
+                    "name": "y",
+                    "units": "meters",
+                    "index_in_array": 0,
+                }
+            )
             axes[-1].update(ycal)
             array_shape.append(axes[-1]["size"])
-            axes.append({
-                'name': "x",
-                'units': "meters",
-                'index_in_array': 1,
-            })
+            axes.append(
+                {
+                    "name": "x",
+                    "units": "meters",
+                    "index_in_array": 1,
+                }
+            )
             axes[-1].update(xcal)
             array_shape.append(axes[-1]["size"])
         elif xcal[b"size"] == ycal[b"size"] == array_size:
             # Oblique line scan
             scale = np.sqrt(xcal["scale"] ** 2 + ycal["scale"] ** 2)
-            axes.append({
-                'name': "x",
-                'units': "meters",
-                'index_in_array': 0,
-                "offset": 0,
-                "scale": scale,
-                "size": xcal["size"]
-            })
+            axes.append(
+                {
+                    "name": "x",
+                    "units": "meters",
+                    "index_in_array": 0,
+                    "offset": 0,
+                    "scale": scale,
+                    "size": xcal["size"],
+                }
+            )
             array_shape.append(axes[-1]["size"])
         else:
             raise IOError
     else:
         array_shape = [header["ValidNumberElements"]]
-        axes.append({
-            'name': "Unknown dimension",
-            'offset': 0,
-            'scale': 1,
-            'units': "",
-            'size': header["ValidNumberElements"],
-            'index_in_array': 0
-        })
+        axes.append(
+            {
+                "name": "Unknown dimension",
+                "offset": 0,
+                "scale": 1,
+                "units": "",
+                "size": header["ValidNumberElements"],
+                "index_in_array": 0,
+            }
+        )
     return array_shape, axes
 
 
@@ -475,8 +489,8 @@ def ser_reader(filename, objects=None, lazy=False, only_valid_data=False):
 
     """
     header, data = load_ser_file(filename)
-    record_by = guess_record_by(header['DataTypeID'])
-    ndim = int(header['NumberDimensions'])
+    record_by = guess_record_by(header["DataTypeID"])
+    ndim = int(header["NumberDimensions"])
     date, time = None, None
     if objects is not None:
         objects_dict = convert_xml_to_dict(objects[0])
@@ -484,10 +498,15 @@ def ser_reader(filename, objects=None, lazy=False, only_valid_data=False):
             acq_date = objects_dict.ObjectInfo.AcquireDate
             date, time = _get_date_time(acq_date)
         except AttributeError:
-            _logger.warning(f'AcquireDate not found in metadata of {filename};'
-                            ' Not setting metadata date or time')
-    if "PositionY" in data.dtype.names and len(data['PositionY']) > 1 and \
-            (data['PositionY'][0] == data['PositionY'][1]):
+            _logger.warning(
+                f"AcquireDate not found in metadata of {filename};"
+                " Not setting metadata date or time"
+            )
+    if (
+        "PositionY" in data.dtype.names
+        and len(data["PositionY"]) > 1
+        and (data["PositionY"][0] == data["PositionY"][1])
+    ):
         # The spatial dimensions are stored in F order i.e. X, Y, ...
         order = "F"
     else:
@@ -496,140 +515,170 @@ def ser_reader(filename, objects=None, lazy=False, only_valid_data=False):
     if ndim == 0 and header["ValidNumberElements"] != 0:
         # The calibration of the axes are not stored in the header.
         # We try to guess from the position coordinates.
-        array_shape, axes = get_axes_from_position(header=header,
-                                                   data=data)
+        array_shape, axes = get_axes_from_position(header=header, data=data)
     else:
         axes = []
-        array_shape = [None, ] * int(ndim)
+        array_shape = [
+            None,
+        ] * int(ndim)
         spatial_axes = ["x", "y"][:ndim]
         for i in range(ndim):
             idim = 1 + i if order == "C" else ndim - i
-            if (record_by == "spectrum" or
-                    header['Dim-%i_DimensionSize' % (i + 1)][0] != 1):
-                units = (header['Dim-%i_Units' % (idim)][0].decode('utf-8')
-                         if header['Dim-%i_UnitsLength' % (idim)] > 0
-                         else None)
+            if (
+                record_by == "spectrum"
+                or header["Dim-%i_DimensionSize" % (i + 1)][0] != 1
+            ):
+                units = (
+                    header["Dim-%i_Units" % (idim)][0].decode("utf-8")
+                    if header["Dim-%i_UnitsLength" % (idim)] > 0
+                    else None
+                )
                 if units == "meters":
-                    name = (spatial_axes.pop() if order == "F"
-                            else spatial_axes.pop(-1))
+                    name = spatial_axes.pop() if order == "F" else spatial_axes.pop(-1)
                 else:
                     name = None
-                axes.append({
-                    'offset': header['Dim-%i_CalibrationOffset' % idim][0],
-                    'scale': header['Dim-%i_CalibrationDelta' % idim][0],
-                    'units': units,
-                    'size': header['Dim-%i_DimensionSize' % idim][0],
-                    'name': name,
-                })
-                array_shape[i] = header['Dim-%i_DimensionSize' % idim][0]
+                axes.append(
+                    {
+                        "offset": header["Dim-%i_CalibrationOffset" % idim][0],
+                        "scale": header["Dim-%i_CalibrationDelta" % idim][0],
+                        "units": units,
+                        "size": header["Dim-%i_DimensionSize" % idim][0],
+                        "name": name,
+                    }
+                )
+                array_shape[i] = header["Dim-%i_DimensionSize" % idim][0]
 
         # Deal with issue when TotalNumberElements does not equal
         # ValidNumberElements for ndim==1.
-        if ndim == 1 and (header['TotalNumberElements']
-                          != header['ValidNumberElements'][0]) and only_valid_data:
-            if header['ValidNumberElements'][0] == 1:
+        if (
+            ndim == 1
+            and (header["TotalNumberElements"] != header["ValidNumberElements"][0])
+            and only_valid_data
+        ):
+            if header["ValidNumberElements"][0] == 1:
                 # no need for navigation dimension
                 array_shape = []
                 axes = []
             else:
-                array_shape[0] = header['ValidNumberElements'][0]
-                axes[0]['size'] = header['ValidNumberElements'][0]
+                array_shape[0] = header["ValidNumberElements"][0]
+                axes[0]["size"] = header["ValidNumberElements"][0]
 
     # Spectral dimension
     if record_by == "spectrum":
-        axes.append({
-            'offset': data['CalibrationOffset'][0],
-            'scale': data['CalibrationDelta'][0],
-            'size': data['ArrayLength'][0],
-            'index_in_array': header['NumberDimensions'][0]
-        })
+        axes.append(
+            {
+                "offset": data["CalibrationOffset"][0],
+                "scale": data["CalibrationDelta"][0],
+                "size": data["ArrayLength"][0],
+                "index_in_array": header["NumberDimensions"][0],
+            }
+        )
 
         # FEI seems to use the international system of units (SI) for the
         # energy scale (eV).
-        axes[-1]['units'] = 'eV'
-        axes[-1]['name'] = 'Energy'
+        axes[-1]["units"] = "eV"
+        axes[-1]["name"] = "Energy"
 
-        array_shape.append(data['ArrayLength'][0])
+        array_shape.append(data["ArrayLength"][0])
 
-    elif record_by == 'image':
+    elif record_by == "image":
         if objects is not None:
             units = _guess_units_from_mode(objects_dict, header)
         else:
             units = "meters"
         # Y axis
-        axes.append({
-            'name': 'y',
-            'offset': data['CalibrationOffsetY'][0] -
-            data['CalibrationElementY'][0] * data['CalibrationDeltaY'][0],
-            'scale': data['CalibrationDeltaY'][0],
-            'units': units,
-            'size': data['ArraySizeY'][0],
-        })
-        array_shape.append(data['ArraySizeY'][0])
+        axes.append(
+            {
+                "name": "y",
+                "offset": data["CalibrationOffsetY"][0]
+                - data["CalibrationElementY"][0] * data["CalibrationDeltaY"][0],
+                "scale": data["CalibrationDeltaY"][0],
+                "units": units,
+                "size": data["ArraySizeY"][0],
+            }
+        )
+        array_shape.append(data["ArraySizeY"][0])
         # X axis
-        axes.append({
-            'name': 'x',
-            'offset': data['CalibrationOffsetX'][0] -
-            data['CalibrationElementX'][0] * data['CalibrationDeltaX'][0],
-            'scale': data['CalibrationDeltaX'][0],
-            'size': data['ArraySizeX'][0],
-            'units': units,
-        })
-        array_shape.append(data['ArraySizeX'][0])
+        axes.append(
+            {
+                "name": "x",
+                "offset": data["CalibrationOffsetX"][0]
+                - data["CalibrationElementX"][0] * data["CalibrationDeltaX"][0],
+                "scale": data["CalibrationDeltaX"][0],
+                "size": data["ArraySizeX"][0],
+                "units": units,
+            }
+        )
+        array_shape.append(data["ArraySizeX"][0])
 
     # FEI seems to use the international system of units (SI) for the
     # spatial scale. However, we prefer to work in nm
     for axis in axes:
-        if axis['units'] == 'meters':
-            axis['units'] = 'nm'
-            axis['scale'] *= 10 ** 9
-        elif axis['units'] == '1/meters':
-            axis['units'] = '1 / nm'
-            axis['scale'] /= 10 ** 9
+        if axis["units"] == "meters":
+            axis["units"] = "nm"
+            axis["scale"] *= 10**9
+        elif axis["units"] == "1/meters":
+            axis["units"] = "1 / nm"
+            axis["scale"] /= 10**9
 
     # Remove Nones from array_shape caused by squeezing size 1 dimensions
     array_shape = [dim for dim in array_shape if dim is not None]
     if lazy:
         from dask import delayed
         from dask.array import from_delayed
-        val = delayed(load_only_data, pure=True)(filename, array_shape,
-                                                 record_by, len(axes),
-                                                 only_valid_data=only_valid_data)
-        dc = from_delayed(val, shape=array_shape,
-                          dtype=data['Array'].dtype)
+
+        val = delayed(load_only_data, pure=True)(
+            filename, array_shape, record_by, len(axes), only_valid_data=only_valid_data
+        )
+        dc = from_delayed(val, shape=array_shape, dtype=data["Array"].dtype)
     else:
-        dc = load_only_data(filename, array_shape, record_by, len(axes),
-                            data=data, header=header,
-                            only_valid_data=only_valid_data)
+        dc = load_only_data(
+            filename,
+            array_shape,
+            record_by,
+            len(axes),
+            data=data,
+            header=header,
+            only_valid_data=only_valid_data,
+        )
 
     original_metadata = OrderedDict()
     header_parameters = sarray2dict(header)
     sarray2dict(data, header_parameters)
     # We remove the Array key to save memory avoiding duplication
-    del header_parameters['Array']
-    original_metadata['ser_header_parameters'] = header_parameters
-    metadata = {'General': {
-        'original_filename': os.path.split(filename)[1],
-    },
+    del header_parameters["Array"]
+    original_metadata["ser_header_parameters"] = header_parameters
+    metadata = {
+        "General": {
+            "original_filename": os.path.split(filename)[1],
+        },
         "Signal": {
-        'signal_type': "",
-        'record_by': record_by,
-    },
+            "signal_type": "",
+            "record_by": record_by,
+        },
     }
     if date is not None and time is not None:
-        metadata['General']['date'] = date
-        metadata['General']['time'] = time
+        metadata["General"]["date"] = date
+        metadata["General"]["time"] = time
     dictionary = {
-        'data': dc,
-        'metadata': metadata,
-        'axes': axes,
-        'original_metadata': original_metadata,
-        'mapping': mapping}
+        "data": dc,
+        "metadata": metadata,
+        "axes": axes,
+        "original_metadata": original_metadata,
+        "mapping": mapping,
+    }
     return dictionary
 
 
-def load_only_data(filename, array_shape, record_by, num_axes, data=None,
-                   header=None, only_valid_data=False):
+def load_only_data(
+    filename,
+    array_shape,
+    record_by,
+    num_axes,
+    data=None,
+    header=None,
+    only_valid_data=False,
+):
     if data is None:
         header, data = load_ser_file(filename)
     # If the acquisition stops before finishing the job, the stored file will
@@ -637,25 +686,24 @@ def load_only_data(filename, array_shape, record_by, num_axes, data=None,
     # if the shapes of the retrieved array does not match that of the data
     # dimensions we must fill the rest with zeros or (better) nans if the
     # dtype is float
-    if np.prod(array_shape) != np.prod(data['Array'].shape):
-        if int(header['NumberDimensions']) == 1 and only_valid_data:
+    if np.prod(array_shape) != np.prod(data["Array"].shape):
+        if int(header["NumberDimensions"]) == 1 and only_valid_data:
             # No need to fill with zeros if `TotalNumberElements !=
             # ValidNumberElements` for series data.
             # The valid data is always `0:ValidNumberElements`
-            dc = data['Array'][0:header['ValidNumberElements'][0], ...]
-            array_shape[0] = header['ValidNumberElements'][0]
+            dc = data["Array"][0 : header["ValidNumberElements"][0], ...]
+            array_shape[0] = header["ValidNumberElements"][0]
         else:
             # Maps will need to be filled with zeros or nans
-            dc = np.zeros(np.prod(array_shape),
-                          dtype=data['Array'].dtype)
-            if dc.dtype is np.dtype('f') or dc.dtype is np.dtype('f8'):
+            dc = np.zeros(np.prod(array_shape), dtype=data["Array"].dtype)
+            if dc.dtype is np.dtype("f") or dc.dtype is np.dtype("f8"):
                 dc[:] = np.nan
-            dc[:data['Array'].ravel().shape[0]] = data['Array'].ravel()
+            dc[: data["Array"].ravel().shape[0]] = data["Array"].ravel()
     else:
-        dc = data['Array']
+        dc = data["Array"]
 
     dc = dc.reshape(array_shape)
-    if record_by == 'image':
+    if record_by == "image":
         dc = dc[..., ::-1, :]
     if num_axes != len(dc.shape):
         dc = dc.squeeze()
@@ -668,43 +716,43 @@ def _guess_units_from_mode(objects_dict, header):
     # in case the xml file doesn't contain the "Mode" or the header doesn't
     # contain 'Dim-1_UnitsLength', return "meters" as default, which will be
     # OK most of the time
-    warn_str = "The navigation axes units could not be determined. " \
-               "Setting them to `nm`, but this may be wrong."
+    warn_str = (
+        "The navigation axes units could not be determined. "
+        "Setting them to `nm`, but this may be wrong."
+    )
     try:
         mode = objects_dict.ObjectInfo.ExperimentalDescription.Mode
-        isCamera = (
-            "CameraNamePath" in objects_dict.ObjectInfo.AcquireInfo.keys())
+        isCamera = "CameraNamePath" in objects_dict.ObjectInfo.AcquireInfo.keys()
     except AttributeError:  # in case the xml chunk doesn't contain the Mode
         warnings.warn(warn_str)
-        return 'meters'  # Most of the time, the unit will be meters!
-    if 'Dim-1_UnitsLength' in header.dtype.fields:
+        return "meters"  # Most of the time, the unit will be meters!
+    if "Dim-1_UnitsLength" in header.dtype.fields:
         # assuming that for an image stack, the UnitsLength of the "3rd"
         # dimension is 0
-        isImageStack = (header['Dim-1_UnitsLength'][0] == 0)
+        isImageStack = header["Dim-1_UnitsLength"][0] == 0
         # Workaround: if this is not an image stack and not a STEM image, then
         # we assume that it should be a diffraction
-        isDiffractionScan = (header['Dim-1_DimensionSize'][0] > 1 and not
-                             isImageStack)
+        isDiffractionScan = header["Dim-1_DimensionSize"][0] > 1 and not isImageStack
     else:
         warnings.warn(warn_str)
-        return 'meters'  # Most of the time, the unit will be meters!
+        return "meters"  # Most of the time, the unit will be meters!
 
     _logger.info(objects_dict.ObjectInfo.AcquireInfo)
     _logger.info("mode: %s", mode)
     _logger.info("isCamera: %s", isCamera)
     _logger.info("isImageStack: %s", isImageStack)
     _logger.info("isImageStack: %s", isDiffractionScan)
-    if 'STEM' in mode:
+    if "STEM" in mode:
         # data recorded in STEM with a camera, so we assume, it's a diffraction
         # in case we can't make use the detector is a camera, use a workaround
         if isCamera or isDiffractionScan:
             return "1/meters"
         else:
             return "meters"
-    elif 'Diffraction' in mode:
+    elif "Diffraction" in mode:
         return "1/meters"
     else:
-        return 'meters'
+        return "meters"
 
 
 def _get_simplified_mode(mode):
@@ -720,47 +768,57 @@ def _get_date_time(value):
 
 
 def _get_microscope_name(value):
-    return value.replace('Microscope ', '')
+    return value.replace("Microscope ", "")
 
 
 mapping = {
     "ObjectInfo.ExperimentalDescription.High_tension_kV": (
         "Acquisition_instrument.TEM.beam_energy",
-        None),
+        None,
+    ),
     "ObjectInfo.ExperimentalDescription.Microscope": (
         "Acquisition_instrument.TEM.microscope",
-        _get_microscope_name),
+        _get_microscope_name,
+    ),
     "ObjectInfo.ExperimentalDescription.Mode": (
         "Acquisition_instrument.TEM.acquisition_mode",
-        _get_simplified_mode),
+        _get_simplified_mode,
+    ),
     "ObjectInfo.ExperimentalDescription.Camera length_m": (
         "Acquisition_instrument.TEM.camera_length",
-        lambda x: x * 1e3),
+        lambda x: x * 1e3,
+    ),
     "ObjectInfo.ExperimentalDescription.Magnification_x": (
         "Acquisition_instrument.TEM.magnification",
-        None),
+        None,
+    ),
     "ObjectInfo.AcquireInfo.CameraNamePath": (
         "Acquisition_instrument.TEM.Detector.Camera.Name",
-        None),
+        None,
+    ),
     "ObjectInfo.AcquireInfo.DwellTimePath": (
         "Acquisition_instrument.TEM.Detector.Camera.exposure",
-        None),
+        None,
+    ),
     "ObjectInfo.ExperimentalDescription.Stage_A_deg": (
         "Acquisition_instrument.TEM.Stage.tilt_alpha",
-        None),
+        None,
+    ),
     "ObjectInfo.ExperimentalDescription.Stage_B_deg": (
         "Acquisition_instrument.TEM.Stage.tilt_beta",
-        None),
+        None,
+    ),
     "ObjectInfo.ExperimentalDescription.Stage_X_um": (
         "Acquisition_instrument.TEM.Stage.x",
-        lambda x: x * 1e-3),
+        lambda x: x * 1e-3,
+    ),
     "ObjectInfo.ExperimentalDescription.Stage_Y_um": (
         "Acquisition_instrument.TEM.Stage.y",
-        lambda x: x * 1e-3),
+        lambda x: x * 1e-3,
+    ),
     "ObjectInfo.ExperimentalDescription.Stage_Z_um": (
         "Acquisition_instrument.TEM.Stage.z",
-        lambda x: x * 1e-3),
-    "ObjectInfo.ExperimentalDescription.User": (
-        "General.authors",
-        None),
+        lambda x: x * 1e-3,
+    ),
+    "ObjectInfo.ExperimentalDescription.User": ("General.authors", None),
 }

--- a/rsciio/impulse/api.py
+++ b/rsciio/impulse/api.py
@@ -5,7 +5,6 @@ import csv
 import logging
 
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -26,11 +25,13 @@ def file_reader(filename, *args, **kwds):
     csv_file = ImpulseCSV(filename)
     return _impulseCSV_log_reader(csv_file)
 
+
 def _impulseCSV_log_reader(csv_file):
     csvs = []
     for key in csv_file.logged_quantity_name_list:
         csvs.append(csv_file.get_dictionary(key))
     return csvs
+
 
 class ImpulseCSV:
     def __init__(self, filename):
@@ -73,8 +74,12 @@ class ImpulseCSV:
 
     def _parse_quantity_units(self, quantity):
         quantity_split = quantity.strip().split(" ")
-        if len(quantity_split) > 1 and quantity_split[-1][0] == "(" and quantity_split[-1][-1] == ")":
-            return quantity_split[-1].replace("(","").replace(")","")
+        if (
+            len(quantity_split) > 1
+            and quantity_split[-1][0] == "("
+            and quantity_split[-1][-1] == ")"
+        ):
+            return quantity_split[-1].replace("(", "").replace(")", "")
         else:
             return ""
 
@@ -142,7 +147,7 @@ class ImpulseCSV:
                     self.original_metadata["Notes"] = notes
 
             else:
-                _logger.warning('No metadata file found in folder')
+                _logger.warning("No metadata file found in folder")
         else:
             raise IOError(invalid_filenaming_error)
 

--- a/rsciio/mrc/api.py
+++ b/rsciio/mrc/api.py
@@ -31,193 +31,217 @@ from rsciio.utils.tools import sarray2dict
 _logger = logging.getLogger(__name__)
 
 
-def get_std_dtype_list(endianess='<'):
+def get_std_dtype_list(endianess="<"):
     end = endianess
-    dtype_list = \
-        [
-            ('NX', end + 'u4'),
-            ('NY', end + 'u4'),
-            ('NZ', end + 'u4'),
-            ('MODE', end + 'u4'),
-            ('NXSTART', end + 'u4'),
-            ('NYSTART', end + 'u4'),
-            ('NZSTART', end + 'u4'),
-            ('MX', end + 'u4'),
-            ('MY', end + 'u4'),
-            ('MZ', end + 'u4'),
-            ('Xlen', end + 'f4'),
-            ('Ylen', end + 'f4'),
-            ('Zlen', end + 'f4'),
-            ('ALPHA', end + 'f4'),
-            ('BETA', end + 'f4'),
-            ('GAMMA', end + 'f4'),
-            ('MAPC', end + 'u4'),
-            ('MAPR', end + 'u4'),
-            ('MAPS', end + 'u4'),
-            ('AMIN', end + 'f4'),
-            ('AMAX', end + 'f4'),
-            ('AMEAN', end + 'f4'),
-            ('ISPG', end + 'u2'),
-            ('NSYMBT', end + 'u2'),
-            ('NEXT', end + 'u4'),
-            ('CREATID', end + 'u2'),
-            ('EXTRA', (np.void, 30)),
-            ('NINT', end + 'u2'),
-            ('NREAL', end + 'u2'),
-            ('EXTRA2', (np.void, 28)),
-            ('IDTYPE', end + 'u2'),
-            ('LENS', end + 'u2'),
-            ('ND1', end + 'u2'),
-            ('ND2', end + 'u2'),
-            ('VD1', end + 'u2'),
-            ('VD2', end + 'u2'),
-            ('TILTANGLES', (np.float32, 6)),
-            ('XORIGIN', end + 'f4'),
-            ('YORIGIN', end + 'f4'),
-            ('ZORIGIN', end + 'f4'),
-            ('CMAP', (bytes, 4)),
-            ('STAMP', (bytes, 4)),
-            ('RMS', end + 'f4'),
-            ('NLABL', end + 'u4'),
-            ('LABELS', (bytes, 800)),
-        ]
+    dtype_list = [
+        ("NX", end + "u4"),
+        ("NY", end + "u4"),
+        ("NZ", end + "u4"),
+        ("MODE", end + "u4"),
+        ("NXSTART", end + "u4"),
+        ("NYSTART", end + "u4"),
+        ("NZSTART", end + "u4"),
+        ("MX", end + "u4"),
+        ("MY", end + "u4"),
+        ("MZ", end + "u4"),
+        ("Xlen", end + "f4"),
+        ("Ylen", end + "f4"),
+        ("Zlen", end + "f4"),
+        ("ALPHA", end + "f4"),
+        ("BETA", end + "f4"),
+        ("GAMMA", end + "f4"),
+        ("MAPC", end + "u4"),
+        ("MAPR", end + "u4"),
+        ("MAPS", end + "u4"),
+        ("AMIN", end + "f4"),
+        ("AMAX", end + "f4"),
+        ("AMEAN", end + "f4"),
+        ("ISPG", end + "u2"),
+        ("NSYMBT", end + "u2"),
+        ("NEXT", end + "u4"),
+        ("CREATID", end + "u2"),
+        ("EXTRA", (np.void, 30)),
+        ("NINT", end + "u2"),
+        ("NREAL", end + "u2"),
+        ("EXTRA2", (np.void, 28)),
+        ("IDTYPE", end + "u2"),
+        ("LENS", end + "u2"),
+        ("ND1", end + "u2"),
+        ("ND2", end + "u2"),
+        ("VD1", end + "u2"),
+        ("VD2", end + "u2"),
+        ("TILTANGLES", (np.float32, 6)),
+        ("XORIGIN", end + "f4"),
+        ("YORIGIN", end + "f4"),
+        ("ZORIGIN", end + "f4"),
+        ("CMAP", (bytes, 4)),
+        ("STAMP", (bytes, 4)),
+        ("RMS", end + "f4"),
+        ("NLABL", end + "u4"),
+        ("LABELS", (bytes, 800)),
+    ]
 
     return dtype_list
 
 
-def get_fei_dtype_list(endianess='<'):
+def get_fei_dtype_list(endianess="<"):
     end = endianess
     dtype_list = [
-        ('a_tilt', end + 'f4'),  # Alpha tilt (deg)
-        ('b_tilt', end + 'f4'),  # Beta tilt (deg)
+        ("a_tilt", end + "f4"),  # Alpha tilt (deg)
+        ("b_tilt", end + "f4"),  # Beta tilt (deg)
         # Stage x position (Unit=m. But if value>1, unit=???m)
-        ('x_stage', end + 'f4'),
+        ("x_stage", end + "f4"),
         # Stage y position (Unit=m. But if value>1, unit=???m)
-        ('y_stage', end + 'f4'),
+        ("y_stage", end + "f4"),
         # Stage z position (Unit=m. But if value>1, unit=???m)
-        ('z_stage', end + 'f4'),
+        ("z_stage", end + "f4"),
         # Signal2D shift x (Unit=m. But if value>1, unit=???m)
-        ('x_shift', end + 'f4'),
+        ("x_shift", end + "f4"),
         # Signal2D shift y (Unit=m. But if value>1, unit=???m)
-        ('y_shift', end + 'f4'),
-        ('defocus', end + 'f4'),  # Defocus Unit=m. But if value>1, unit=???m)
-        ('exp_time', end + 'f4'),  # Exposure time (s)
-        ('mean_int', end + 'f4'),  # Mean value of image
-        ('tilt_axis', end + 'f4'),  # Tilt axis (deg)
-        ('pixel_size', end + 'f4'),  # Pixel size of image (m)
-        ('magnification', end + 'f4'),  # Magnification used
+        ("y_shift", end + "f4"),
+        ("defocus", end + "f4"),  # Defocus Unit=m. But if value>1, unit=???m)
+        ("exp_time", end + "f4"),  # Exposure time (s)
+        ("mean_int", end + "f4"),  # Mean value of image
+        ("tilt_axis", end + "f4"),  # Tilt axis (deg)
+        ("pixel_size", end + "f4"),  # Pixel size of image (m)
+        ("magnification", end + "f4"),  # Magnification used
         # Not used (filling up to 128 bytes)
-        ('empty', (np.void, 128 - 13 * 4)),
+        ("empty", (np.void, 128 - 13 * 4)),
     ]
     return dtype_list
 
 
-def get_data_type(index, endianess='<'):
+def get_data_type(index, endianess="<"):
     end = endianess
     data_type = [
-        end + 'u2',         # 0 = Signal2D     unsigned bytes
-        end + 'i2',         # 1 = Signal2D     signed short integer (16 bits)
-        end + 'f4',         # 2 = Signal2D     float
-        (end + 'i2', 2),    # 3 = Complex   short*2
-        end + 'c8',         # 4 = Complex   float*2
+        end + "u2",  # 0 = Signal2D     unsigned bytes
+        end + "i2",  # 1 = Signal2D     signed short integer (16 bits)
+        end + "f4",  # 2 = Signal2D     float
+        (end + "i2", 2),  # 3 = Complex   short*2
+        end + "c8",  # 4 = Complex   float*2
     ]
     return data_type[index]
 
 
-def file_reader(filename, endianess='<', **kwds):
+def file_reader(filename, endianess="<", **kwds):
     metadata = {}
-    f = open(filename, 'rb')
-    std_header = np.fromfile(f, dtype=get_std_dtype_list(endianess),
-                             count=1)
+    f = open(filename, "rb")
+    std_header = np.fromfile(f, dtype=get_std_dtype_list(endianess), count=1)
     fei_header = None
-    if std_header['NEXT'] / 1024 == 128:
+    if std_header["NEXT"] / 1024 == 128:
         _logger.info("%s seems to contain an extended FEI header", filename)
-        fei_header = np.fromfile(f, dtype=get_fei_dtype_list(endianess),
-                                 count=1024)
-    if f.tell() == 1024 + std_header['NEXT']:
+        fei_header = np.fromfile(f, dtype=get_fei_dtype_list(endianess), count=1024)
+    if f.tell() == 1024 + std_header["NEXT"]:
         _logger.debug("The FEI header was correctly loaded")
     else:
         _logger.warning("There was a problem reading the extended header")
-        f.seek(1024 + std_header['NEXT'])
+        f.seek(1024 + std_header["NEXT"])
         fei_header = None
-    NX, NY, NZ = std_header['NX'], std_header['NY'], std_header['NZ']
-    mmap_mode = kwds.pop('mmap_mode', 'c')
-    lazy = kwds.pop('lazy', False)
+    NX, NY, NZ = std_header["NX"], std_header["NY"], std_header["NZ"]
+    mmap_mode = kwds.pop("mmap_mode", "c")
+    lazy = kwds.pop("lazy", False)
     if lazy:
-        mmap_mode = 'r'
-    data = np.memmap(f, mode=mmap_mode, offset=f.tell(),
-                     dtype=get_data_type(std_header['MODE'][0], endianess)
-                     ).squeeze().reshape((NX[0], NY[0], NZ[0]), order='F').T
+        mmap_mode = "r"
+    data = (
+        np.memmap(
+            f,
+            mode=mmap_mode,
+            offset=f.tell(),
+            dtype=get_data_type(std_header["MODE"][0], endianess),
+        )
+        .squeeze()
+        .reshape((NX[0], NY[0], NZ[0]), order="F")
+        .T
+    )
 
-    original_metadata = {'std_header': sarray2dict(std_header)}
+    original_metadata = {"std_header": sarray2dict(std_header)}
     # Convert bytes to unicode
     for key in ["CMAP", "STAMP", "LABELS"]:
-        original_metadata["std_header"][key] = \
-            original_metadata["std_header"][key].decode()
+        original_metadata["std_header"][key] = original_metadata["std_header"][
+            key
+        ].decode()
     if fei_header is not None:
-        fei_dict = sarray2dict(fei_header,)
-        del fei_dict['empty']
-        original_metadata['fei_header'] = fei_dict
+        fei_dict = sarray2dict(
+            fei_header,
+        )
+        del fei_dict["empty"]
+        original_metadata["fei_header"] = fei_dict
 
     dim = len(data.shape)
     if fei_header is None:
         # The scale is in Amstrongs, we convert it to nm
-        scales = [10 * float(std_header['Zlen'] / std_header['MZ'])
-                  if float(std_header['MZ']) != 0 else 1,
-                  10 * float(std_header['Ylen'] / std_header['MY'])
-                  if float(std_header['MY']) != 0 else 1,
-                  10 * float(std_header['Xlen'] / std_header['MX'])
-                  if float(std_header['MX']) != 0 else 1, ]
-        offsets = [10 * float(std_header['ZORIGIN']),
-                   10 * float(std_header['YORIGIN']),
-                   10 * float(std_header['XORIGIN']), ]
+        scales = [
+            10 * float(std_header["Zlen"] / std_header["MZ"])
+            if float(std_header["MZ"]) != 0
+            else 1,
+            10 * float(std_header["Ylen"] / std_header["MY"])
+            if float(std_header["MY"]) != 0
+            else 1,
+            10 * float(std_header["Xlen"] / std_header["MX"])
+            if float(std_header["MX"]) != 0
+            else 1,
+        ]
+        offsets = [
+            10 * float(std_header["ZORIGIN"]),
+            10 * float(std_header["YORIGIN"]),
+            10 * float(std_header["XORIGIN"]),
+        ]
 
     else:
         # FEI does not use the standard header to store the scale
         # It does store the spatial scale in pixel_size, one per angle in
         # meters
-        scales = [1, ] + [fei_header['pixel_size'][0] * 10 ** 9, ] * 2
-        offsets = [0, ] * 3
+        scales = [1,] + [
+            fei_header["pixel_size"][0] * 10**9,
+        ] * 2
+        offsets = [
+            0,
+        ] * 3
 
-    units = [None, 'nm', 'nm']
-    names = ['z', 'y', 'x']
-    metadata = {'General': {'original_filename': os.path.split(filename)[1]},
-                "Signal": {'signal_type': "",
-                           'record_by': 'image', },
-                }
+    units = [None, "nm", "nm"]
+    names = ["z", "y", "x"]
+    metadata = {
+        "General": {"original_filename": os.path.split(filename)[1]},
+        "Signal": {
+            "signal_type": "",
+            "record_by": "image",
+        },
+    }
     # create the axis objects for each axis
     axes = [
         {
-            'size': data.shape[i],
-            'index_in_array': i,
-            'name': names[i + 3 - dim],
-            'scale': scales[i + 3 - dim],
-            'offset': offsets[i + 3 - dim],
-            'units': units[i + 3 - dim], }
-        for i in range(dim)]
+            "size": data.shape[i],
+            "index_in_array": i,
+            "name": names[i + 3 - dim],
+            "scale": scales[i + 3 - dim],
+            "offset": offsets[i + 3 - dim],
+            "units": units[i + 3 - dim],
+        }
+        for i in range(dim)
+    ]
 
-    dictionary = {'data': data,
-                  'axes': axes,
-                  'metadata': metadata,
-                  'original_metadata': original_metadata,
-                  'mapping': mapping}
+    dictionary = {
+        "data": data,
+        "axes": axes,
+        "metadata": metadata,
+        "original_metadata": original_metadata,
+        "mapping": mapping,
+    }
 
-    return [dictionary, ]
+    return [
+        dictionary,
+    ]
 
 
 mapping = {
-    'fei_header.a_tilt':
-    ("Acquisition_instrument.TEM.Stage.tilt_alpha", None),
-    'fei_header.b_tilt':
-    ("Acquisition_instrument.TEM.Stage.tilt_beta", None),
-    'fei_header.x_stage':
-    ("Acquisition_instrument.TEM.Stage.x", None),
-    'fei_header.y_stage':
-    ("Acquisition_instrument.TEM.Stage.y", None),
-    'fei_header.z_stage':
-    ("Acquisition_instrument.TEM.Stage.z", None),
-    'fei_header.exp_time':
-    ("Acquisition_instrument.TEM.Detector.Camera.exposure", None),
-    'fei_header.magnification':
-    ("Acquisition_instrument.TEM.magnification", None),
+    "fei_header.a_tilt": ("Acquisition_instrument.TEM.Stage.tilt_alpha", None),
+    "fei_header.b_tilt": ("Acquisition_instrument.TEM.Stage.tilt_beta", None),
+    "fei_header.x_stage": ("Acquisition_instrument.TEM.Stage.x", None),
+    "fei_header.y_stage": ("Acquisition_instrument.TEM.Stage.y", None),
+    "fei_header.z_stage": ("Acquisition_instrument.TEM.Stage.z", None),
+    "fei_header.exp_time": (
+        "Acquisition_instrument.TEM.Detector.Camera.exposure",
+        None,
+    ),
+    "fei_header.magnification": ("Acquisition_instrument.TEM.magnification", None),
 }

--- a/rsciio/mrcz/api.py
+++ b/rsciio/mrcz/api.py
@@ -25,9 +25,23 @@ from rsciio.utils.tools import DTBox
 _logger = logging.getLogger(__name__)
 
 
-_POP_FROM_HEADER = ['compressor', 'MRCtype', 'C3', 'dimensions', 'dtype',
-                    'extendedBytes', 'gain', 'maxImage', 'minImage', 'meanImage',
-                    'metaId', 'packedBytes', 'pixelsize', 'pixelunits', 'voltage']
+_POP_FROM_HEADER = [
+    "compressor",
+    "MRCtype",
+    "C3",
+    "dimensions",
+    "dtype",
+    "extendedBytes",
+    "gain",
+    "maxImage",
+    "minImage",
+    "meanImage",
+    "metaId",
+    "packedBytes",
+    "pixelsize",
+    "pixelunits",
+    "voltage",
+]
 # Hyperspy uses an unusual mixed Fortran- and C-ordering scheme
 _READ_ORDER = [1, 2, 0]
 _WRITE_ORDER = [0, 1, 2]
@@ -42,44 +56,45 @@ def _parse_metadata(metadata):
 
 
 mapping = {
-    'mrcz_header.voltage':
-        ("Acquisition_instrument.TEM.beam_energy",
-         _parse_metadata),
-    'mrcz_header.gain':
-        ("Signal.Noise_properties.Variance_linear_model.gain_factor",
-         _parse_metadata),
+    "mrcz_header.voltage": ("Acquisition_instrument.TEM.beam_energy", _parse_metadata),
+    "mrcz_header.gain": (
+        "Signal.Noise_properties.Variance_linear_model.gain_factor",
+        _parse_metadata,
+    ),
     # There is no metadata field for spherical aberration
     #'mrcz_header.C3':
-    #("Acquisition_instrument.TEM.C3", lambda x: x),
+    # ("Acquisition_instrument.TEM.C3", lambda x: x),
 }
 
 
-def file_reader(filename, endianess='<', lazy=False, mmap_mode='c',
-                **kwds):
+def file_reader(filename, endianess="<", lazy=False, mmap_mode="c", **kwds):
     _logger.debug("Reading MRCZ file: %s" % filename)
 
-    if mmap_mode != 'c':
+    if mmap_mode != "c":
         # Note also that MRCZ does not support memory-mapping of compressed data.
         # Perhaps we could use the zarr package for that
-        raise ValueError('MRCZ supports only C-ordering memory-maps')
+        raise ValueError("MRCZ supports only C-ordering memory-maps")
 
-    mrcz_endian = 'le' if endianess == '<' else 'be'
-    data, mrcz_header = _mrcz.readMRC(filename, endian=mrcz_endian,
-                                      useMemmap=lazy,
-                                      pixelunits='nm',
-                                      **kwds)
+    mrcz_endian = "le" if endianess == "<" else "be"
+    data, mrcz_header = _mrcz.readMRC(
+        filename, endian=mrcz_endian, useMemmap=lazy, pixelunits="nm", **kwds
+    )
 
     # Create the axis objects for each axis
-    names = ['y', 'x', 'z']
+    names = ["y", "x", "z"]
     navigate = [False, False, True]
-    axes = [{'size': data.shape[hsIndex],
-             'index_in_array': hsIndex,
-             'name': names[index],
-             'scale': mrcz_header['pixelsize'][hsIndex],
-             'offset': 0.0,
-             'units': mrcz_header['pixelunits'],
-             'navigate': nav}
-            for index, (hsIndex, nav) in enumerate(zip(_READ_ORDER, navigate))]
+    axes = [
+        {
+            "size": data.shape[hsIndex],
+            "index_in_array": hsIndex,
+            "name": names[index],
+            "scale": mrcz_header["pixelsize"][hsIndex],
+            "offset": 0.0,
+            "units": mrcz_header["pixelunits"],
+            "navigate": nav,
+        }
+        for index, (hsIndex, nav) in enumerate(zip(_READ_ORDER, navigate))
+    ]
     axes.insert(0, axes.pop(2))  # re-order the axes
 
     metadata = mrcz_header.copy()
@@ -87,40 +102,63 @@ def file_reader(filename, endianess='<', lazy=False, mmap_mode='c',
     for popTarget in _POP_FROM_HEADER:
         metadata.pop(popTarget)
 
-    dictionary = {'data': data,
-                  'axes': axes,
-                  'metadata': metadata,
-                  'original_metadata': {'mrcz_header': mrcz_header},
-                  'mapping': mapping, }
+    dictionary = {
+        "data": data,
+        "axes": axes,
+        "metadata": metadata,
+        "original_metadata": {"mrcz_header": mrcz_header},
+        "mapping": mapping,
+    }
 
-    return [dictionary, ]
+    return [
+        dictionary,
+    ]
 
 
-def file_writer(filename, signal, do_async=False, compressor=None, clevel=1,
-                n_threads=None, **kwds):
-    endianess = kwds.pop('endianess', '<')
-    mrcz_endian = 'le' if endianess == '<' else 'be'
+def file_writer(
+    filename, signal, do_async=False, compressor=None, clevel=1, n_threads=None, **kwds
+):
+    endianess = kwds.pop("endianess", "<")
+    mrcz_endian = "le" if endianess == "<" else "be"
 
     md = DTBox(signal["metadata"], box_dots=True)
 
     # Get pixelsize and pixelunits from the axes
-    pixelunits = signal['axes'][-1]['units']
-    pixelsize = [signal['axes'][I]['scale'] for I in _WRITE_ORDER]
+    pixelunits = signal["axes"][-1]["units"]
+    pixelsize = [signal["axes"][I]["scale"] for I in _WRITE_ORDER]
 
     # Strip out voltage from meta-data
-    voltage = md.get('Acquisition_instrument.TEM.beam_energy')
+    voltage = md.get("Acquisition_instrument.TEM.beam_energy")
     # There aren't hyperspy fields for spherical aberration or detector gain
     C3 = 0.0
     gain = md.get("Signal.Noise_properties.Variance_linear_model.gain_factor", 1.0)
     if do_async:
-        _mrcz.asyncWriteMRC(signal['data'], filename, meta=md, endian=mrcz_endian,
-                            pixelsize=pixelsize, pixelunits=pixelunits,
-                            voltage=voltage, C3=C3, gain=gain,
-                            compressor=compressor, clevel=clevel,
-                            n_threads=n_threads)
+        _mrcz.asyncWriteMRC(
+            signal["data"],
+            filename,
+            meta=md,
+            endian=mrcz_endian,
+            pixelsize=pixelsize,
+            pixelunits=pixelunits,
+            voltage=voltage,
+            C3=C3,
+            gain=gain,
+            compressor=compressor,
+            clevel=clevel,
+            n_threads=n_threads,
+        )
     else:
-        _mrcz.writeMRC(signal['data'], filename, meta=md, endian=mrcz_endian,
-                       pixelsize=pixelsize, pixelunits=pixelunits,
-                       voltage=voltage, C3=C3, gain=gain,
-                       compressor=compressor, clevel=clevel,
-                       n_threads=n_threads)
+        _mrcz.writeMRC(
+            signal["data"],
+            filename,
+            meta=md,
+            endian=mrcz_endian,
+            pixelsize=pixelsize,
+            pixelunits=pixelunits,
+            voltage=voltage,
+            C3=C3,
+            gain=gain,
+            compressor=compressor,
+            clevel=clevel,
+            n_threads=n_threads,
+        )

--- a/rsciio/msa/api.py
+++ b/rsciio/msa/api.py
@@ -36,8 +36,8 @@ _logger = logging.getLogger(__name__)
 # https://www.amc.anl.gov/ANLSoftwareLibrary/02-MMSLib/XEDS/EMMFF/EMMFF.IBM/Emmff.Total
 
 US_MONTHS_D2A = {
-    "01" : "JAN",
-    "02" : "FEB",
+    "01": "JAN",
+    "02": "FEB",
     "03": "MAR",
     "04": "APR",
     "05": "MAY",
@@ -47,91 +47,112 @@ US_MONTHS_D2A = {
     "09": "SEP",
     "10": "OCT",
     "11": "NOV",
-    "12": "DEC", }
+    "12": "DEC",
+}
 
 US_MONTH_A2D = dict([reversed(i) for i in US_MONTHS_D2A.items()])
 
 keywords = {
     # Required parameters
-    'FORMAT': {'dtype': str, 'mapped_to': None},
-    'VERSION': {'dtype': str, 'mapped_to': None},
-    'TITLE': {'dtype': str, 'mapped_to': 'General.title'},
-    'DATE': {'dtype': str, 'mapped_to': None},
-    'TIME': {'dtype': str, 'mapped_to': None},
-    'OWNER': {'dtype': str, 'mapped_to': None},
-    'NPOINTS': {'dtype': float, 'mapped_to': None},
-    'NCOLUMNS': {'dtype': float, 'mapped_to': None},
-    'DATATYPE': {'dtype': str, 'mapped_to': None},
-    'XPERCHAN': {'dtype': float, 'mapped_to': None},
-    'OFFSET': {'dtype': float, 'mapped_to': None},
+    "FORMAT": {"dtype": str, "mapped_to": None},
+    "VERSION": {"dtype": str, "mapped_to": None},
+    "TITLE": {"dtype": str, "mapped_to": "General.title"},
+    "DATE": {"dtype": str, "mapped_to": None},
+    "TIME": {"dtype": str, "mapped_to": None},
+    "OWNER": {"dtype": str, "mapped_to": None},
+    "NPOINTS": {"dtype": float, "mapped_to": None},
+    "NCOLUMNS": {"dtype": float, "mapped_to": None},
+    "DATATYPE": {"dtype": str, "mapped_to": None},
+    "XPERCHAN": {"dtype": float, "mapped_to": None},
+    "OFFSET": {"dtype": float, "mapped_to": None},
     # Optional parameters
     # Signal1D characteristics
-    'SIGNALTYPE': {'dtype': str, 'mapped_to':
-                   'Signal.signal_type'},
-    'XLABEL': {'dtype': str, 'mapped_to': None},
-    'YLABEL': {'dtype': str, 'mapped_to': None},
-    'XUNITS': {'dtype': str, 'mapped_to': None},
-    'YUNITS': {'dtype': str, 'mapped_to': None},
-    'CHOFFSET': {'dtype': float, 'mapped_to': None},
-    'COMMENT': {'dtype': str, 'mapped_to': None},
+    "SIGNALTYPE": {"dtype": str, "mapped_to": "Signal.signal_type"},
+    "XLABEL": {"dtype": str, "mapped_to": None},
+    "YLABEL": {"dtype": str, "mapped_to": None},
+    "XUNITS": {"dtype": str, "mapped_to": None},
+    "YUNITS": {"dtype": str, "mapped_to": None},
+    "CHOFFSET": {"dtype": float, "mapped_to": None},
+    "COMMENT": {"dtype": str, "mapped_to": None},
     # Microscope
-    'BEAMKV': {'dtype': float, 'mapped_to':
-               'Acquisition_instrument.TEM.beam_energy'},
-    'EMISSION': {'dtype': float, 'mapped_to': None},
-    'PROBECUR': {'dtype': float, 'mapped_to':
-                 'Acquisition_instrument.TEM.beam_current'},
-    'BEAMDIAM': {'dtype': float, 'mapped_to': None},
-    'MAGCAM': {'dtype': float, 'mapped_to': None},
-    'OPERMODE': {'dtype': str, 'mapped_to': None},
-    'CONVANGLE': {'dtype': float, 'mapped_to':
-                  'Acquisition_instrument.TEM.convergence_angle'},
-
+    "BEAMKV": {"dtype": float, "mapped_to": "Acquisition_instrument.TEM.beam_energy"},
+    "EMISSION": {"dtype": float, "mapped_to": None},
+    "PROBECUR": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.beam_current",
+    },
+    "BEAMDIAM": {"dtype": float, "mapped_to": None},
+    "MAGCAM": {"dtype": float, "mapped_to": None},
+    "OPERMODE": {"dtype": str, "mapped_to": None},
+    "CONVANGLE": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.convergence_angle",
+    },
     # Specimen
-    'THICKNESS': {'dtype': float, 'mapped_to':
-                  'Sample.thickness'},
-    'XTILTSTGE': {'dtype': float, 'mapped_to':
-                  'Acquisition_instrument.TEM.Stage.tilt_alpha'},
-    'YTILTSTGE': {'dtype': float, 'mapped_to': None},
-    'XPOSITION': {'dtype': float, 'mapped_to': None},
-    'YPOSITION': {'dtype': float, 'mapped_to': None},
-    'ZPOSITION': {'dtype': float, 'mapped_to': None},
-
+    "THICKNESS": {"dtype": float, "mapped_to": "Sample.thickness"},
+    "XTILTSTGE": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Stage.tilt_alpha",
+    },
+    "YTILTSTGE": {"dtype": float, "mapped_to": None},
+    "XPOSITION": {"dtype": float, "mapped_to": None},
+    "YPOSITION": {"dtype": float, "mapped_to": None},
+    "ZPOSITION": {"dtype": float, "mapped_to": None},
     # EELS
     # in ms:
-    'INTEGTIME': {'dtype': float, 'mapped_to':
-                  'Acquisition_instrument.TEM.Detector.EELS.exposure'},
+    "INTEGTIME": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EELS.exposure",
+    },
     # in ms:
-    'DWELLTIME': {'dtype': float, 'mapped_to':
-                  'Acquisition_instrument.TEM.Detector.EELS.dwell_time'},
-    'COLLANGLE': {'dtype': float, 'mapped_to':
-                  'Acquisition_instrument.TEM.Detector.EELS.collection_angle'},
-    'ELSDET': {'dtype': str, 'mapped_to': None},
-
+    "DWELLTIME": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EELS.dwell_time",
+    },
+    "COLLANGLE": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EELS.collection_angle",
+    },
+    "ELSDET": {"dtype": str, "mapped_to": None},
     # EDS
-    'ELEVANGLE': {'dtype': float, 'mapped_to':
-                  'Acquisition_instrument.TEM.Detector.EDS.elevation_angle'},
-    'AZIMANGLE': {'dtype': float, 'mapped_to':
-                  'Acquisition_instrument.TEM.Detector.EDS.azimuth_angle'},
-    'SOLIDANGLE': {'dtype': float, 'mapped_to':
-                   'Acquisition_instrument.TEM.Detector.EDS.solid_angle'},
-    'LIVETIME': {'dtype': float, 'mapped_to':
-                 'Acquisition_instrument.TEM.Detector.EDS.live_time'},
-    'REALTIME': {'dtype': float, 'mapped_to':
-                 'Acquisition_instrument.TEM.Detector.EDS.real_time'},
-    'FWHMMNKA': {'dtype': float, 'mapped_to':
-                 'Acquisition_instrument.TEM.Detector.EDS.' +
-                 'energy_resolution_MnKa'},
-    'TBEWIND': {'dtype': float, 'mapped_to': None},
-    'TAUWIND': {'dtype': float, 'mapped_to': None},
-    'TDEADLYR': {'dtype': float, 'mapped_to': None},
-    'TACTLYR': {'dtype': float, 'mapped_to': None},
-    'TALWIND': {'dtype': float, 'mapped_to': None},
-    'TPYWIND': {'dtype': float, 'mapped_to': None},
-    'TBNWIND': {'dtype': float, 'mapped_to': None},
-    'TDIWIND': {'dtype': float, 'mapped_to': None},
-    'THCWIND': {'dtype': float, 'mapped_to': None},
-    'EDSDET': {'dtype': str, 'mapped_to':
-               'Acquisition_instrument.TEM.Detector.EDS.EDS_det'},
+    "ELEVANGLE": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EDS.elevation_angle",
+    },
+    "AZIMANGLE": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EDS.azimuth_angle",
+    },
+    "SOLIDANGLE": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EDS.solid_angle",
+    },
+    "LIVETIME": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EDS.live_time",
+    },
+    "REALTIME": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EDS.real_time",
+    },
+    "FWHMMNKA": {
+        "dtype": float,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EDS."
+        + "energy_resolution_MnKa",
+    },
+    "TBEWIND": {"dtype": float, "mapped_to": None},
+    "TAUWIND": {"dtype": float, "mapped_to": None},
+    "TDEADLYR": {"dtype": float, "mapped_to": None},
+    "TACTLYR": {"dtype": float, "mapped_to": None},
+    "TALWIND": {"dtype": float, "mapped_to": None},
+    "TPYWIND": {"dtype": float, "mapped_to": None},
+    "TBNWIND": {"dtype": float, "mapped_to": None},
+    "TDIWIND": {"dtype": float, "mapped_to": None},
+    "THCWIND": {"dtype": float, "mapped_to": None},
+    "EDSDET": {
+        "dtype": str,
+        "mapped_to": "Acquisition_instrument.TEM.Detector.EDS.EDS_det",
+    },
 }
 
 
@@ -164,30 +185,29 @@ def parse_msa_string(string, filename=None):
         if data_section is False:
             if line[0] == "#":
                 try:
-                    key, value = line.split(': ')
+                    key, value = line.split(": ")
                     value = value.strip()
                 except ValueError:
                     key = line
                     value = None
-                key = key.strip('#').strip()
+                key = key.strip("#").strip()
 
-                if key != 'SPECTRUM':
+                if key != "SPECTRUM":
                     parameters[key] = value
                 else:
                     data_section = True
         else:
             # Read the data
             if line[0] != "#" and line.strip():
-                if parameters['DATATYPE'] == 'XY':
-                    xy = line.replace(',', ' ').strip().split()
+                if parameters["DATATYPE"] == "XY":
+                    xy = line.replace(",", " ").strip().split()
                     y.append(float(xy[1]))
-                elif parameters['DATATYPE'] == 'Y':
-                    data = [
-                        float(i) for i in line.replace(',', ' ').strip().split()]
+                elif parameters["DATATYPE"] == "Y":
+                    data = [float(i) for i in line.replace(",", " ").strip().split()]
                     y.extend(data)
     # We rewrite the format value to be sure that it complies with the
     # standard, because it will be used by the writer routine
-    parameters['FORMAT'] = "EMSA/MAS Spectral Data File"
+    parameters["FORMAT"] = "EMSA/MAS Spectral Data File"
 
     # Convert the parameters to the right type and map some
     # TODO: the msa format seems to support specifying the units of some
@@ -195,167 +215,162 @@ def parse_msa_string(string, filename=None):
     for parameter, value in parameters.items():
         # Some parameters names can contain the units information
         # e.g. #AZIMANGLE-dg: 90.
-        if '-' in parameter:
-            clean_par, units = parameter.split('-')
+        if "-" in parameter:
+            clean_par, units = parameter.split("-")
             clean_par, units = clean_par.strip(), units.strip()
         else:
             clean_par, units = parameter, None
         if clean_par in keywords:
-            type_ = keywords[clean_par]['dtype']
+            type_ = keywords[clean_par]["dtype"]
             try:
                 parameters[parameter] = type_(value)
             except BaseException:
                 error = f"The {parameter} keyword value, {value} could \
                     not be converted to the right type."
-                if 'e' in value.lower():
-                    # Normally, the offending misspelling is a space in the 
+                if "e" in value.lower():
+                    # Normally, the offending misspelling is a space in the
                     # scientific notation, e.g. 2.0 E-06
                     try:
-                        parameters[parameter] = type_(value.replace(' ', ''))
+                        parameters[parameter] = type_(value.replace(" ", ""))
                     except BaseException:  # pragma: no cover
                         _logger.exception(error)
                 else:
                     # Some files have two values separated by a space
                     # https://eelsdb.eu/wp-content/uploads/2017/03/Cu4O3-O-K.msa
                     try:
-                        parameters[parameter] = type_(value.split(' ')[0])
+                        parameters[parameter] = type_(value.split(" ")[0])
                     except BaseException:  # pragma: no cover
                         _logger.exception(error)
 
-            if keywords[clean_par]['mapped_to'] is not None:
-                mapped.set_item(keywords[clean_par]['mapped_to'],
-                                parameters[parameter])
+            if keywords[clean_par]["mapped_to"] is not None:
+                mapped.set_item(keywords[clean_par]["mapped_to"], parameters[parameter])
                 if units is not None:
-                    mapped.set_item(keywords[clean_par]['mapped_to'] +
-                                    '_units', units)
-    if 'TIME' in parameters and parameters['TIME']:
+                    mapped.set_item(keywords[clean_par]["mapped_to"] + "_units", units)
+    if "TIME" in parameters and parameters["TIME"]:
         try:
-            time = dt.strptime(parameters['TIME'], "%H:%M")
-            mapped.set_item('General.time', time.time().isoformat())
+            time = dt.strptime(parameters["TIME"], "%H:%M")
+            mapped.set_item("General.time", time.time().isoformat())
         except ValueError as e:
             _logger.warning(
-                'Possible malformed TIME field in msa file. The time '
-                f'information could not be retrieved.: {e}'
-                )
+                "Possible malformed TIME field in msa file. The time "
+                f"information could not be retrieved.: {e}"
+            )
 
-    malformed_date_error = 'Possibly malformed DATE in msa file. The date information could not be retrieved.'
+    malformed_date_error = "Possibly malformed DATE in msa file. The date information could not be retrieved."
     if "DATE" in parameters and parameters["DATE"]:
         try:
             day, month, year = parameters["DATE"].split("-")
             if month.upper() in US_MONTH_A2D:
                 month = US_MONTH_A2D[month.upper()]
                 date = dt.strptime("-".join((day, month, year)), "%d-%m-%Y")
-                mapped.set_item('General.date', date.date().isoformat())
+                mapped.set_item("General.date", date.date().isoformat())
             else:
-                    _logger.warning(malformed_date_error)
-        except ValueError as e: # Error raised if split does not return 3 elements in this case
+                _logger.warning(malformed_date_error)
+        except ValueError as e:  # Error raised if split does not return 3 elements in this case
             _logger.warning(malformed_date_error + ": %s" % e)
 
-
-    axes = [{
-        'size': len(y),
-        'index_in_array': 0,
-        'name': parameters['XLABEL'] if 'XLABEL' in parameters else '',
-        'scale': parameters['XPERCHAN'] if 'XPERCHAN' in parameters else 1,
-        'offset': parameters['OFFSET'] if 'OFFSET' in parameters else 0,
-        'units': parameters['XUNITS'] if 'XUNITS' in parameters else '',
-    }]
+    axes = [
+        {
+            "size": len(y),
+            "index_in_array": 0,
+            "name": parameters["XLABEL"] if "XLABEL" in parameters else "",
+            "scale": parameters["XPERCHAN"] if "XPERCHAN" in parameters else 1,
+            "offset": parameters["OFFSET"] if "OFFSET" in parameters else 0,
+            "units": parameters["XUNITS"] if "XUNITS" in parameters else "",
+        }
+    ]
     if filename is not None:
-        mapped.set_item('General.original_filename',
-                        os.path.split(filename)[1])
-    mapped.set_item('Signal.record_by', 'spectrum')
-    if mapped.has_item('Signal.signal_type'):
-        if mapped.Signal.signal_type == 'ELS':
-            mapped.Signal.signal_type = 'EELS'
-        if mapped.Signal.signal_type in ['EDX', 'XEDS']:
-            mapped.Signal.signal_type = 'EDS'
+        mapped.set_item("General.original_filename", os.path.split(filename)[1])
+    mapped.set_item("Signal.record_by", "spectrum")
+    if mapped.has_item("Signal.signal_type"):
+        if mapped.Signal.signal_type == "ELS":
+            mapped.Signal.signal_type = "EELS"
+        if mapped.Signal.signal_type in ["EDX", "XEDS"]:
+            mapped.Signal.signal_type = "EDS"
     else:
         # Defaulting to EELS looks reasonable
-        mapped.set_item('Signal.signal_type', 'EELS')
-    if 'YUNITS' in parameters.keys():
-        yunits = "(%s)" % parameters['YUNITS']
+        mapped.set_item("Signal.signal_type", "EELS")
+    if "YUNITS" in parameters.keys():
+        yunits = "(%s)" % parameters["YUNITS"]
     else:
         yunits = ""
-    if 'YLABEL' in parameters.keys():
-        quantity = "%s" % parameters['YLABEL']
+    if "YLABEL" in parameters.keys():
+        quantity = "%s" % parameters["YLABEL"]
     else:
-        if mapped.Signal.signal_type == 'EELS':
-            quantity = 'Electrons'
+        if mapped.Signal.signal_type == "EELS":
+            quantity = "Electrons"
             if not yunits:
                 yunits = "(Counts)"
-        elif 'EDS' in mapped.Signal.signal_type:
-            quantity = 'X-rays'
+        elif "EDS" in mapped.Signal.signal_type:
+            quantity = "X-rays"
             if not yunits:
                 yunits = "(Counts)"
         else:
             quantity = ""
     if quantity or yunits:
         quantity_units = "%s %s" % (quantity, yunits)
-        mapped.set_item('Signal.quantity', quantity_units.strip())
+        mapped.set_item("Signal.quantity", quantity_units.strip())
 
     dictionary = {
-        'data': np.array(y),
-        'axes': axes,
-        'metadata': mapped.to_dict(),
-        'original_metadata': parameters
+        "data": np.array(y),
+        "axes": axes,
+        "metadata": mapped.to_dict(),
+        "original_metadata": parameters,
     }
-    file_data_list = [dictionary, ]
+    file_data_list = [
+        dictionary,
+    ]
     return file_data_list
 
 
-def file_reader(filename, encoding='latin-1', **kwds):
-    with codecs.open(
-            filename,
-            encoding=encoding,
-            errors='replace') as spectrum_file:
-        return parse_msa_string(string=spectrum_file,
-                                filename=filename)
+def file_reader(filename, encoding="latin-1", **kwds):
+    with codecs.open(filename, encoding=encoding, errors="replace") as spectrum_file:
+        return parse_msa_string(string=spectrum_file, filename=filename)
 
 
-def file_writer(filename, signal, format=None, separator=', ',
-                encoding='latin-1'):
+def file_writer(filename, signal, format=None, separator=", ", encoding="latin-1"):
     loc_kwds = {}
     FORMAT = "EMSA/MAS Spectral Data File"
     md = DTBox(signal["metadata"], box_dots=True)
     if signal["original_metadata"].get("FORMAT", None) == FORMAT:
         loc_kwds = signal["original_metadata"]
         if format is not None:
-            loc_kwds['DATATYPE'] = format
+            loc_kwds["DATATYPE"] = format
         else:
-            if 'DATATYPE' in loc_kwds:
-                format = loc_kwds['DATATYPE']
+            if "DATATYPE" in loc_kwds:
+                format = loc_kwds["DATATYPE"]
     else:
         if format is None:
-            format = 'Y'
+            format = "Y"
         if "General.date" in md:
             date = dt.strptime(md.General.date, "%Y-%m-%d")
             date_str = date.strftime("%d-%m-%Y")
             day, month, year = date_str.split("-")
             month = US_MONTHS_D2A[month]
-            loc_kwds['DATE'] = "-".join((day, month, year)) 
+            loc_kwds["DATE"] = "-".join((day, month, year))
         if "General.item" in md:
             time = dt.strptime(md.General.time, "%H:%M:%S")
-            loc_kwds['TIME'] = time.strftime("%H:%M")
+            loc_kwds["TIME"] = time.strftime("%H:%M")
     keys_from_signal = {
         # Required parameters
-        'FORMAT': FORMAT,
-        'VERSION': '1.0',
+        "FORMAT": FORMAT,
+        "VERSION": "1.0",
         # 'TITLE' : signal.title[:64] if hasattr(signal, "title") else '',
-        'DATE': '',
-        'TIME': '',
-        'OWNER': '',
-        'NPOINTS': signal["axes"][0]["size"],
-        'NCOLUMNS': 1,
-        'DATATYPE': format,
-        'SIGNALTYPE': md.Signal.signal_type,
-        'XPERCHAN': signal["axes"][0]["scale"],
-        'OFFSET': signal["axes"][0]["offset"],
+        "DATE": "",
+        "TIME": "",
+        "OWNER": "",
+        "NPOINTS": signal["axes"][0]["size"],
+        "NCOLUMNS": 1,
+        "DATATYPE": format,
+        "SIGNALTYPE": md.Signal.signal_type,
+        "XPERCHAN": signal["axes"][0]["scale"],
+        "OFFSET": signal["axes"][0]["offset"],
         # Signal1D characteristics
-        'XLABEL': signal["axes"][0]["name"],
+        "XLABEL": signal["axes"][0]["name"],
         #        'YLABEL' : '',
-        'XUNITS': signal["axes"][0]["units"],
+        "XUNITS": signal["axes"][0]["units"],
         #        'YUNITS' : '',
-        'COMMENT': 'File created by RosettaSciIO version %s' % __version__,
+        "COMMENT": "File created by RosettaSciIO version %s" % __version__,
         # Microscope
         #        'BEAMKV' : ,
         #        'EMISSION' : ,
@@ -381,48 +396,44 @@ def file_writer(filename, signal, format=None, separator=', ',
 
     # Update the loc_kwds with the information retrieved from the signal class
     for key, value in keys_from_signal.items():
-        if key not in loc_kwds or value != '':
+        if key not in loc_kwds or value != "":
             loc_kwds[key] = value
 
     for key, dic in keywords.items():
 
-        if dic['mapped_to'] is not None:
-            if 'SEM' in md.Signal.signal_type:
-                dic['mapped_to'] = dic['mapped_to'].replace('TEM', 'SEM')
-            if dic['mapped_to'] in md:
-                loc_kwds[key] = eval('md.%s' % dic['mapped_to'])
+        if dic["mapped_to"] is not None:
+            if "SEM" in md.Signal.signal_type:
+                dic["mapped_to"] = dic["mapped_to"].replace("TEM", "SEM")
+            if dic["mapped_to"] in md:
+                loc_kwds[key] = eval("md.%s" % dic["mapped_to"])
 
-    with codecs.open(
-            filename,
-            'w',
-            encoding=encoding,
-            errors='ignore') as f:
+    with codecs.open(filename, "w", encoding=encoding, errors="ignore") as f:
         # Remove the following keys from loc_kwds if they are in
         # (although they shouldn't)
-        for key in ['SPECTRUM', 'ENDOFDATA']:
+        for key in ["SPECTRUM", "ENDOFDATA"]:
             if key in loc_kwds:
-                del(loc_kwds[key])
+                del loc_kwds[key]
 
-        f.write('#%-12s: %s\u000D\u000A' % ('FORMAT', loc_kwds.pop('FORMAT')))
-        f.write(
-            '#%-12s: %s\u000D\u000A' %
-            ('VERSION', loc_kwds.pop('VERSION')))
+        f.write("#%-12s: %s\u000D\u000A" % ("FORMAT", loc_kwds.pop("FORMAT")))
+        f.write("#%-12s: %s\u000D\u000A" % ("VERSION", loc_kwds.pop("VERSION")))
         for keyword, value in loc_kwds.items():
-            f.write('#%-12s: %s\u000D\u000A' % (keyword, value))
+            f.write("#%-12s: %s\u000D\u000A" % (keyword, value))
 
-        f.write('#%-12s: Spectral Data Starts Here\u000D\u000A' % 'SPECTRUM')
+        f.write("#%-12s: Spectral Data Starts Here\u000D\u000A" % "SPECTRUM")
 
-        if format == 'XY':
+        if format == "XY":
             axis_dict = signal["axes"][0]
-            axis = axis_dict["offset"] + axis_dict["scale"] * np.arange(axis_dict["size"])
+            axis = axis_dict["offset"] + axis_dict["scale"] * np.arange(
+                axis_dict["size"]
+            )
             for x, y in zip(axis, signal["data"]):
                 f.write("%g%s%g" % (x, separator, y))
-                f.write('\u000D\u000A')
-        elif format == 'Y':
+                f.write("\u000D\u000A")
+        elif format == "Y":
             for y in signal["data"]:
-                f.write('%f%s' % (y, separator))
-                f.write('\u000D\u000A')
+                f.write("%f%s" % (y, separator))
+                f.write("\u000D\u000A")
         else:
-            raise ValueError('format must be one of: None, \'XY\' or \'Y\'')
+            raise ValueError("format must be one of: None, 'XY' or 'Y'")
 
-        f.write('#%-12s: End Of Data and File' % 'ENDOFDATA')
+        f.write("#%-12s: End Of Data and File" % "ENDOFDATA")

--- a/rsciio/netcdf/api.py
+++ b/rsciio/netcdf/api.py
@@ -26,169 +26,178 @@ _logger = logging.getLogger(__name__)
 no_netcdf = False
 try:
     from netCDF4 import Dataset
-    which_netcdf = 'netCDF4'
+
+    which_netcdf = "netCDF4"
 except BaseException:
     try:
         from netCDF3 import Dataset
-        which_netcdf = 'netCDF3'
+
+        which_netcdf = "netCDF3"
     except BaseException:
         try:
             from Scientific.IO.NetCDF import NetCDFFile as Dataset
-            which_netcdf = 'Scientific Python'
+
+            which_netcdf = "Scientific Python"
         except BaseException:
             no_netcdf = True
 
 
+attrib2netcdf = {
+    "energyorigin": "energy_origin",
+    "energyscale": "energy_scale",
+    "energyunits": "energy_units",
+    "xorigin": "x_origin",
+    "xscale": "x_scale",
+    "xunits": "x_units",
+    "yorigin": "y_origin",
+    "yscale": "y_scale",
+    "yunits": "y_units",
+    "zorigin": "z_origin",
+    "zscale": "z_scale",
+    "zunits": "z_units",
+    "exposure": "exposure",
+    "title": "title",
+    "binning": "binning",
+    "readout_frequency": "readout_frequency",
+    "ccd_height": "ccd_height",
+    "blanking": "blanking",
+}
 
-attrib2netcdf = \
-    {
-        'energyorigin': 'energy_origin',
-        'energyscale': 'energy_scale',
-        'energyunits': 'energy_units',
-        'xorigin': 'x_origin',
-        'xscale': 'x_scale',
-        'xunits': 'x_units',
-        'yorigin': 'y_origin',
-        'yscale': 'y_scale',
-        'yunits': 'y_units',
-        'zorigin': 'z_origin',
-        'zscale': 'z_scale',
-        'zunits': 'z_units',
-        'exposure': 'exposure',
-        'title': 'title',
-        'binning': 'binning',
-        'readout_frequency': 'readout_frequency',
-        'ccd_height': 'ccd_height',
-        'blanking': 'blanking'
-    }
+acquisition2netcdf = {
+    "exposure": "exposure",
+    "binning": "binning",
+    "readout_frequency": "readout_frequency",
+    "ccd_height": "ccd_height",
+    "blanking": "blanking",
+    "gain": "gain",
+    "pppc": "pppc",
+}
 
-acquisition2netcdf = \
-    {
-        'exposure': 'exposure',
-        'binning': 'binning',
-        'readout_frequency': 'readout_frequency',
-        'ccd_height': 'ccd_height',
-        'blanking': 'blanking',
-        'gain': 'gain',
-        'pppc': 'pppc',
-    }
-
-treatments2netcdf = \
-    {
-        'dark_current': 'dark_current',
-        'readout': 'readout',
-    }
+treatments2netcdf = {
+    "dark_current": "dark_current",
+    "readout": "readout",
+}
 
 
 def file_reader(filename, *args, **kwds):
     if no_netcdf is True:
-        raise ImportError("No netCDF library installed. "
-                          "To read EELSLab netcdf files install "
-                          "one of the following packages:"
-                          "netCDF4, netCDF3, netcdf, scientific")
+        raise ImportError(
+            "No netCDF library installed. "
+            "To read EELSLab netcdf files install "
+            "one of the following packages:"
+            "netCDF4, netCDF3, netcdf, scientific"
+        )
 
-    ncfile = Dataset(filename, 'r')
+    ncfile = Dataset(filename, "r")
 
-    if hasattr(ncfile, 'file_format_version'):
-        if ncfile.file_format_version == 'EELSLab 0.1':
-            dictionary = nc_hyperspy_reader_0dot1(
-                ncfile,
-                filename,
-                *args,
-                **kwds)
+    if hasattr(ncfile, "file_format_version"):
+        if ncfile.file_format_version == "EELSLab 0.1":
+            dictionary = nc_hyperspy_reader_0dot1(ncfile, filename, *args, **kwds)
     else:
         ncfile.close()
-        raise IOError('Unsupported netCDF file')
+        raise IOError("Unsupported netCDF file")
 
-    return dictionary,
+    return (dictionary,)
 
 
 def nc_hyperspy_reader_0dot1(ncfile, filename, *args, **kwds):
     calibration_dict, acquisition_dict, treatments_dict = {}, {}, {}
-    dc = ncfile.variables['data_cube']
+    dc = ncfile.variables["data_cube"]
     data = dc[:]
-    if 'history' in calibration_dict:
-        calibration_dict['history'] = eval(ncfile.history)
+    if "history" in calibration_dict:
+        calibration_dict["history"] = eval(ncfile.history)
     for attrib in attrib2netcdf.items():
         if hasattr(dc, attrib[1]):
-            value = eval('dc.' + attrib[1])
+            value = eval("dc." + attrib[1])
             if isinstance(value, np.ndarray):
                 calibration_dict[attrib[0]] = value[0]
             else:
                 calibration_dict[attrib[0]] = value
         else:
-            _logger.warning("Warning: the attribute '%s' is not defined in "
-                            "the file '%s'", attrib[0], filename)
+            _logger.warning(
+                "Warning: the attribute '%s' is not defined in " "the file '%s'",
+                attrib[0],
+                filename,
+            )
     for attrib in acquisition2netcdf.items():
         if hasattr(dc, attrib[1]):
-            value = eval('dc.' + attrib[1])
+            value = eval("dc." + attrib[1])
             if isinstance(value, np.ndarray):
                 acquisition_dict[attrib[0]] = value[0]
             else:
                 acquisition_dict[attrib[0]] = value
         else:
-            _logger.warning("Warning: the attribute '%s' is not defined in "
-                            "the file '%s'", attrib[0], filename)
+            _logger.warning(
+                "Warning: the attribute '%s' is not defined in " "the file '%s'",
+                attrib[0],
+                filename,
+            )
     for attrib in treatments2netcdf.items():
         if hasattr(dc, attrib[1]):
-            treatments_dict[attrib[0]] = eval('dc.' + attrib[1])
+            treatments_dict[attrib[0]] = eval("dc." + attrib[1])
         else:
-            _logger.warning("Warning: the attribute '%s' is not defined in "
-                            "the file '%s'", attrib[0], filename)
-    original_metadata = {'record_by': ncfile.type,
-                         'calibration': calibration_dict,
-                         'acquisition': acquisition_dict,
-                         'treatments': treatments_dict}
+            _logger.warning(
+                "Warning: the attribute '%s' is not defined in " "the file '%s'",
+                attrib[0],
+                filename,
+            )
+    original_metadata = {
+        "record_by": ncfile.type,
+        "calibration": calibration_dict,
+        "acquisition": acquisition_dict,
+        "treatments": treatments_dict,
+    }
     ncfile.close()
     # Now we'll map some parameters
-    record_by = 'image' if original_metadata[
-        'record_by'] == 'image' else 'spectrum'
-    if record_by == 'image':
+    record_by = "image" if original_metadata["record_by"] == "image" else "spectrum"
+    if record_by == "image":
         dim = len(data.shape)
-        names = ['Z', 'Y', 'X'][3 - dim:]
-        scaleskeys = ['zscale', 'yscale', 'xscale']
-        originskeys = ['zorigin', 'yorigin', 'xorigin']
-        unitskeys = ['zunits', 'yunits', 'xunits']
+        names = ["Z", "Y", "X"][3 - dim :]
+        scaleskeys = ["zscale", "yscale", "xscale"]
+        originskeys = ["zorigin", "yorigin", "xorigin"]
+        unitskeys = ["zunits", "yunits", "xunits"]
 
-    elif record_by == 'spectrum':
+    elif record_by == "spectrum":
         dim = len(data.shape)
-        names = ['Y', 'X', 'Energy'][3 - dim:]
-        scaleskeys = ['yscale', 'xscale', 'energyscale']
-        originskeys = ['yorigin', 'xorigin', 'energyorigin']
-        unitskeys = ['yunits', 'xunits', 'energyunits']
+        names = ["Y", "X", "Energy"][3 - dim :]
+        scaleskeys = ["yscale", "xscale", "energyscale"]
+        originskeys = ["yorigin", "xorigin", "energyorigin"]
+        unitskeys = ["yunits", "xunits", "energyunits"]
 
     # The images are recorded in the Fortran order
     data = data.T.copy()
     try:
-        scales = [calibration_dict[key] for key in scaleskeys[3 - dim:]]
+        scales = [calibration_dict[key] for key in scaleskeys[3 - dim :]]
     except KeyError:
-        scales = [1, 1, 1][3 - dim:]
+        scales = [1, 1, 1][3 - dim :]
     try:
-        origins = [calibration_dict[key] for key in originskeys[3 - dim:]]
+        origins = [calibration_dict[key] for key in originskeys[3 - dim :]]
     except KeyError:
-        origins = [0, 0, 0][3 - dim:]
+        origins = [0, 0, 0][3 - dim :]
     try:
-        units = [calibration_dict[key] for key in unitskeys[3 - dim:]]
+        units = [calibration_dict[key] for key in unitskeys[3 - dim :]]
     except KeyError:
-        units = ['', '', '']
+        units = ["", "", ""]
     axes = [
         {
-            'size': int(data.shape[i]),
-            'index_in_array': i,
-            'name': names[i],
-            'scale': scales[i],
-            'offset': origins[i],
-            'units': units[i], }
-        for i in range(dim)]
-    metadata = {'General': {}, 'Signal': {}}
-    metadata['General']['original_filename'] = os.path.split(filename)[1]
-    metadata["Signal"]['record_by'] = record_by
-    metadata["General"]['signal_type'] = ""
+            "size": int(data.shape[i]),
+            "index_in_array": i,
+            "name": names[i],
+            "scale": scales[i],
+            "offset": origins[i],
+            "units": units[i],
+        }
+        for i in range(dim)
+    ]
+    metadata = {"General": {}, "Signal": {}}
+    metadata["General"]["original_filename"] = os.path.split(filename)[1]
+    metadata["Signal"]["record_by"] = record_by
+    metadata["General"]["signal_type"] = ""
     dictionary = {
-        'data': data,
-        'axes': axes,
-        'metadata': metadata,
-        'original_metadata': original_metadata,
+        "data": data,
+        "axes": axes,
+        "metadata": metadata,
+        "original_metadata": original_metadata,
     }
 
     return dictionary

--- a/rsciio/nexus/api.py
+++ b/rsciio/nexus/api.py
@@ -35,8 +35,6 @@ from rsciio.utils.tools import DTBox
 _logger = logging.getLogger(__name__)
 
 
-
-
 def _byte_to_string(value):
     """Decode a byte string.
 
@@ -53,8 +51,8 @@ def _byte_to_string(value):
     try:
         text = value.decode("utf-8")
     except UnicodeDecodeError:
-        text = value.decode('latin-1')
-    return text.replace('\x00', '').rstrip()
+        text = value.decode("latin-1")
+    return text.replace("\x00", "").rstrip()
 
 
 def _parse_from_file(value, lazy=False):
@@ -152,8 +150,8 @@ def _text_split(s, sep):
         for substr in stack:
             pieces.extend(substr.split(char))
         stack = pieces
-    if '' in stack:
-        stack.remove('')
+    if "" in stack:
+        stack.remove("")
     return stack
 
 
@@ -171,15 +169,15 @@ def _getlink(h5group, rootkey, key):
 
     """
     _target = None
-    if rootkey != '/':
+    if rootkey != "/":
         if isinstance(h5group, h5py.Group):
             _link = h5group.get(key, getlink=True)
             if isinstance(_link, h5py.SoftLink):
                 _target = _link.path
-        if 'target' in h5group.attrs.keys():
-            _target = _parse_from_file(h5group.attrs['target'])
-            if not _target.startswith('/'):
-                _target = '/' + _target
+        if "target" in h5group.attrs.keys():
+            _target = _parse_from_file(h5group.attrs["target"])
+            if not _target.startswith("/"):
+                _target = "/" + _target
             if _target == rootkey:
                 _target = None
 
@@ -208,13 +206,13 @@ def _get_nav_list(data, dataentry):
     axis_index_list = []
     if "axes" in dataentry.attrs.keys():
         axes_key = dataentry.attrs["axes"]
-        axes_list = ["."]*data.ndim
+        axes_list = ["."] * data.ndim
         if isinstance(axes_key, np.ndarray):
-            axes_keys = axes_key[:data.ndim]
+            axes_keys = axes_key[: data.ndim]
             for i, num in enumerate(axes_keys):
                 axes_list[i] = _parse_from_file(num)
         elif isinstance(axes_key, (str, bytes)):
-            axes_list = _parse_from_file(axes_key).split(',')[:data.ndim]
+            axes_list = _parse_from_file(axes_key).split(",")[: data.ndim]
         else:
             axes_list[0] = _parse_from_file(axes_key)
 
@@ -238,47 +236,53 @@ def _get_nav_list(data, dataentry):
                 if _is_numeric_data(dataentry[ax]):
                     if dataentry[ax].size > 1:
                         if _is_linear_axis(dataentry[ax]):
-                            nav_list.append({
-                                'size': data.shape[ind_in_array],
-                                'index_in_array': ind_in_array,
-                                'name': ax,
-                                'scale': abs(dataentry[ax][1] -
-                                             dataentry[ax][0]),
-                                'offset': min(dataentry[ax][0],
-                                              dataentry[ax][-1]),
-                                'units': units,
-                                'navigate': navigation
-                                })
+                            nav_list.append(
+                                {
+                                    "size": data.shape[ind_in_array],
+                                    "index_in_array": ind_in_array,
+                                    "name": ax,
+                                    "scale": abs(dataentry[ax][1] - dataentry[ax][0]),
+                                    "offset": min(dataentry[ax][0], dataentry[ax][-1]),
+                                    "units": units,
+                                    "navigate": navigation,
+                                }
+                            )
                         else:
-                            nav_list.append({
-                                'size': data.shape[ind_in_array],
-                                'index_in_array': ind_in_array,
-                                'name': ax,
-                                'scale': 1,
-                                'offset': 0,
-                                'navigate': navigation
-                                })
+                            nav_list.append(
+                                {
+                                    "size": data.shape[ind_in_array],
+                                    "index_in_array": ind_in_array,
+                                    "name": ax,
+                                    "scale": 1,
+                                    "offset": 0,
+                                    "navigate": navigation,
+                                }
+                            )
                     else:
-                        nav_list.append({
-                            'size': 1,
-                            'index_in_array': ind_in_array,
-                            'name': ax,
-                            'scale': 1,
-                            'offset': dataentry[ax][0],
-                            'units': units,
-                            'navigate': True
-                            })
+                        nav_list.append(
+                            {
+                                "size": 1,
+                                "index_in_array": ind_in_array,
+                                "name": ax,
+                                "scale": 1,
+                                "offset": dataentry[ax][0],
+                                "units": units,
+                                "navigate": True,
+                            }
+                        )
             else:
                 if len(data.shape) == len(axes_list):
-                    nav_list.append({
-                            'size': data.shape[named_axes[detector_index]],
-                            'index_in_array': named_axes[detector_index],
-                            'scale': 1,
-                            'offset': 0.0,
-                            'units': '',
-                            'navigate': False
-                           })
-                    detector_index = detector_index+1
+                    nav_list.append(
+                        {
+                            "size": data.shape[named_axes[detector_index]],
+                            "index_in_array": named_axes[detector_index],
+                            "scale": 1,
+                            "offset": 0.0,
+                            "units": "",
+                            "navigate": False,
+                        }
+                    )
+                    detector_index = detector_index + 1
 
     return nav_list
 
@@ -306,11 +310,11 @@ def _extract_hdf_dataset(group, dataset, lazy=False):
 
     # exclude the dataset tagged by the signal attribute to avoid extracting
     # duplicated dataset, which is already loaded when loading NeXus data
-    if 'signal' in data.parent.attrs.keys():
-        data_key = data.parent.attrs['signal']
+    if "signal" in data.parent.attrs.keys():
+        data_key = data.parent.attrs["signal"]
         if isinstance(data_key, bytes):
             data_key = data_key.decode()
-        if dataset.split('/')[-1] == data_key:
+        if dataset.split("/")[-1] == data_key:
             return
 
     nav_list = _get_nav_list(data, data.parent)
@@ -319,15 +323,18 @@ def _extract_hdf_dataset(group, dataset, lazy=False):
         if "chunks" in data.attrs.keys():
             chunks = data.attrs["chunks"]
         else:
-            signal_axes = [d['index_in_array'] for d in nav_list
-                           if not d['navigate']]
+            signal_axes = [d["index_in_array"] for d in nav_list if not d["navigate"]]
             chunks = get_signal_chunks(data.shape, data.dtype, signal_axes)
         data_lazy = da.from_array(data, chunks=chunks)
     else:
         data_lazy = np.array(data)
 
-    dictionary = {'data': data_lazy, 'metadata': {}, 'original_metadata': {},
-                  'axes': nav_list}
+    dictionary = {
+        "data": data_lazy,
+        "metadata": {},
+        "original_metadata": {},
+        "axes": nav_list,
+    }
 
     return dictionary
 
@@ -358,11 +365,15 @@ def _nexus_dataset_to_signal(group, nexus_dataset_path, lazy=False):
         else:
             data_key = dataentry.attrs["signal"]
     else:
-        _logger.info("No signal attr associated with NXdata will\
-                     try assume signal name is data")
+        _logger.info(
+            "No signal attr associated with NXdata will\
+                     try assume signal name is data"
+        )
         if "data" not in dataentry.keys():
-            raise ValueError("Signal attribute not found in NXdata and "
-                             "attempt to find a default \"data\" key failed")
+            raise ValueError(
+                "Signal attribute not found in NXdata and "
+                'attempt to find a default "data" key failed'
+            )
         else:
             data_key = "data"
 
@@ -376,8 +387,7 @@ def _nexus_dataset_to_signal(group, nexus_dataset_path, lazy=False):
         if "chunks" in data.attrs.keys():
             chunks = data.attrs["chunks"]
         else:
-            signal_axes = [d['index_in_array'] for d in nav_list
-                           if not d['navigate']]
+            signal_axes = [d["index_in_array"] for d in nav_list if not d["navigate"]]
             chunks = get_signal_chunks(data.shape, data.dtype, signal_axes)
         data_lazy = da.from_array(data, chunks=chunks)
     else:
@@ -385,16 +395,18 @@ def _nexus_dataset_to_signal(group, nexus_dataset_path, lazy=False):
 
     if not nav_list:
         for i in range(data.ndim):
-            nav_list.append({
-                    'size': data_lazy.shape[i],
-                    'index_in_array': i,
-                    'scale': 1,
-                    'offset': 0.0,
-                    'units': '',
-                    'navigate': True
-                   })
-    title = _text_split(nexus_dataset_path, '/')[-1]
-    metadata = {'General': {'title': title}}
+            nav_list.append(
+                {
+                    "size": data_lazy.shape[i],
+                    "index_in_array": i,
+                    "scale": 1,
+                    "offset": 0.0,
+                    "units": "",
+                    "navigate": True,
+                }
+            )
+    title = _text_split(nexus_dataset_path, "/")[-1]
+    metadata = {"General": {"title": title}}
 
     #
     # if interpretation - reset the nav axes
@@ -409,19 +421,22 @@ def _nexus_dataset_to_signal(group, nexus_dataset_path, lazy=False):
             nav_list[-1]["navigate"] = False
             nav_list[-2]["navigate"] = False
 
-    dictionary = {'data': data_lazy,
-                  'axes': nav_list,
-                  'metadata': metadata}
+    dictionary = {"data": data_lazy, "axes": nav_list, "metadata": metadata}
     return dictionary
 
 
-def file_reader(filename, lazy=False, dataset_key=None, dataset_path=None,
-                metadata_key=None,
-                skip_array_metadata=False,
-                nxdata_only=False,
-                hardlinks_only=False,
-                use_default=False,
-                **kwds):
+def file_reader(
+    filename,
+    lazy=False,
+    dataset_key=None,
+    dataset_path=None,
+    metadata_key=None,
+    skip_array_metadata=False,
+    nxdata_only=False,
+    hardlinks_only=False,
+    use_default=False,
+    **kwds,
+):
     """Read NXdata class or hdf datasets from a file and return signal(s).
 
     Note
@@ -484,40 +499,47 @@ def file_reader(filename, lazy=False, dataset_key=None, dataset_path=None,
     """
     # search for NXdata sets...
 
-    mapping = kwds.get('mapping', {})
+    mapping = kwds.get("mapping", {})
     original_metadata = {}
     learning = {}
     fin = h5py.File(filename, "r")
     signal_dict_list = []
 
-    if 'dataset_keys' in kwds:
-        warnings.warn("The `dataset_keys` keyword is deprecated. "
-                      "Use `dataset_key` instead.", VisibleDeprecationWarning)
-        dataset_key = kwds['dataset_keys']
+    if "dataset_keys" in kwds:
+        warnings.warn(
+            "The `dataset_keys` keyword is deprecated. " "Use `dataset_key` instead.",
+            VisibleDeprecationWarning,
+        )
+        dataset_key = kwds["dataset_keys"]
 
-    if 'dataset_paths' in kwds:
-        warnings.warn("The `dataset_paths` keyword is deprecated. "
-                      "Use `dataset_path` instead.", VisibleDeprecationWarning)
-        dataset_path = kwds['dataset_paths']
+    if "dataset_paths" in kwds:
+        warnings.warn(
+            "The `dataset_paths` keyword is deprecated. " "Use `dataset_path` instead.",
+            VisibleDeprecationWarning,
+        )
+        dataset_path = kwds["dataset_paths"]
 
-    if 'metadata_keys' in kwds:
-        warnings.warn("The `metadata_keys` keyword is deprecated. "
-                      "Use `metadata_key` instead.", VisibleDeprecationWarning)
-        metadata_key = kwds['metadata_keys']
+    if "metadata_keys" in kwds:
+        warnings.warn(
+            "The `metadata_keys` keyword is deprecated. " "Use `metadata_key` instead.",
+            VisibleDeprecationWarning,
+        )
+        metadata_key = kwds["metadata_keys"]
 
     dataset_key = _check_search_keys(dataset_key)
     dataset_path = _check_search_keys(dataset_path)
     metadata_key = _check_search_keys(metadata_key)
-    original_metadata = _load_metadata(fin, lazy=lazy,
-                                       skip_array_metadata=skip_array_metadata)
+    original_metadata = _load_metadata(
+        fin, lazy=lazy, skip_array_metadata=skip_array_metadata
+    )
     # some default values...
     nexus_data_paths = []
     hdf_data_paths = []
     # check if a default dataset is defined
     if use_default:
-        nexus_data_paths, hdf_data_paths = _find_data(fin,
-                                                      search_keys=None,
-                                                      hardlinks_only=False)
+        nexus_data_paths, hdf_data_paths = _find_data(
+            fin, search_keys=None, hardlinks_only=False
+        )
         nxentry = None
         nxdata = None
         if "attrs" in original_metadata:
@@ -532,18 +554,21 @@ def file_reader(filename, lazy=False, dataset_key=None, dataset_path=None,
                 if "default" in original_metadata[nxentry]["attrs"]:
                     nxdata = original_metadata[nxentry]["attrs"]["default"]
             if nxentry and nxdata:
-                nxdata = "/"+nxentry+"/"+nxdata
+                nxdata = "/" + nxentry + "/" + nxdata
             if nxdata:
                 hdf_data_paths = []
-                nexus_data_paths = [nxpath for nxpath in nexus_data_paths
-                                    if nxdata in nxpath]
+                nexus_data_paths = [
+                    nxpath for nxpath in nexus_data_paths if nxdata in nxpath
+                ]
 
     # if no default found then search for the data as normal
     if not nexus_data_paths and not hdf_data_paths:
-        nexus_data_paths, hdf_data_paths = \
-            _find_data(fin, search_keys=dataset_key,
-                       hardlinks_only=hardlinks_only,
-                       absolute_path=dataset_path)
+        nexus_data_paths, hdf_data_paths = _find_data(
+            fin,
+            search_keys=dataset_key,
+            hardlinks_only=hardlinks_only,
+            absolute_path=dataset_path,
+        )
 
     for data_path in nexus_data_paths:
         dictionary = _nexus_dataset_to_signal(fin, data_path, lazy=lazy)
@@ -552,41 +577,45 @@ def file_reader(filename, lazy=False, dataset_key=None, dataset_path=None,
         title = dictionary["metadata"]["General"]["title"]
         if entryname in original_metadata:
             if metadata_key is None:
-                dictionary["original_metadata"] = \
-                    original_metadata[entryname]
+                dictionary["original_metadata"] = original_metadata[entryname]
             else:
-                dictionary["original_metadata"] = \
-                    _find_search_keys_in_dict(original_metadata,
-                                              search_keys=metadata_key)
+                dictionary["original_metadata"] = _find_search_keys_in_dict(
+                    original_metadata, search_keys=metadata_key
+                )
             # test if it's a hyperspy_nexus format and update metadata
             # as appropriate.
-            if "attrs" in original_metadata and \
-                    "file_writer" in original_metadata["attrs"]:
-                if original_metadata["attrs"]["file_writer"] == \
-                        "hyperspy_nexus_v3":
+            if (
+                "attrs" in original_metadata
+                and "file_writer" in original_metadata["attrs"]
+            ):
+                if original_metadata["attrs"]["file_writer"] == "hyperspy_nexus_v3":
                     orig_metadata = original_metadata[entryname]
                     if "auxiliary" in orig_metadata:
                         oma = orig_metadata["auxiliary"]
                         if "learning_results" in oma:
                             learning = oma["learning_results"]
                             dictionary["attributes"] = {}
-                            dictionary["attributes"]["learning_results"] = \
-                                learning
+                            dictionary["attributes"]["learning_results"] = learning
                         if "original_metadata" in oma:
                             if metadata_key is None:
-                                dictionary["original_metadata"] = \
-                                    (oma["original_metadata"])
+                                dictionary["original_metadata"] = oma[
+                                    "original_metadata"
+                                ]
                             else:
-                                dictionary["original_metadata"] = \
-                                    _find_search_keys_in_dict(
-                                        (oma["original_metadata"]),
-                                        search_keys=metadata_key)
+                                dictionary[
+                                    "original_metadata"
+                                ] = _find_search_keys_in_dict(
+                                    (oma["original_metadata"]), search_keys=metadata_key
+                                )
                             # reconstruct the axes_list for axes_manager
-                            for k, v in oma['original_metadata'].items():
-                                if k.startswith('_sig_'):
-                                    hyper_ax = [ax_v for ax_k, ax_v in v.items()
-                                                if ax_k.startswith('_axes')]
-                                    oma['original_metadata'][k]['axes'] = hyper_ax
+                            for k, v in oma["original_metadata"].items():
+                                if k.startswith("_sig_"):
+                                    hyper_ax = [
+                                        ax_v
+                                        for ax_k, ax_v in v.items()
+                                        if ax_k.startswith("_axes")
+                                    ]
+                                    oma["original_metadata"][k]["axes"] = hyper_ax
                         if "hyperspy_metadata" in oma:
                             hyper_metadata = oma["hyperspy_metadata"]
                             hyper_metadata.update(dictionary["metadata"])
@@ -600,11 +629,13 @@ def file_reader(filename, lazy=False, dataset_key=None, dataset_path=None,
         for data_path in hdf_data_paths:
             datadict = _extract_hdf_dataset(fin, data_path, lazy=lazy)
             if datadict:
-                title = data_path[1:].replace('/', '_')
-                basic_metadata = {'General':
-                                  {'original_filename':
-                                   os.path.split(filename)[1],
-                                   'title': title}}
+                title = data_path[1:].replace("/", "_")
+                basic_metadata = {
+                    "General": {
+                        "original_filename": os.path.split(filename)[1],
+                        "title": title,
+                    }
+                }
                 datadict["metadata"].update(basic_metadata)
                 signal_dict_list.append(datadict)
 
@@ -625,7 +656,7 @@ def _is_linear_axis(data):
 
     """
     steps = np.diff(data)
-    est_steps = np.array([steps[0]]*len(steps))
+    est_steps = np.array([steps[0]] * len(steps))
     return np.allclose(est_steps, steps, rtol=1.0e-5)
 
 
@@ -680,12 +711,10 @@ def _check_search_keys(search_keys):
     elif search_keys is None:
         return search_keys
     else:
-        raise ValueError("search keys must be None, a string, "
-                         "or a list of strings")
+        raise ValueError("search keys must be None, a string, " "or a list of strings")
 
 
-def _find_data(group, search_keys=None, hardlinks_only=False,
-               absolute_path=None):
+def _find_data(group, search_keys=None, hardlinks_only=False, absolute_path=None):
     """Read from a nexus or hdf file and return a list of the dataset entries.
 
     The method iterates through group attributes and returns NXdata or
@@ -735,8 +764,10 @@ def _find_data(group, search_keys=None, hardlinks_only=False,
             if isinstance(value, h5py.Group):
                 target = _getlink(group, rootkey, key)
                 if "NX_class" in value.attrs:
-                    if value.attrs["NX_class"] == b"NXdata" \
-                            and "signal" in value.attrs.keys():
+                    if (
+                        value.attrs["NX_class"] == b"NXdata"
+                        and "signal" in value.attrs.keys()
+                    ):
                         all_nx_datasets.append(rootkey)
                         if target is None:
                             unique_nx_datasets.append(rootkey)
@@ -749,11 +780,11 @@ def _find_data(group, search_keys=None, hardlinks_only=False,
                 if isinstance(value, h5py.Dataset):
                     if value.size >= 2:
                         target = _getlink(group, rootkey, key)
-                        if not(value.dtype.type is str or
-                                value.dtype.type is object):
+                        if not (value.dtype.type is str or value.dtype.type is object):
                             all_hdf_datasets.append(rootkey)
                             if target is None:
                                 unique_hdf_datasets.append(rootkey)
+
     # need to use custom recursive function as visititems in h5py
     # does not visit links
     find_data_in_tree(group, rootname)
@@ -779,16 +810,20 @@ def _find_data(group, search_keys=None, hardlinks_only=False,
     matched_nexus = set()
     # return data having the specified absolute paths
     if absolute_path is not None:
-        matched_hdf.update([j for j in hdf_datasets
-                            if any(s==j for s in absolute_path)])
-        matched_nexus.update([j for j in nx_datasets
-                              if any(s==j for s in absolute_path)])
+        matched_hdf.update(
+            [j for j in hdf_datasets if any(s == j for s in absolute_path)]
+        )
+        matched_nexus.update(
+            [j for j in nx_datasets if any(s == j for s in absolute_path)]
+        )
     # return data which contains a search string
     if search_keys is not None:
-        matched_hdf.update([j for j in hdf_datasets
-                            if any(s in j for s in search_keys)])
-        matched_nexus.update([j for j in nx_datasets
-                              if any(s in j for s in search_keys)])
+        matched_hdf.update(
+            [j for j in hdf_datasets if any(s in j for s in search_keys)]
+        )
+        matched_nexus.update(
+            [j for j in nx_datasets if any(s in j for s in search_keys)]
+        )
 
     matched_nexus = list(matched_nexus)
     matched_hdf = list(matched_hdf)
@@ -821,8 +856,7 @@ def _load_metadata(group, lazy=False, skip_array_metadata=False):
     """
     rootname = ""
 
-    def find_meta_in_tree(group, rootname, lazy=False,
-                          skip_array_metadata=False):
+    def find_meta_in_tree(group, rootname, lazy=False, skip_array_metadata=False):
         tree = {}
         for key, item in group.attrs.items():
             new_key = _fix_exclusion_keys(key)
@@ -843,17 +877,14 @@ def _load_metadata(group, lazy=False, skip_array_metadata=False):
                     # avoid loading array as metadata
                     if skip_array_metadata:
                         if item.size < 2 and item.ndim == 0:
-                            tree[new_key]["value"] = _parse_from_file(item,
-                                                                      lazy=lazy)
+                            tree[new_key]["value"] = _parse_from_file(item, lazy=lazy)
                     else:
-                        tree[new_key]["value"] = _parse_from_file(item,
-                                                                  lazy=lazy)
+                        tree[new_key]["value"] = _parse_from_file(item, lazy=lazy)
 
                     for k, v in item.attrs.items():
                         if "attrs" not in tree[new_key].keys():
                             tree[new_key]["attrs"] = {}
-                        tree[new_key]["attrs"][k] = _parse_from_file(v,
-                                                                     lazy=lazy)
+                        tree[new_key]["attrs"][k] = _parse_from_file(v, lazy=lazy)
                 else:
                     # this is to support hyperspy where datasets are not saved
                     # with attributes
@@ -866,17 +897,25 @@ def _load_metadata(group, lazy=False, skip_array_metadata=False):
             elif type(item) is h5py.Group:
                 if "NX_class" in item.attrs:
                     if item.attrs["NX_class"] != b"NXdata":
-                        tree[new_key] = find_meta_in_tree(item, rootkey,
-                                                          lazy=lazy,
-                                      skip_array_metadata=skip_array_metadata)
+                        tree[new_key] = find_meta_in_tree(
+                            item,
+                            rootkey,
+                            lazy=lazy,
+                            skip_array_metadata=skip_array_metadata,
+                        )
                 else:
-                    tree[new_key] = find_meta_in_tree(item, rootkey,
-                                                      lazy=lazy,
-                                      skip_array_metadata=skip_array_metadata)
+                    tree[new_key] = find_meta_in_tree(
+                        item,
+                        rootkey,
+                        lazy=lazy,
+                        skip_array_metadata=skip_array_metadata,
+                    )
 
         return tree
-    extracted_tree = find_meta_in_tree(group, rootname, lazy=lazy,
-                                       skip_array_metadata=skip_array_metadata)
+
+    extracted_tree = find_meta_in_tree(
+        group, rootname, lazy=lazy, skip_array_metadata=skip_array_metadata
+    )
     return extracted_tree
 
 
@@ -899,7 +938,7 @@ def _fix_exclusion_keys(key):
 
     """
     if key.startswith("keys"):
-        return "fix_"+key
+        return "fix_" + key
     else:
         return key
 
@@ -936,8 +975,7 @@ def _find_search_keys_in_dict(tree, search_keys=None):
                 rootkey = rootname + "/" + key
             else:
                 rootkey = key
-            if type(search_keys) is list \
-                    and any([s1 in rootkey for s1 in search_keys]):
+            if type(search_keys) is list and any([s1 in rootkey for s1 in search_keys]):
                 mod_keys = _text_split(rootkey, (".", "/"))
                 # create the key, values in the dict
                 p = metadata_dict
@@ -975,28 +1013,37 @@ def _write_nexus_groups(dictionary, group, skip_keys=None, **kwds):
         skip_keys = [skip_keys]
 
     for key, value in dictionary.items():
-        if key == 'attrs' or key in skip_keys:
+        if key == "attrs" or key in skip_keys:
             # we will handle attrs later... and skip unwanted keys
             continue
         if isinstance(value, dict):
             if "attrs" in value:
-                if "NX_class" in value["attrs"] and \
-                        value["attrs"]["NX_class"] == "NXdata":
+                if (
+                    "NX_class" in value["attrs"]
+                    and value["attrs"]["NX_class"] == "NXdata"
+                ):
                     continue
-            if 'value' in value.keys() \
-                and not isinstance(value["value"], dict) \
-                    and len(set(list(value.keys()) + ["attrs", "value"])) == 2:
+            if (
+                "value" in value.keys()
+                and not isinstance(value["value"], dict)
+                and len(set(list(value.keys()) + ["attrs", "value"])) == 2
+            ):
                 value = value["value"]
             else:
-                _write_nexus_groups(value, group.require_group(key),
-                                    skip_keys=skip_keys, **kwds)
+                _write_nexus_groups(
+                    value, group.require_group(key), skip_keys=skip_keys, **kwds
+                )
         if isinstance(value, (list, tuple, np.ndarray, da.Array)):
             if all(isinstance(v, dict) for v in value):
                 # a list of dictionary is from the axes of HyperSpy signal
                 for i, ax_dict in enumerate(value):
-                    ax_key = '_axes_' + str(i)
-                    _write_nexus_groups(ax_dict, group.require_group(ax_key),
-                                        skip_keys=skip_keys, **kwds)
+                    ax_key = "_axes_" + str(i)
+                    _write_nexus_groups(
+                        ax_dict,
+                        group.require_group(ax_key),
+                        skip_keys=skip_keys,
+                        **kwds,
+                    )
             else:
                 data = _parse_to_file(value)
                 overwrite_dataset(group, data, key, chunks=None, **kwds)
@@ -1004,8 +1051,9 @@ def _write_nexus_groups(dictionary, group, skip_keys=None, **kwds):
             group.create_dataset(key, data=_parse_to_file(value))
         else:
             if value is not None and key not in group:
-                _write_nexus_groups(value, group.require_group(key),
-                                    skip_keys=skip_keys, **kwds)
+                _write_nexus_groups(
+                    value, group.require_group(key), skip_keys=skip_keys, **kwds
+                )
 
 
 def _write_nexus_attr(dictionary, group, skip_keys=None):
@@ -1027,24 +1075,25 @@ def _write_nexus_attr(dictionary, group, skip_keys=None):
         skip_keys = [skip_keys]
 
     for key, value in dictionary.items():
-        if key == 'attrs':
+        if key == "attrs":
 
             for k, v in value.items():
                 group.attrs[k] = _parse_to_file(v)
         else:
             if isinstance(value, dict):
                 if "attrs" in value:
-                    if "NX_class" in value["attrs"] and \
-                            value["attrs"]["NX_class"] == "NXdata":
+                    if (
+                        "NX_class" in value["attrs"]
+                        and value["attrs"]["NX_class"] == "NXdata"
+                    ):
                         continue
                 if key not in skip_keys:
-                    _write_nexus_attr(dictionary[key], group[key],
-                                      skip_keys=skip_keys)
+                    _write_nexus_attr(dictionary[key], group[key], skip_keys=skip_keys)
 
 
-def read_metadata_from_file(filename, metadata_key=None,
-                            lazy=False, verbose=False,
-                            skip_array_metadata=False):
+def read_metadata_from_file(
+    filename, metadata_key=None, lazy=False, verbose=False, skip_array_metadata=False
+):
     """Read the metadata from a nexus or hdf file.
 
     This method iterates through the file and returns a dictionary of
@@ -1086,10 +1135,12 @@ def read_metadata_from_file(filename, metadata_key=None,
     fin = h5py.File(filename, "r")
     # search for NXdata sets...
     # strip out the metadata (basically everything other than NXdata)
-    stripped_metadata = _load_metadata(fin, lazy=lazy,
-                                       skip_array_metadata=skip_array_metadata)
-    stripped_metadata = _find_search_keys_in_dict(stripped_metadata,
-                                                  search_keys=search_keys)
+    stripped_metadata = _load_metadata(
+        fin, lazy=lazy, skip_array_metadata=skip_array_metadata
+    )
+    stripped_metadata = _find_search_keys_in_dict(
+        stripped_metadata, search_keys=search_keys
+    )
     if verbose:
         pprint.pprint(stripped_metadata)
 
@@ -1097,9 +1148,9 @@ def read_metadata_from_file(filename, metadata_key=None,
     return stripped_metadata
 
 
-def list_datasets_in_file(filename, dataset_key=None,
-                          hardlinks_only=False,
-                          verbose=True):
+def list_datasets_in_file(
+    filename, dataset_key=None, hardlinks_only=False, verbose=True
+):
     """Read from a nexus or hdf file and return a list of the dataset paths.
 
     This method is used to inspect the contents of a Nexus file.
@@ -1142,8 +1193,9 @@ def list_datasets_in_file(filename, dataset_key=None,
     fin = h5py.File(filename, "r")
     # search for NXdata sets...
     # strip out the metadata (basically everything other than NXdata)
-    nexus_data_paths, hdf_dataset_paths = \
-        _find_data(fin, search_keys=search_keys, hardlinks_only=hardlinks_only)
+    nexus_data_paths, hdf_dataset_paths = _find_data(
+        fin, search_keys=search_keys, hardlinks_only=hardlinks_only
+    )
     if verbose:
         if nexus_data_paths:
             print("NXdata found")
@@ -1173,8 +1225,8 @@ def _write_signal(signal, nxgroup, signal_name, **kwds):
         Name under which to store the signal entry in the file
 
     """
-    signal_axes = [ax for ax in signal['axes'] if not ax['navigate']]
-    data = signal['data']
+    signal_axes = [ax for ax in signal["axes"] if not ax["navigate"]]
+    data = signal["data"]
     if len(signal_axes) == 1:
         record_by = "spectrum"
     elif len(signal_axes) == 2:
@@ -1187,42 +1239,48 @@ def _write_signal(signal, nxgroup, signal_name, **kwds):
     nxdata.attrs["signal"] = _parse_to_file("data")
     if record_by:
         nxdata.attrs["interpretation"] = _parse_to_file(record_by)
-    overwrite_dataset(nxdata, data, "data", chunks=None,
-                      signal_axes=[signal['axes'].index(ax) for ax in signal_axes],
-                      **kwds)
+    overwrite_dataset(
+        nxdata,
+        data,
+        "data",
+        chunks=None,
+        signal_axes=[signal["axes"].index(ax) for ax in signal_axes],
+        **kwds,
+    )
     axis_names = [_parse_to_file(".")] * len(data.shape)
-    for i, ax in enumerate(signal['axes']):
-        if ax['name'] is not None:
-            index_in_array = signal['axes'].index(ax)
-            indices = _parse_to_file(ax['name'] + "_indices")
+    for i, ax in enumerate(signal["axes"]):
+        if ax["name"] is not None:
+            index_in_array = signal["axes"].index(ax)
+            indices = _parse_to_file(ax["name"] + "_indices")
             nxdata.attrs[indices] = _parse_to_file(index_in_array)
-            if ax['_type'] == 'DataAxis':
-                data = ax['axis']
-            elif ax['_type'] == 'UniformDataAxis':
-               data = ax['offset'] + ax['scale'] * np.arange(ax['size'])
-            elif ax['_type'] == 'FunctionalDataAxis':
-                raise ValueError('Not supported')
+            if ax["_type"] == "DataAxis":
+                data = ax["axis"]
+            elif ax["_type"] == "UniformDataAxis":
+                data = ax["offset"] + ax["scale"] * np.arange(ax["size"])
+            elif ax["_type"] == "FunctionalDataAxis":
+                raise ValueError("Not supported")
             else:
-                raise RuntimeError(
-                    f"Axis of type ({ax['_type']}) are not supported."
-                    )
+                raise RuntimeError(f"Axis of type ({ax['_type']}) are not supported.")
             dset = nxdata.require_dataset(
-                ax['name'], data=data, shape=data.shape, dtype=data.dtype
-                )
-            if ax['units'] is not None:
-                dset.attrs['units'] = ax['units']
-            axis_names[index_in_array] = ax['name']
+                ax["name"], data=data, shape=data.shape, dtype=data.dtype
+            )
+            if ax["units"] is not None:
+                dset.attrs["units"] = ax["units"]
+            axis_names[index_in_array] = ax["name"]
 
     nxdata.attrs["axes"] = _parse_to_file(axis_names)
     return nxdata
 
 
-def file_writer(filename,
-                signals,
-                save_original_metadata=True,
-                skip_metadata_key=None,
-                use_default=False,
-                *args, **kwds):
+def file_writer(
+    filename,
+    signals,
+    save_original_metadata=True,
+    skip_metadata_key=None,
+    use_default=False,
+    *args,
+    **kwds,
+):
     """Write the signal and metadata as a nexus file.
 
     This will save the signal in NXdata format in the file.
@@ -1257,11 +1315,11 @@ def file_writer(filename,
     if not isinstance(signals, list):
         signals = [signals]
 
-    with h5py.File(filename, mode='w') as f:
-        f.attrs['file_format'] = "nexus"
-        f.attrs['file_writer'] = "hyperspy_nexus_v3"
-        if 'compression' not in kwds:
-            kwds['compression'] = 'gzip'
+    with h5py.File(filename, mode="w") as f:
+        f.attrs["file_format"] = "nexus"
+        f.attrs["file_writer"] = "hyperspy_nexus_v3"
+        if "compression" not in kwds:
+            kwds["compression"] = "gzip"
         if use_default:
             f.attrs["default"] = "entry1"
         #
@@ -1273,9 +1331,9 @@ def file_writer(filename,
             nxentry = f.create_group(f"entry{i + 1}")
             nxentry.attrs["NX_class"] = _parse_to_file("NXentry")
 
-            signal_name = md.get('General.title')
+            signal_name = md.get("General.title")
             if not signal_name:
-                signal_name = f'unnamed__{i}'
+                signal_name = f"unnamed__{i}"
             if "/" in signal_name:
                 signal_name = signal_name.replace("/", "_")
             if signal_name.startswith("__"):
@@ -1288,9 +1346,9 @@ def file_writer(filename,
             nxaux.attrs["NX_class"] = _parse_to_file("NXentry")
             _write_signal(sig, nxentry, signal_name, **kwds)
 
-            learn = sig.get('learning_results')
+            learn = sig.get("learning_results")
             if learn:
-                nxlearn = nxaux.create_group('learning_results')
+                nxlearn = nxaux.create_group("learning_results")
                 nxlearn.attrs["NX_class"] = _parse_to_file("NXcollection")
                 _write_nexus_groups(learn, nxlearn, **kwds)
                 _write_nexus_attr(learn, nxlearn)
@@ -1298,17 +1356,17 @@ def file_writer(filename,
             # write metadata
             #
             if save_original_metadata:
-                om = sig.get('original_metadata')
+                om = sig.get("original_metadata")
                 if om:
-                    nxom = nxaux.create_group('original_metadata')
+                    nxom = nxaux.create_group("original_metadata")
                     nxom.attrs["NX_class"] = _parse_to_file("NXcollection")
                     # write the groups and structure
                     _write_nexus_groups(om, nxom, skip_keys=skip_metadata_key, **kwds)
-                    _write_nexus_attr(om, nxom,  skip_keys=skip_metadata_key)
+                    _write_nexus_attr(om, nxom, skip_keys=skip_metadata_key)
 
-            md = sig.get('metadata')
+            md = sig.get("metadata")
             if md:
-                nxmd = nxaux.create_group('hyperspy_metadata')
+                nxmd = nxaux.create_group("hyperspy_metadata")
                 nxmd.attrs["NX_class"] = _parse_to_file("NXcollection")
                 # write the groups and structure
                 _write_nexus_groups(md, nxmd, **kwds)

--- a/rsciio/phenom/api.py
+++ b/rsciio/phenom/api.py
@@ -47,73 +47,190 @@ import xml.etree.ElementTree as ET
 
 
 def element_symbol(z):
-    elements = ['',
-        'H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar',
-        'K', 'Ca', 'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 'Ge', 'As', 'Se', 'Br',
-        'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 'Te',
-        'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm',
-        'Yb', 'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn',
-        'Fr', 'Ra', 'Ac', 'Th', 'Pa', 'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 'No', 'Lr',
-        'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og']
+    elements = [
+        "",
+        "H",
+        "He",
+        "Li",
+        "Be",
+        "B",
+        "C",
+        "N",
+        "O",
+        "F",
+        "Ne",
+        "Na",
+        "Mg",
+        "Al",
+        "Si",
+        "P",
+        "S",
+        "Cl",
+        "Ar",
+        "K",
+        "Ca",
+        "Sc",
+        "Ti",
+        "V",
+        "Cr",
+        "Mn",
+        "Fe",
+        "Co",
+        "Ni",
+        "Cu",
+        "Zn",
+        "Ga",
+        "Ge",
+        "As",
+        "Se",
+        "Br",
+        "Kr",
+        "Rb",
+        "Sr",
+        "Y",
+        "Zr",
+        "Nb",
+        "Mo",
+        "Tc",
+        "Ru",
+        "Rh",
+        "Pd",
+        "Ag",
+        "Cd",
+        "In",
+        "Sn",
+        "Sb",
+        "Te",
+        "I",
+        "Xe",
+        "Cs",
+        "Ba",
+        "La",
+        "Ce",
+        "Pr",
+        "Nd",
+        "Pm",
+        "Sm",
+        "Eu",
+        "Gd",
+        "Tb",
+        "Dy",
+        "Ho",
+        "Er",
+        "Tm",
+        "Yb",
+        "Lu",
+        "Hf",
+        "Ta",
+        "W",
+        "Re",
+        "Os",
+        "Ir",
+        "Pt",
+        "Au",
+        "Hg",
+        "Tl",
+        "Pb",
+        "Bi",
+        "Po",
+        "At",
+        "Rn",
+        "Fr",
+        "Ra",
+        "Ac",
+        "Th",
+        "Pa",
+        "U",
+        "Np",
+        "Pu",
+        "Am",
+        "Cm",
+        "Bk",
+        "Cf",
+        "Es",
+        "Fm",
+        "Md",
+        "No",
+        "Lr",
+        "Rf",
+        "Db",
+        "Sg",
+        "Bh",
+        "Hs",
+        "Mt",
+        "Ds",
+        "Rg",
+        "Cn",
+        "Nh",
+        "Fl",
+        "Mc",
+        "Lv",
+        "Ts",
+        "Og",
+    ]
     if z < 1 or z >= len(elements):
-        raise Exception('Invalid atomic number')
+        raise Exception("Invalid atomic number")
     return elements[z]
 
+
 def family_symbol(i):
-    families = ['',	'K', 'L', 'M', 'N', 'O', 'P']
+    families = ["", "K", "L", "M", "N", "O", "P"]
     if i < 1 or i >= len(families):
-        raise Exception('Invalid atomic number')
+        raise Exception("Invalid atomic number")
     return families[i]
 
+
 def IsGZip(pathname):
-    with open(pathname, 'rb') as f:
-        (magic,) = struct.unpack('2s', f.read(2))
-    return magic == b'\x1f\x8b'
+    with open(pathname, "rb") as f:
+        (magic,) = struct.unpack("2s", f.read(2))
+    return magic == b"\x1f\x8b"
+
 
 def IsBZip2(pathname):
-    with open(pathname, 'rb') as f:
-        (magic, _, bytes) = struct.unpack('2s2s6s', f.read(10))
-    return magic == b'BZ' and bytes == b'\x31\x41\x59\x26\x53\x59'
+    with open(pathname, "rb") as f:
+        (magic, _, bytes) = struct.unpack("2s2s6s", f.read(10))
+    return magic == b"BZ" and bytes == b"\x31\x41\x59\x26\x53\x59"
 
 
 class ElidReader:
-
-    def __init__(self, pathname, block_size=1024*1024):
+    def __init__(self, pathname, block_size=1024 * 1024):
         if IsGZip(pathname):
-            raise Exception('pre EID 3.8 files are not supported')
+            raise Exception("pre EID 3.8 files are not supported")
         if not IsBZip2(pathname):
-            raise Exception('not an ELID file')
+            raise Exception("not an ELID file")
 
         self._pathname = pathname
-        self._file = open(pathname, 'rb')
+        self._file = open(pathname, "rb")
         self._decompressor = bz2.BZ2Decompressor()
         self._block_size = block_size
-        (id, version) = struct.unpack('<4si', self._read(8))
-        if id != b'EID2':
-            raise Exception('not an ELID file')
+        (id, version) = struct.unpack("<4si", self._read(8))
+        if id != b"EID2":
+            raise Exception("not an ELID file")
         if version > 2:
-            raise Exception('unsupported ELID format')
+            raise Exception("unsupported ELID format")
         self._version = version
         self.dictionaries = self._read_Project()
         self._file.close()
 
     def _read(self, size=1):
-        data = self._decompressor.decompress(b'', size)
+        data = self._decompressor.decompress(b"", size)
         while self._decompressor.needs_input:
-            data += self._decompressor.decompress(self._file.read(self._block_size), size - len(data))
+            data += self._decompressor.decompress(
+                self._file.read(self._block_size), size - len(data)
+            )
         return data
 
     def _read_bool(self):
-        return struct.unpack('?', self._read(1))[0]
+        return struct.unpack("?", self._read(1))[0]
 
     def _read_uint8(self):
-        return struct.unpack('B', self._read(1))[0]
+        return struct.unpack("B", self._read(1))[0]
 
     def _read_int32(self):
-        return struct.unpack('<i', self._read(4))[0]
+        return struct.unpack("<i", self._read(4))[0]
 
     def _read_uint32(self):
-        return struct.unpack('<I', self._read(4))[0]
+        return struct.unpack("<I", self._read(4))[0]
 
     def _read_string(self):
         n = self._read_uint32()
@@ -122,36 +239,35 @@ class ElidReader:
     def _get_unit_factor(self, unit):
         if len(unit) < 2:
             return 1
-        elif unit[0] == 'M':
-            return 1e+6
-        elif unit[0] == 'k':
-            return 1e+3
-        elif unit[0] == 'm':
+        elif unit[0] == "M":
+            return 1e6
+        elif unit[0] == "k":
+            return 1e3
+        elif unit[0] == "m":
             return 1e-3
-        elif unit[0] == 'u' or unit[0] == 'µ':
+        elif unit[0] == "u" or unit[0] == "µ":
             return 1e-6
-        elif unit[0] == 'n':
+        elif unit[0] == "n":
             return 1e-9
-        elif unit[0] == 'p':
+        elif unit[0] == "p":
             return 1e-12
         else:
-            raise Exception('Unknown unit: ' + unit)
+            raise Exception("Unknown unit: " + unit)
 
     def _get_value_with_unit(self, item):
         if isinstance(item, dict):
-            return float(item['value']) * self._get_unit_factor(item['unit'])
+            return float(item["value"]) * self._get_unit_factor(item["unit"])
         else:
             return float(item)
 
     def _read_tiff(self):
-
         def xml_element_to_dict(element):
             dict = {}
             if len(element) == 0:
                 if len(element.items()) > 0:
-                    dict[element.tag] = { 'value': element.text }
+                    dict[element.tag] = {"value": element.text}
                     for attrib, value in element.items():
-                        dict[element.tag].update({ attrib: value })
+                        dict[element.tag].update({attrib: value})
                 else:
                     dict[element.tag] = element.text
             else:
@@ -162,7 +278,7 @@ class ElidReader:
 
         def make_metadata_dict(xml):
             dict = xml_element_to_dict(ET.fromstring(xml))
-            return dict['FeiImage'] if dict else {}
+            return dict["FeiImage"] if dict else {}
 
         n = self._read_uint32()
         if n == 0:
@@ -173,12 +289,16 @@ class ElidReader:
             if len(data.shape) > 2:
                 # HyperSpy uses struct arrays to store RGB data
                 from rsciio.utils import rgb_tools
+
                 data = rgb_tools.regular_array2rgbx(data)
 
             tags = tiff.pages[0].tags
-            if 'FEI_TITAN' in tags:
-                metadata = make_metadata_dict(tags['FEI_TITAN'].value)
-                metadata['acquisition']['scan']['fieldSize'] = max(self._get_value_with_unit(metadata['pixelHeight']) * data.shape[0], self._get_value_with_unit(metadata['pixelWidth']) * data.shape[1])
+            if "FEI_TITAN" in tags:
+                metadata = make_metadata_dict(tags["FEI_TITAN"].value)
+                metadata["acquisition"]["scan"]["fieldSize"] = max(
+                    self._get_value_with_unit(metadata["pixelHeight"]) * data.shape[0],
+                    self._get_value_with_unit(metadata["pixelWidth"]) * data.shape[1],
+                )
             else:
                 metadata = {}
         return (metadata, data)
@@ -188,7 +308,7 @@ class ElidReader:
         return [self._read_int32() for _ in range(n)]
 
     def _read_float64(self):
-        return struct.unpack('<d', self._read(8))[0]
+        return struct.unpack("<d", self._read(8))[0]
 
     def _read_float64s(self):
         n = self._read_uint32()
@@ -222,7 +342,7 @@ class ElidReader:
         oxide = element_symbol(element)
         if num_element > 1:
             oxide += str(num_element)
-        oxide += 'O'
+        oxide += "O"
         if num_oxygen > 1:
             oxide += str(num_oxygen)
         return oxide
@@ -243,82 +363,90 @@ class ElidReader:
     def _read_drift_correction(self):
         dc = self._read_uint8()
         if dc == 1:
-            return 'on'
+            return "on"
         elif dc == 2:
-            return 'off'
+            return "off"
         else:
-            return 'unknown'
+            return "unknown"
 
     def _read_eds_metadata(self, om):
         metadata = {}
-        metadata['high_tension'] = self._read_float64()
+        metadata["high_tension"] = self._read_float64()
         detector_elevation = self._read_float64()
         if self._version == 0:
             detector_elevation = math.radians(detector_elevation)
-        metadata['detector_elevation'] = detector_elevation
-        metadata['detector_azimuth'] = self._read_float64()
-        metadata['live_time'] = self._read_float64()
-        metadata['real_time'] = self._read_float64()
-        metadata['slow_peaking_time'] = self._read_float64()
-        metadata['fast_peaking_time'] = self._read_float64()
-        metadata['detector_resolution'] = self._read_float64()
-        metadata['instrument_id'] = self._read_string()
-        if self._version == 0 and 'workingDistance' in om:
-            metadata['working_distance'] = self._get_value_with_unit(om['workingDistance'])
-            metadata['slow_peaking_time'] = 11.2e-6 if float(om['acquisition']['scan']['spotSize']) < 4.5 else 2e-6
-            metadata['fast_peaking_time'] = 100e-9;
-            metadata['detector_surface_area'] = 25e-6;
+        metadata["detector_elevation"] = detector_elevation
+        metadata["detector_azimuth"] = self._read_float64()
+        metadata["live_time"] = self._read_float64()
+        metadata["real_time"] = self._read_float64()
+        metadata["slow_peaking_time"] = self._read_float64()
+        metadata["fast_peaking_time"] = self._read_float64()
+        metadata["detector_resolution"] = self._read_float64()
+        metadata["instrument_id"] = self._read_string()
+        if self._version == 0 and "workingDistance" in om:
+            metadata["working_distance"] = self._get_value_with_unit(
+                om["workingDistance"]
+            )
+            metadata["slow_peaking_time"] = (
+                11.2e-6 if float(om["acquisition"]["scan"]["spotSize"]) < 4.5 else 2e-6
+            )
+            metadata["fast_peaking_time"] = 100e-9
+            metadata["detector_surface_area"] = 25e-6
         elif self._version > 0:
-            metadata['optical_working_distance'] = self._read_float64()
-            metadata['working_distance'] = self._read_float64()
-            metadata['detector_surface_area'] = self._read_float64()
-            metadata['detector_distance'] = self._read_float64()
-            metadata['sample_tilt_angle'] = self._read_float64()
+            metadata["optical_working_distance"] = self._read_float64()
+            metadata["working_distance"] = self._read_float64()
+            metadata["detector_surface_area"] = self._read_float64()
+            metadata["detector_distance"] = self._read_float64()
+            metadata["sample_tilt_angle"] = self._read_float64()
         return metadata
 
     def _read_CommonAnalysis(self, am):
         (metadata, cutout) = self._read_tiff()
         sum_spectrum = self._read_spectrum()
         eds_metadata = self._read_eds_metadata(am)
-        eds_metadata['offset'] = sum_spectrum[0]
-        eds_metadata['dispersion'] = sum_spectrum[1]
+        eds_metadata["offset"] = sum_spectrum[0]
+        eds_metadata["dispersion"] = sum_spectrum[1]
         data = sum_spectrum[2]
-        eds_metadata['included_elements'] = [element_symbol(z) for z in self._read_uint8s()]
-        eds_metadata['excluded_elements'] = [element_symbol(z) for z in self._read_uint8s()]
-        eds_metadata['background_fit_bins'] = self._read_int32s()
-        eds_metadata['selected_oxides'] = self._read_oxides()
-        eds_metadata['auto_id'] = self._read_bool()
-        eds_metadata['order_nr'] = self._read_int32()
-        eds_metadata['family_overrides'] = self._read_element_families()
+        eds_metadata["included_elements"] = [
+            element_symbol(z) for z in self._read_uint8s()
+        ]
+        eds_metadata["excluded_elements"] = [
+            element_symbol(z) for z in self._read_uint8s()
+        ]
+        eds_metadata["background_fit_bins"] = self._read_int32s()
+        eds_metadata["selected_oxides"] = self._read_oxides()
+        eds_metadata["auto_id"] = self._read_bool()
+        eds_metadata["order_nr"] = self._read_int32()
+        eds_metadata["family_overrides"] = self._read_element_families()
         if self._version >= 2:
-            eds_metadata['drift_correction'] = self._read_drift_correction()
+            eds_metadata["drift_correction"] = self._read_drift_correction()
         else:
-            eds_metadata['drift_correction'] = 'unknown'
+            eds_metadata["drift_correction"] = "unknown"
         if metadata:
-            metadata['acquisition']['scan']['detectors']['EDS'] = eds_metadata
+            metadata["acquisition"]["scan"]["detectors"]["EDS"] = eds_metadata
         else:
             metadata = {}
-            metadata.update({'acquisition': {'scan': {'detectors': {}}}})
-            metadata['acquisition']['scan']['detectors']['EDS'] = eds_metadata
+            metadata.update({"acquisition": {"scan": {"detectors": {}}}})
+            metadata["acquisition"]["scan"]["detectors"]["EDS"] = eds_metadata
         return (metadata, data)
 
     def _make_metadata_dict(self, signal_type=None, title="", datetime=None):
         metadata_dict = {
-            'General': {
-                'original_filename': os.path.split(self._pathname)[1],
-                'title': title
+            "General": {
+                "original_filename": os.path.split(self._pathname)[1],
+                "title": title,
             }
         }
         if signal_type:
-            metadata_dict['Signal'] = {
-                'signal_type': signal_type
-                }
+            metadata_dict["Signal"] = {"signal_type": signal_type}
         if datetime:
-            metadata_dict['General'].update({
-                'date': datetime[0],
-                'time': datetime[1],
-                'time_zone': self._get_local_time_zone()
-            })
+            metadata_dict["General"].update(
+                {
+                    "date": datetime[0],
+                    "time": datetime[1],
+                    "time_zone": self._get_local_time_zone(),
+                }
+            )
         return metadata_dict
 
     def _get_local_time_zone(self):
@@ -326,159 +454,211 @@ class ElidReader:
 
     def _make_mapping(self):
         return {
-            'acquisition.scan.detectors.EDS.detector_azimuth': ('Acquisition_instrument.SEM.Detector.EDS.azimuth_angle', lambda x: math.degrees(float(x))),
-            'acquisition.scan.detectors.EDS.detector_elevation': ('Acquisition_instrument.SEM.Detector.EDS.elevation_angle', lambda x: math.degrees(float(x))),
-            'acquisition.scan.detectors.EDS.detector_resolution': ('Acquisition_instrument.SEM.Detector.EDS.energy_resolution_MnKa', lambda x: float(x)),
-            'acquisition.scan.detectors.EDS.live_time': ('Acquisition_instrument.SEM.Detector.EDS.live_time', lambda x: float(x)),
-            'acquisition.scan.detectors.EDS.real_time': ('Acquisition_instrument.SEM.Detector.EDS.real_time', lambda x: float(x)),
-            'acquisition.scan.detectors.EDS.high_tension': ('Acquisition_instrument.SEM.beam_energy', lambda x: float(x) / 1e3),
-            'acquisition.scan.highVoltage.value': ('Acquisition_instrument.SEM.beam_energy', lambda x: -float(x)),
-            'instrument.uniqueID': ('Acquisition_instrument.SEM.microscope', lambda x: x),
-            'samplePosition.x': ('Acquisition_instrument.SEM.Stage.x', lambda x: float(x) / 1e-3),
-            'samplePosition.y': ('Acquisition_instrument.SEM.Stage.y', lambda x: float(x) / 1e-3),
-            'acquisition.scan.detectors.EDS.sample_tilt_angle': ('Acquisition_instrument.SEM.Stage.tilt_alpha', lambda x: math.degrees(float(x))),
-            'acquisition.scan.detectors.EDS.working_distance': ('Acquisition_instrument.SEM.working_distance', lambda x: float(x) / 1e-3)
+            "acquisition.scan.detectors.EDS.detector_azimuth": (
+                "Acquisition_instrument.SEM.Detector.EDS.azimuth_angle",
+                lambda x: math.degrees(float(x)),
+            ),
+            "acquisition.scan.detectors.EDS.detector_elevation": (
+                "Acquisition_instrument.SEM.Detector.EDS.elevation_angle",
+                lambda x: math.degrees(float(x)),
+            ),
+            "acquisition.scan.detectors.EDS.detector_resolution": (
+                "Acquisition_instrument.SEM.Detector.EDS.energy_resolution_MnKa",
+                lambda x: float(x),
+            ),
+            "acquisition.scan.detectors.EDS.live_time": (
+                "Acquisition_instrument.SEM.Detector.EDS.live_time",
+                lambda x: float(x),
+            ),
+            "acquisition.scan.detectors.EDS.real_time": (
+                "Acquisition_instrument.SEM.Detector.EDS.real_time",
+                lambda x: float(x),
+            ),
+            "acquisition.scan.detectors.EDS.high_tension": (
+                "Acquisition_instrument.SEM.beam_energy",
+                lambda x: float(x) / 1e3,
+            ),
+            "acquisition.scan.highVoltage.value": (
+                "Acquisition_instrument.SEM.beam_energy",
+                lambda x: -float(x),
+            ),
+            "instrument.uniqueID": (
+                "Acquisition_instrument.SEM.microscope",
+                lambda x: x,
+            ),
+            "samplePosition.x": (
+                "Acquisition_instrument.SEM.Stage.x",
+                lambda x: float(x) / 1e-3,
+            ),
+            "samplePosition.y": (
+                "Acquisition_instrument.SEM.Stage.y",
+                lambda x: float(x) / 1e-3,
+            ),
+            "acquisition.scan.detectors.EDS.sample_tilt_angle": (
+                "Acquisition_instrument.SEM.Stage.tilt_alpha",
+                lambda x: math.degrees(float(x)),
+            ),
+            "acquisition.scan.detectors.EDS.working_distance": (
+                "Acquisition_instrument.SEM.working_distance",
+                lambda x: float(x) / 1e-3,
+            ),
         }
 
     def _make_spot_spectrum_dict(self, om, offset, dispersion, data, title):
-        axes = [{
-            'name': 'Energy',
-            'offset': offset / 1e3,
-            'scale': dispersion / 1e3,
-            'size': len(data),
-            'units': 'keV',
-            'navigate': False}]
+        axes = [
+            {
+                "name": "Energy",
+                "offset": offset / 1e3,
+                "scale": dispersion / 1e3,
+                "size": len(data),
+                "units": "keV",
+                "navigate": False,
+            }
+        ]
         dict = {
-            'data': data,
-            'axes': axes,
-            'metadata': self._make_metadata_dict('EDS_SEM', title, self._get_datetime(om)),
-            'original_metadata': om,
-            'mapping': self._make_mapping()
+            "data": data,
+            "axes": axes,
+            "metadata": self._make_metadata_dict(
+                "EDS_SEM", title, self._get_datetime(om)
+            ),
+            "original_metadata": om,
+            "mapping": self._make_mapping(),
         }
         return dict
 
     def _get_datetime(self, metadata):
-        if 'time' in metadata:
-            return metadata['time'].split('T')
+        if "time" in metadata:
+            return metadata["time"].split("T")
 
     def _make_line_spectrum_dict(self, om, offset, dispersion, data, title):
         axes = [
-        {
-            'index_in_array': 0,
-            'name': 'i',
-            'offset': 0,
-            'scale': 1,
-            'size': data.shape[0],
-            'units': 'points',
-            'navigate': True
-        },
-        {
-            'index_in_array': 1,
-            'name': 'X-ray energy',
-            'offset': offset / 1e3,
-            'scale': dispersion / 1e3,
-            'size': data.shape[1],
-            'units': 'keV',
-            'navigate': False
-        }]
+            {
+                "index_in_array": 0,
+                "name": "i",
+                "offset": 0,
+                "scale": 1,
+                "size": data.shape[0],
+                "units": "points",
+                "navigate": True,
+            },
+            {
+                "index_in_array": 1,
+                "name": "X-ray energy",
+                "offset": offset / 1e3,
+                "scale": dispersion / 1e3,
+                "size": data.shape[1],
+                "units": "keV",
+                "navigate": False,
+            },
+        ]
         dict = {
-            'data': data,
-            'axes': axes,
-            'metadata': self._make_metadata_dict('EDS_SEM', title, self._get_datetime(om)),
-            'original_metadata': om,
-            'mapping': self._make_mapping()
+            "data": data,
+            "axes": axes,
+            "metadata": self._make_metadata_dict(
+                "EDS_SEM", title, self._get_datetime(om)
+            ),
+            "original_metadata": om,
+            "mapping": self._make_mapping(),
         }
         return dict
 
     def _get_unit(self, value):
         if value > 1:
-            return (1, '')
+            return (1, "")
         elif value > 1e-3:
-            return (1e-3, 'm')
+            return (1e-3, "m")
         elif value > 1e-6:
-            return (1e-6, 'µ')
+            return (1e-6, "µ")
         elif value > 1e-9:
-            return (1e-9, 'n')
+            return (1e-9, "n")
         else:
-            return (1, '')
+            return (1, "")
 
     def _make_map_spectrum_dict(self, om, offset, dispersion, data, title):
-        size = om['acquisition']['scan']['fieldSize'] * float(om['acquisition']['scan']['scanScale'])
+        size = om["acquisition"]["scan"]["fieldSize"] * float(
+            om["acquisition"]["scan"]["scanScale"]
+        )
         (scale, prefix) = self._get_unit(size)
-        unit = prefix + 'm'
+        unit = prefix + "m"
         size = size / scale
         axes = [
-        {
-            'index_in_array': 0,
-            'name': 'y',
-            'offset': 0,
-            'scale': size / data.shape[0],
-            'size': data.shape[0],
-            'units': unit,
-            'navigate': True
-        },
-        {
-            'index_in_array': 1,
-            'name': 'x',
-            'offset': 0,
-            'scale': size / data.shape[1],
-            'size': data.shape[1],
-            'units': unit,
-            'navigate': True
-        },
-        {
-            'index_in_array': 2,
-            'name': 'X-ray energy',
-            'offset': offset / 1e3,
-            'scale': dispersion / 1e3,
-            'size': data.shape[2],
-            'units': 'keV',
-            'navigate': False
-        }]
+            {
+                "index_in_array": 0,
+                "name": "y",
+                "offset": 0,
+                "scale": size / data.shape[0],
+                "size": data.shape[0],
+                "units": unit,
+                "navigate": True,
+            },
+            {
+                "index_in_array": 1,
+                "name": "x",
+                "offset": 0,
+                "scale": size / data.shape[1],
+                "size": data.shape[1],
+                "units": unit,
+                "navigate": True,
+            },
+            {
+                "index_in_array": 2,
+                "name": "X-ray energy",
+                "offset": offset / 1e3,
+                "scale": dispersion / 1e3,
+                "size": data.shape[2],
+                "units": "keV",
+                "navigate": False,
+            },
+        ]
         dict = {
-            'data': data,
-            'axes': axes,
-            'metadata': self._make_metadata_dict('EDS_SEM', title, self._get_datetime(om)),
-            'original_metadata': om,
-            'mapping': self._make_mapping()
+            "data": data,
+            "axes": axes,
+            "metadata": self._make_metadata_dict(
+                "EDS_SEM", title, self._get_datetime(om)
+            ),
+            "original_metadata": om,
+            "mapping": self._make_mapping(),
         }
         return dict
 
     def _make_image_dict(self, om, data, title):
         if om:
-            (scale, prefix) = self._get_unit(0.2 * om['acquisition']['scan']['fieldSize'])
-            scale_x = self._get_value_with_unit(om['pixelWidth']) / scale
-            scale_y = self._get_value_with_unit(om['pixelHeight']) / scale
-            unit = prefix + 'm'
+            (scale, prefix) = self._get_unit(
+                0.2 * om["acquisition"]["scan"]["fieldSize"]
+            )
+            scale_x = self._get_value_with_unit(om["pixelWidth"]) / scale
+            scale_y = self._get_value_with_unit(om["pixelHeight"]) / scale
+            unit = prefix + "m"
         else:
             scale_x = 1
             scale_y = 1
-            unit = 'points'
+            unit = "points"
         axes = [
-        {
-            'index_in_array': 0,
-            'name': 'y',
-            'offset': 0,
-            'scale': scale_y,
-            'size': data.shape[0],
-            'units': unit,
-            'navigate': True
-        },
-        {
-            'index_in_array': 1,
-            'name': 'x',
-            'offset': 0,
-            'scale': scale_x,
-            'size': data.shape[1],
-            'units': unit,
-            'navigate': True
-        }]
+            {
+                "index_in_array": 0,
+                "name": "y",
+                "offset": 0,
+                "scale": scale_y,
+                "size": data.shape[0],
+                "units": unit,
+                "navigate": True,
+            },
+            {
+                "index_in_array": 1,
+                "name": "x",
+                "offset": 0,
+                "scale": scale_x,
+                "size": data.shape[1],
+                "units": unit,
+                "navigate": True,
+            },
+        ]
         dict = {
-            'data': data,
-            'axes': axes,
-            'metadata': self._make_metadata_dict('', title, self._get_datetime(om)),
-            'original_metadata': om,
-            'mapping': self._make_mapping()
+            "data": data,
+            "axes": axes,
+            "metadata": self._make_metadata_dict("", title, self._get_datetime(om)),
+            "original_metadata": om,
+            "mapping": self._make_mapping(),
         }
         return dict
 
@@ -486,16 +666,37 @@ class ElidReader:
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
         original_metadata = copy.deepcopy(am)
         original_metadata.update(om)
-        return self._make_spot_spectrum_dict(original_metadata, om['acquisition']['scan']['detectors']['EDS']['offset'], om['acquisition']['scan']['detectors']['EDS']['dispersion'], np.array(sum_spectrum), '{}, MSA {}'.format(label, om['acquisition']['scan']['detectors']['EDS']['order_nr']))
+        return self._make_spot_spectrum_dict(
+            original_metadata,
+            om["acquisition"]["scan"]["detectors"]["EDS"]["offset"],
+            om["acquisition"]["scan"]["detectors"]["EDS"]["dispersion"],
+            np.array(sum_spectrum),
+            "{}, MSA {}".format(
+                label, om["acquisition"]["scan"]["detectors"]["EDS"]["order_nr"]
+            ),
+        )
 
     def _read_SpotAnalysis(self, label, am):
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
         x = self._read_float64()
         y = self._read_float64()
         original_metadata = copy.deepcopy(am)
-        original_metadata['acquisition']['scan']['detectors']['EDS'] = om['acquisition']['scan']['detectors']['EDS']
-        original_metadata['acquisition']['scan']['detectors']['EDS']['position'] = {'x': x, 'y': y}
-        return self._make_spot_spectrum_dict(original_metadata, om['acquisition']['scan']['detectors']['EDS']['offset'], om['acquisition']['scan']['detectors']['EDS']['dispersion'], np.array(sum_spectrum), '{}, Spot {}'.format(label, om['acquisition']['scan']['detectors']['EDS']['order_nr']))
+        original_metadata["acquisition"]["scan"]["detectors"]["EDS"] = om[
+            "acquisition"
+        ]["scan"]["detectors"]["EDS"]
+        original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["position"] = {
+            "x": x,
+            "y": y,
+        }
+        return self._make_spot_spectrum_dict(
+            original_metadata,
+            om["acquisition"]["scan"]["detectors"]["EDS"]["offset"],
+            om["acquisition"]["scan"]["detectors"]["EDS"]["dispersion"],
+            np.array(sum_spectrum),
+            "{}, Spot {}".format(
+                label, om["acquisition"]["scan"]["detectors"]["EDS"]["order_nr"]
+            ),
+        )
 
     def _read_LineScanAnalysis(self, label, am):
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
@@ -508,12 +709,16 @@ class ElidReader:
         offset = self._read_float64()
         dispersion = self._read_float64()
         eds_metadata = self._read_eds_metadata(am)
-        eds_metadata['live_time'] = om['acquisition']['scan']['detectors']['EDS']['live_time']
-        eds_metadata['real_time'] = om['acquisition']['scan']['detectors']['EDS']['real_time']
-        eds_metadata['begin'] = { 'x': x1, 'y': y1 }
-        eds_metadata['end'] = { 'x': x2, 'y': y2 }
-        eds_metadata['offset'] = offset
-        eds_metadata['dispersion'] = dispersion
+        eds_metadata["live_time"] = om["acquisition"]["scan"]["detectors"]["EDS"][
+            "live_time"
+        ]
+        eds_metadata["real_time"] = om["acquisition"]["scan"]["detectors"]["EDS"][
+            "real_time"
+        ]
+        eds_metadata["begin"] = {"x": x1, "y": y1}
+        eds_metadata["end"] = {"x": x2, "y": y2}
+        eds_metadata["offset"] = offset
+        eds_metadata["dispersion"] = dispersion
         has_variable_real_time = self._read_bool()
         has_variable_live_time = self._read_bool()
         data = np.empty([size, bins], dtype=np.uint32)
@@ -521,17 +726,29 @@ class ElidReader:
             for bin in range(bins):
                 data[i, bin] = self._read_varuint32()
         if has_variable_real_time:
-            eds_metadata['real_time_values'] = [self._read_float64() for _ in range(size)]
+            eds_metadata["real_time_values"] = [
+                self._read_float64() for _ in range(size)
+            ]
         else:
-            eds_metadata['real_time_values'] = [self._read_float64()] * size
+            eds_metadata["real_time_values"] = [self._read_float64()] * size
         if has_variable_live_time:
-            eds_metadata['live_time_values'] = [self._read_float64() for _ in range(size)]
+            eds_metadata["live_time_values"] = [
+                self._read_float64() for _ in range(size)
+            ]
         else:
-            eds_metadata['live_time_values'] = [self._read_float64()] * size
-        eds_metadata['high_accuracy_quantification'] = self._read_bool()
+            eds_metadata["live_time_values"] = [self._read_float64()] * size
+        eds_metadata["high_accuracy_quantification"] = self._read_bool()
         original_metadata = copy.deepcopy(am)
-        original_metadata['acquisition']['scan']['detectors']['EDS'] = eds_metadata
-        return self._make_line_spectrum_dict(original_metadata, om['acquisition']['scan']['detectors']['EDS']['offset'], om['acquisition']['scan']['detectors']['EDS']['dispersion'], data, '{}, Line {}'.format(label, om['acquisition']['scan']['detectors']['EDS']['order_nr']))
+        original_metadata["acquisition"]["scan"]["detectors"]["EDS"] = eds_metadata
+        return self._make_line_spectrum_dict(
+            original_metadata,
+            om["acquisition"]["scan"]["detectors"]["EDS"]["offset"],
+            om["acquisition"]["scan"]["detectors"]["EDS"]["dispersion"],
+            data,
+            "{}, Line {}".format(
+                label, om["acquisition"]["scan"]["detectors"]["EDS"]["order_nr"]
+            ),
+        )
 
     def _read_MapAnalysis(self, label, am):
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
@@ -547,9 +764,13 @@ class ElidReader:
         dispersion = self._read_float64()
         original_metadata = copy.deepcopy(am)
         eds_metadata = self._read_eds_metadata(am)
-        eds_metadata['live_time'] = om['acquisition']['scan']['detectors']['EDS']['live_time']
-        eds_metadata['real_time'] = om['acquisition']['scan']['detectors']['EDS']['real_time']
-        original_metadata['acquisition']['scan']['detectors']['EDS'] = eds_metadata
+        eds_metadata["live_time"] = om["acquisition"]["scan"]["detectors"]["EDS"][
+            "live_time"
+        ]
+        eds_metadata["real_time"] = om["acquisition"]["scan"]["detectors"]["EDS"][
+            "real_time"
+        ]
+        original_metadata["acquisition"]["scan"]["detectors"]["EDS"] = eds_metadata
         has_variable_real_time = self._read_bool()
         has_variable_live_time = self._read_bool()
         data = np.empty([height, width, bins], dtype=np.uint32)
@@ -562,26 +783,46 @@ class ElidReader:
             for y in range(height):
                 for x in range(width):
                     real_time_values[y, x] = self._read_float64()
-            eds_metadata['real_time_values'] = real_time_values
+            eds_metadata["real_time_values"] = real_time_values
         else:
-            eds_metadata['real_time_values'] = np.full([height, width], self._read_float64())
+            eds_metadata["real_time_values"] = np.full(
+                [height, width], self._read_float64()
+            )
         if has_variable_live_time:
             live_time_values = np.empty([height, width], dtype=float)
             for y in range(height):
                 for x in range(width):
                     live_time_values[y, x] = self._read_float64()
-            eds_metadata['live_time_values'] = live_time_values
+            eds_metadata["live_time_values"] = live_time_values
         else:
-            eds_metadata['live_time_values'] = np.full([height, width], self._read_float64())
-        return self._make_map_spectrum_dict(original_metadata, om['acquisition']['scan']['detectors']['EDS']['offset'], om['acquisition']['scan']['detectors']['EDS']['dispersion'], data, '{}, Map {}'.format(label, om['acquisition']['scan']['detectors']['EDS']['order_nr']))
+            eds_metadata["live_time_values"] = np.full(
+                [height, width], self._read_float64()
+            )
+        return self._make_map_spectrum_dict(
+            original_metadata,
+            om["acquisition"]["scan"]["detectors"]["EDS"]["offset"],
+            om["acquisition"]["scan"]["detectors"]["EDS"]["dispersion"],
+            data,
+            "{}, Map {}".format(
+                label, om["acquisition"]["scan"]["detectors"]["EDS"]["order_nr"]
+            ),
+        )
 
     def _read_DifferenceAnalysis(self, label, am):
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
         minuend = self._read_uint32()
         subtrahend = self._read_uint32()
         original_metadata = copy.deepcopy(am)
-        original_metadata['acquisition']['scan']['detectors']['EDS'] = om['acquisition']['scan']['detectors']['EDS']
-        return self._make_spot_spectrum_dict(original_metadata, om['acquisition']['scan']['detectors']['EDS']['offset'], om['acquisition']['scan']['detectors']['EDS']['dispersion'], np.array(sum_spectrum), '{}, Difference {} - {}'.format(label, minuend, subtrahend))
+        original_metadata["acquisition"]["scan"]["detectors"]["EDS"] = om[
+            "acquisition"
+        ]["scan"]["detectors"]["EDS"]
+        return self._make_spot_spectrum_dict(
+            original_metadata,
+            om["acquisition"]["scan"]["detectors"]["EDS"]["offset"],
+            om["acquisition"]["scan"]["detectors"]["EDS"]["dispersion"],
+            np.array(sum_spectrum),
+            "{}, Difference {} - {}".format(label, minuend, subtrahend),
+        )
 
     def _read_RegionAnalysis(self, label, am):
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
@@ -590,14 +831,24 @@ class ElidReader:
         right = self._read_float64()
         bottom = self._read_float64()
         original_metadata = copy.deepcopy(am)
-        original_metadata['acquisition']['scan']['detectors']['EDS'] = om['acquisition']['scan']['detectors']['EDS']
-        original_metadata['acquisition']['scan']['detectors']['EDS']['rectangle'] = {
-            'left': left,
-            'top': top,
-            'right': right,
-            'bottom': bottom
+        original_metadata["acquisition"]["scan"]["detectors"]["EDS"] = om[
+            "acquisition"
+        ]["scan"]["detectors"]["EDS"]
+        original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["rectangle"] = {
+            "left": left,
+            "top": top,
+            "right": right,
+            "bottom": bottom,
         }
-        return self._make_spot_spectrum_dict(original_metadata, om['acquisition']['scan']['detectors']['EDS']['offset'], om['acquisition']['scan']['detectors']['EDS']['dispersion'], np.array(sum_spectrum), '{}, Region {}'.format(label, om['acquisition']['scan']['detectors']['EDS']['order_nr']))
+        return self._make_spot_spectrum_dict(
+            original_metadata,
+            om["acquisition"]["scan"]["detectors"]["EDS"]["offset"],
+            om["acquisition"]["scan"]["detectors"]["EDS"]["dispersion"],
+            np.array(sum_spectrum),
+            "{}, Region {}".format(
+                label, om["acquisition"]["scan"]["detectors"]["EDS"]["order_nr"]
+            ),
+        )
 
     def _read_ConstructiveAnalysisSource(self):
         analysis_index = self._read_uint32()
@@ -615,7 +866,7 @@ class ElidReader:
 
     def _read_ConstructiveAnalyses(self):
         n = self._read_uint32()
-        return [self._read_ConstructiveAnalysis('', {}) for _ in range(n)]
+        return [self._read_ConstructiveAnalysis("", {}) for _ in range(n)]
 
     def _read_Analysis(self, label, am):
         type = self._read_uint8()
@@ -634,7 +885,7 @@ class ElidReader:
         elif type == 7:
             return self._read_ConstructiveAnalysis(label, am)
         else:
-            raise Exception('Unknown Analysis type')
+            raise Exception("Unknown Analysis type")
 
     def _read_Analyses(self, label, metadata):
         n = self._read_uint32()
@@ -659,7 +910,7 @@ class ElidReader:
     def _read_Project(self):
         dictionaries = self._read_Images()
         if self._version >= 1:
-            self._read_Analyses('', {})
+            self._read_Analyses("", {})
             self._read_ConstructiveAnalyses()
         return [dict for dict in dictionaries if dict]
 

--- a/rsciio/protochips/api.py
+++ b/rsciio/protochips/api.py
@@ -24,15 +24,16 @@ import warnings
 import logging
 
 
-
 _logger = logging.getLogger(__name__)
 
 
 # At some point, if there is another readerw, whith also use csv file, it will
 # be necessary to mention the other reader in this message (and to add an
 # argument in the load function to specify the correct reader)
-invalid_file_error = "The Protochips csv reader can't import the file, please"\
+invalid_file_error = (
+    "The Protochips csv reader can't import the file, please"
     " make sure, this is a valid Protochips log file."
+)
 
 
 def file_reader(filename, *args, **kwds):
@@ -51,16 +52,18 @@ def _protochips_log_reader(csv_file):
 
 
 class ProtochipsCSV(object):
-
-    def __init__(self, filename, ):
+    def __init__(
+        self,
+        filename,
+    ):
         self.filename = filename
         self._parse_header()
         self._read_data()
 
     def _parse_header(self):
-        with open(self.filename, 'r') as f:
+        with open(self.filename, "r") as f:
             s = f.readline()
-            self.column_name = s.replace(', ', ',').replace('\n', '').split(',')
+            self.column_name = s.replace(", ", ",").replace("\n", "").split(",")
             if not self._is_protochips_csv_file():
                 raise IOError(invalid_file_error)
             self._read_all_metadata_header(f)
@@ -68,139 +71,153 @@ class ProtochipsCSV(object):
 
     def _is_protochips_csv_file(self):
         # This check is not great, but it's better than nothing...
-        if 'Time' in self.column_name and 'Notes' in self.column_name and len(
-                self.column_name) >= 3:
+        if (
+            "Time" in self.column_name
+            and "Notes" in self.column_name
+            and len(self.column_name) >= 3
+        ):
             return True
         else:
             return False
 
     def get_dictionary(self, quantity):
-        return {'data': self._data_dictionary[quantity],
-                'axes': self._get_axes(),
-                'metadata': self._get_metadata(quantity),
-                'mapping': self._get_mapping(),
-                'original_metadata': {'Protochips_header':
-                                      self._get_original_metadata()}}
+        return {
+            "data": self._data_dictionary[quantity],
+            "axes": self._get_axes(),
+            "metadata": self._get_metadata(quantity),
+            "mapping": self._get_mapping(),
+            "original_metadata": {"Protochips_header": self._get_original_metadata()},
+        }
 
     def _get_original_metadata(self):
-        d = {'Start time': self.start_datetime}
-        d['Time units'] = self.time_units
+        d = {"Start time": self.start_datetime}
+        d["Time units"] = self.time_units
         for quantity in self.logged_quantity_name_list:
-            d['%s_units' % quantity] = self._parse_quantity_units(quantity)
+            d["%s_units" % quantity] = self._parse_quantity_units(quantity)
         if self.user:
-            d['User'] = self.user
-        d['Calibration file path'] = self._parse_calibration_filepath()
-        d['Time axis'] = self._get_metadata_time_axis()
+            d["User"] = self.user
+        d["Calibration file path"] = self._parse_calibration_filepath()
+        d["Time axis"] = self._get_metadata_time_axis()
         # Add the notes here, because there are not well formatted enough to
         # go in metadata
-        d['Original notes'] = self._parse_notes()
+        d["Original notes"] = self._parse_notes()
         return d
 
     def _get_metadata(self, quantity):
-        date, time = np.datetime_as_string(self.start_datetime).split('T')
-        return {'General': {'original_filename': os.path.split(self.filename)[1],
-                            'title': '%s (%s)' % (quantity,
-                                                  self._parse_quantity_units(quantity)),
-                            'date': date,
-                            'time': time},
-                "Signal": {'signal_type': '',
-                           'quantity': self._parse_quantity(quantity)}}
+        date, time = np.datetime_as_string(self.start_datetime).split("T")
+        return {
+            "General": {
+                "original_filename": os.path.split(self.filename)[1],
+                "title": "%s (%s)" % (quantity, self._parse_quantity_units(quantity)),
+                "date": date,
+                "time": time,
+            },
+            "Signal": {"signal_type": "", "quantity": self._parse_quantity(quantity)},
+        }
 
     def _get_mapping(self):
         mapping = {
             "Protochips_header.Calibration file path": (
                 "General.notes",
-                self._parse_calibration_file_name),
-            "Protochips_header.User": (
-                "General.authors",
-                None),
+                self._parse_calibration_file_name,
+            ),
+            "Protochips_header.User": ("General.authors", None),
         }
         return mapping
 
     def _get_metadata_time_axis(self):
-        return {'value': self.time_axis,
-                'units': self.time_units}
+        return {"value": self.time_axis, "units": self.time_units}
 
     def _read_data(self):
-        names = [name.replace(' ', '_') for name in self.column_name]
-        data = np.genfromtxt(self.filename, delimiter=',', dtype=None,
-                             names=names,
-                             skip_header=self.header_last_line_number,
-                             encoding='latin1')
+        names = [name.replace(" ", "_") for name in self.column_name]
+        data = np.genfromtxt(
+            self.filename,
+            delimiter=",",
+            dtype=None,
+            names=names,
+            skip_header=self.header_last_line_number,
+            encoding="latin1",
+        )
 
         self._data_dictionary = dict()
-        for i, name, name_dtype in zip(range(len(names)), self.column_name,
-                                       names):
-            if name == 'Notes':
+        for i, name, name_dtype in zip(range(len(names)), self.column_name, names):
+            if name == "Notes":
                 self.notes = data[name_dtype].astype(str)
-            elif name == 'Time':
+            elif name == "Time":
                 self.time_axis = data[name_dtype]
             else:
                 self._data_dictionary[name] = data[name_dtype]
 
     def _parse_notes(self):
         arr = np.vstack((self.time_axis, self.notes))
-        return np.compress(arr[1] != '', arr, axis=1)
+        return np.compress(arr[1] != "", arr, axis=1)
 
     def _parse_calibration_filepath(self):
-         # for the gas cell, the calibration is saved in the notes colunm
+        # for the gas cell, the calibration is saved in the notes colunm
         if hasattr(self, "calibration_file"):
             calibration_file = self.calibration_file
         else:
-            calibration_file = "The calibration files names are saved in the"\
+            calibration_file = (
+                "The calibration files names are saved in the"
                 " 'Original notes' array of the original metadata."
+            )
         return calibration_file
 
     def _parse_calibration_file_name(self, path):
         basename = os.path.basename(path)
-        return "Calibration file name: %s" % basename.split('\\')[-1]
+        return "Calibration file name: %s" % basename.split("\\")[-1]
 
     def _get_axes(self):
         scale = np.diff(self.time_axis[1:-1]).mean()
         max_diff = np.diff(self.time_axis[1:-1]).max()
-        units = 's'
+        units = "s"
         offset = 0
-        if self.time_units == 'Milliseconds':
+        if self.time_units == "Milliseconds":
             scale /= 1000
             max_diff /= 1000
             # Once we support non-uniform axis, don't forgot to update the
             # documentation of the protochips reader
-            _logger.warning("The time axis is not uniform, the time step is "
-                            "thus extrapolated to {0} {1}. The maximal step in time step is {2} {1}".format(
-                                scale, units, max_diff))
+            _logger.warning(
+                "The time axis is not uniform, the time step is "
+                "thus extrapolated to {0} {1}. The maximal step in time step is {2} {1}".format(
+                    scale, units, max_diff
+                )
+            )
         else:
             warnings.warn("Time units not recognised, assuming second.")
 
-        return [{'size': self.time_axis.shape[0],
-                 'index_in_array': 0,
-                 'name': 'Time',
-                 'scale': scale,
-                 'offset': offset,
-                 'units': units,
-                 'navigate': False
-                 }]
+        return [
+            {
+                "size": self.time_axis.shape[0],
+                "index_in_array": 0,
+                "name": "Time",
+                "scale": scale,
+                "offset": offset,
+                "units": units,
+                "navigate": False,
+            }
+        ]
 
     def _parse_quantity(self, quantity):
-        quantity_name = quantity.split(' ')[-1]
-        return '%s (%s)' % (quantity_name,
-                            self._parse_quantity_units(quantity))
+        quantity_name = quantity.split(" ")[-1]
+        return "%s (%s)" % (quantity_name, self._parse_quantity_units(quantity))
 
     def _parse_quantity_units(self, quantity):
-        quantity = quantity.split(' ')[-1].lower()
-        return self.__dict__['%s_units' % quantity]
+        quantity = quantity.split(" ")[-1].lower()
+        return self.__dict__["%s_units" % quantity]
 
     def _read_all_metadata_header(self, f):
         param, value = self._parse_metadata_header(f.readline())
         i = 2
-        while 'User' not in param:  # user should be the last of the header
-            if 'Calibration file' in param:
+        while "User" not in param:  # user should be the last of the header
+            if "Calibration file" in param:
                 self.calibration_file = value
-            elif 'Date (yyyy.mm.dd)' in param:
+            elif "Date (yyyy.mm.dd)" in param:
                 date = value
-            elif 'Time (hh:mm:ss.ms)' in param:
+            elif "Time (hh:mm:ss.ms)" in param:
                 time = value
             else:
-                attr_name = param.replace(' ', '_').lower()
+                attr_name = param.replace(" ", "_").lower()
                 self.__dict__[attr_name] = value
             i += 1
             try:
@@ -216,8 +233,9 @@ class ProtochipsCSV(object):
         else:
             self.user = value
         self.header_last_line_number = i
-        self.start_datetime = np.datetime64(dt.strptime(date + time,
-                                                        "%Y.%m.%d%H:%M:%S.%f"))
+        self.start_datetime = np.datetime64(
+            dt.strptime(date + time, "%Y.%m.%d%H:%M:%S.%f")
+        )
 
     def _parse_metadata_header(self, line):
-        return line.replace(', ', ',').split(',')[1].split(' = ')
+        return line.replace(", ", ",").split(",")[1].split(" = ")

--- a/rsciio/prz/api.py
+++ b/rsciio/prz/api.py
@@ -38,21 +38,25 @@ _logger = logging.getLogger(__name__)
 
 def file_reader(filename, **kwds):
     prz_file = np.load(filename, allow_pickle=True)
-    data = prz_file['data']
-    meta_data = prz_file['meta_data'][0]
+    data = prz_file["data"]
+    meta_data = prz_file["meta_data"][0]
     return import_pr(data, meta_data, filename)
 
 
 def file_writer(filename, signal, **kwds):
     data, meta_data = export_pr(signal=signal)
-    with open(filename, mode='wb') as f:
+    with open(filename, mode="wb") as f:
         # use open file to avoid numpy adding the npz extension
-        np.savez_compressed(file=f, data=data, meta_data=[meta_data],
-                            file_format_version=2, data_model=[{}]
-                            )
+        np.savez_compressed(
+            file=f,
+            data=data,
+            meta_data=[meta_data],
+            file_format_version=2,
+            data_model=[{}],
+        )
 
 
-def import_pr(data, meta_data, filename = None):
+def import_pr(data, meta_data, filename=None):
     """Converts metadata from PantaRhei to hyperspy format, and corrects
     the order of data axes if needed.
 
@@ -71,55 +75,64 @@ def import_pr(data, meta_data, filename = None):
     """
 
     data_dimensions = len(data.shape)
-    data_type = meta_data.get('type')
-    content_type = meta_data.get('content.types')
+    data_type = meta_data.get("type")
+    content_type = meta_data.get("content.types")
     calibrations = []
     for axis in range(data_dimensions):
         try:
-            calib = meta_data['device.calib'][axis]
+            calib = meta_data["device.calib"][axis]
         except (IndexError, KeyError):
             calib = None
         calibrations.append(calib)
 
     if content_type is None:
-        if data_type in ('Stack', '3D'):
-            content_type = [None, None, 'Index']
-        elif data_type == '1D' and data_dimensions == 3:
-            content_type = [None, 'PlotIndex', 'Index']
-        elif data_type == '1D':
-            content_type = [None, 'PlotIndex']
+        if data_type in ("Stack", "3D"):
+            content_type = [None, None, "Index"]
+        elif data_type == "1D" and data_dimensions == 3:
+            content_type = [None, "PlotIndex", "Index"]
+        elif data_type == "1D":
+            content_type = [None, "PlotIndex"]
         elif data_dimensions >= 3:
-            content_type = [None, None, ] + ['Index' for _ in range(data_dimensions-2)]
+            content_type = [
+                None,
+                None,
+            ] + ["Index" for _ in range(data_dimensions - 2)]
         else:
             content_type = [None for _ in range(data_dimensions)]
-    elif data_type == '1D':
+    elif data_type == "1D":
         if len(content_type) == 1 and data_dimensions == 2:
-            content_type = [None, 'PlotIndex']
+            content_type = [None, "PlotIndex"]
         elif len(content_type) == 2 and data_dimensions == 3:
-            content_type = [None, 'PlotIndex', 'Index']
+            content_type = [None, "PlotIndex", "Index"]
         elif len(content_type) != data_dimensions:
             raise Exception(
                 "Content type is not known for all dimensions "
                 f"{content_type}, {data.shape}."
-                )
+            )
 
-    navigation_dimensions = ['ScanY', 'ScanX', 'Index', 'PlotIndex']
-    signal_dimensions = ['CameraY', 'CameraX', 'Pixel', 'Energy', '*']
+    navigation_dimensions = ["ScanY", "ScanX", "Index", "PlotIndex"]
+    signal_dimensions = ["CameraY", "CameraX", "Pixel", "Energy", "*"]
 
     content_type_np_order = content_type[::-1]
     calibrations_np_order = calibrations[::-1]
     if len(content_type_np_order) != data_dimensions:  # pragma: no cover
-        raise RuntimeError("Unsupported file, please report the error in the "
-                           "the HyperSpy issue tracker.")
+        raise RuntimeError(
+            "Unsupported file, please report the error in the "
+            "the HyperSpy issue tracker."
+        )
 
-    trivial_indices = [i for i, _ in enumerate(content_type_np_order)
-                        if data.shape[i] == 1
-                        and 'Index' in content_type_np_order[i]]
+    trivial_indices = [
+        i
+        for i, _ in enumerate(content_type_np_order)
+        if data.shape[i] == 1 and "Index" in content_type_np_order[i]
+    ]
 
-    content_type_np_order = [c for i, c in enumerate(content_type_np_order)
-                                if i not in trivial_indices]
-    calibrations_np_order = [c for i, c in enumerate(calibrations_np_order)
-                                if i not in trivial_indices]
+    content_type_np_order = [
+        c for i, c in enumerate(content_type_np_order) if i not in trivial_indices
+    ]
+    calibrations_np_order = [
+        c for i, c in enumerate(calibrations_np_order) if i not in trivial_indices
+    ]
 
     data = np.squeeze(data, axis=tuple(trivial_indices))
 
@@ -130,36 +143,41 @@ def import_pr(data, meta_data, filename = None):
         else:
             return len(order)
 
-    new_order = sorted(range(len(content_type_np_order)),
-                        key=_navigation_first)
-    default_labels = reversed(['X','Y','Z'][:content_type_np_order.count(None)])
+    new_order = sorted(range(len(content_type_np_order)), key=_navigation_first)
+    default_labels = reversed(["X", "Y", "Z"][: content_type_np_order.count(None)])
 
-    data_labels = [content_type_np_order[i]
-                    if content_type_np_order[i] is not None
-                    else next(default_labels)
-                    for i in new_order]
+    data_labels = [
+        content_type_np_order[i]
+        if content_type_np_order[i] is not None
+        else next(default_labels)
+        for i in new_order
+    ]
     calibration_ordered = [calibrations_np_order[i] for i in new_order]
     data = np.moveaxis(data, new_order, list(range(len(content_type_np_order))))
 
     # TODO: Will have to be updated once CEOS adds selectable dispersion orientation
-    if meta_data.get('filter.mode') == 'EELS':
-        flip_axis = tuple(i for i, label in enumerate(data_labels) if label == 'Energy')
+    if meta_data.get("filter.mode") == "EELS":
+        flip_axis = tuple(i for i, label in enumerate(data_labels) if label == "Energy")
         if flip_axis:
             data = np.flip(data, flip_axis)
     else:
         flip_axis = ()
 
-    for key in ['content.types',
-                'user.calib',
-                'inherited.calib',
-                'device.calib', 'size', 'ref_size']:
+    for key in [
+        "content.types",
+        "user.calib",
+        "inherited.calib",
+        "device.calib",
+        "size",
+        "ref_size",
+    ]:
         if key in meta_data:
             assert isinstance(meta_data[key], (list, tuple))
             if isinstance(meta_data[key], list):
                 old_meta_data = meta_data[key].copy()
             else:
                 old_meta_data = meta_data[key]
-            if len(old_meta_data) == data.ndim+1:
+            if len(old_meta_data) == data.ndim + 1:
                 item_in_numpy_order = old_meta_data[-2::-1]
             else:
                 item_in_numpy_order = old_meta_data[::-1]
@@ -168,41 +186,45 @@ def import_pr(data, meta_data, filename = None):
                 try:
                     meta_data[key].append(item_in_numpy_order[new_order[i]])
                 except Exception as e:  # pragma: no cover
-                    raise Exception(f"Could not load meta data: {key} "
-                                    f"in hyperspy file: {e}.")
+                    raise Exception(
+                        f"Could not load meta data: {key} " f"in hyperspy file: {e}."
+                    )
     axes = []
     for i, (label, calib) in enumerate(zip(data_labels, calibration_ordered)):
-        ax = { 'navigate' : label in navigation_dimensions,
-                'name' : label,
-                'size' : data.shape[i],
-            }
+        ax = {
+            "navigate": label in navigation_dimensions,
+            "name": label,
+            "size": data.shape[i],
+        }
         if calib:
-            if 'unit' in calib:
-                ax['units'] = calib['unit']
-            if 'value' in calib:
-                ax['offset'] = calib['offset'] * calib['value']
+            if "unit" in calib:
+                ax["units"] = calib["unit"]
+            if "value" in calib:
+                ax["offset"] = calib["offset"] * calib["value"]
             else:
-                ax['offset'] = calib['offset']
-            if 'pixel_factor' in calib:
-                ax['scale'] = calib['value'] * calib['pixel_factor']
+                ax["offset"] = calib["offset"]
+            if "pixel_factor" in calib:
+                ax["scale"] = calib["value"] * calib["pixel_factor"]
             else:
-                ax['scale'] = calib['value']
+                ax["scale"] = calib["value"]
             if i in flip_axis:
                 # TODO: Will have to be updated once CEOS adds selectable dispersion orientation
-                new_offset = -(ax['offset'] + (data.shape[i]-1)*ax['scale'])
-                ax['offset'] = new_offset
+                new_offset = -(ax["offset"] + (data.shape[i] - 1) * ax["scale"])
+                ax["offset"] = new_offset
 
         axes.append(ax)
 
     mapped = _metadata_converter_in(meta_data, axes, filename)
 
     dictionary = {
-        'data': data,
-        'axes': axes,
-        'metadata': mapped.to_dict(),
-        'original_metadata': meta_data
+        "data": data,
+        "axes": axes,
+        "metadata": mapped.to_dict(),
+        "original_metadata": meta_data,
     }
-    file_data_list = [dictionary, ]
+    file_data_list = [
+        dictionary,
+    ]
 
     return file_data_list
 
@@ -227,14 +249,12 @@ def export_pr(signal):
     original_metadata = signal["original_metadata"]
     axes_info = signal["axes"]
     meta_data = _metadata_converter_out(metadata, original_metadata)
-    if 'ref_size' not in meta_data:
-        meta_data['ref_size'] = data.shape[::-1]
+    if "ref_size" not in meta_data:
+        meta_data["ref_size"] = data.shape[::-1]
 
-    ref_size = meta_data['ref_size'][::-1] #switch to numpy order
-    pixel_factors = [ref_size[i]/data.shape[i] for i in range(data.ndim)]
-    axes_meta_data = get_metadata_from_axes_info(
-        axes_info, pixel_factors=pixel_factors
-        )
+    ref_size = meta_data["ref_size"][::-1]  # switch to numpy order
+    pixel_factors = [ref_size[i] / data.shape[i] for i in range(data.ndim)]
+    axes_meta_data = get_metadata_from_axes_info(axes_info, pixel_factors=pixel_factors)
     for k in axes_meta_data:
         meta_data[k] = axes_meta_data[k]
     return data, meta_data
@@ -245,75 +265,80 @@ def _metadata_converter_in(meta_data, axes, filename):
 
     signal_dimensions = 0
     for ax in axes:
-        if ax['navigate'] == False :
+        if ax["navigate"] == False:
             signal_dimensions += 1
 
-    microscope_base_voltage = meta_data.get('electron_gun.voltage')
-    convergence_angle = meta_data.get('condenser.convergence_semi_angle')
-    collection_angle = meta_data.get('filter.collection_semi_angle')
+    microscope_base_voltage = meta_data.get("electron_gun.voltage")
+    convergence_angle = meta_data.get("condenser.convergence_semi_angle")
+    collection_angle = meta_data.get("filter.collection_semi_angle")
 
     if microscope_base_voltage:
-        total_voltage_shift = meta_data.get('filter.ht_offset', meta_data.get('electron_gun.voltage_offset', 0))
+        total_voltage_shift = meta_data.get(
+            "filter.ht_offset", meta_data.get("electron_gun.voltage_offset", 0)
+        )
         beam_energy_keV = (microscope_base_voltage + total_voltage_shift) / 1000
-        mapped.set_item('Acquisition_instrument.TEM.beam_energy', beam_energy_keV)
+        mapped.set_item("Acquisition_instrument.TEM.beam_energy", beam_energy_keV)
 
     if convergence_angle:
         convergence_angle_mrad = convergence_angle * 1e3
-        mapped.set_item('Acquisition_instrument.TEM.convergence_angle', convergence_angle_mrad)
+        mapped.set_item(
+            "Acquisition_instrument.TEM.convergence_angle", convergence_angle_mrad
+        )
 
     if collection_angle:
         collection_angle_mrad = collection_angle * 1e3
-        mapped.set_item('Acquisition_instrument.TEM.Detector.EELS.collection_angle', collection_angle_mrad)
+        mapped.set_item(
+            "Acquisition_instrument.TEM.Detector.EELS.collection_angle",
+            collection_angle_mrad,
+        )
 
-    if meta_data.get('filter.mode') == 'EELS' and signal_dimensions == 1 :
-        mapped.set_item('Signal.signal_type', 'EELS')
+    if meta_data.get("filter.mode") == "EELS" and signal_dimensions == 1:
+        mapped.set_item("Signal.signal_type", "EELS")
 
-    name = meta_data.get('repo_id').split('.')[0]
-    mapped.set_item('General.title', name)
+    name = meta_data.get("repo_id").split(".")[0]
+    mapped.set_item("General.title", name)
 
     if filename is not None:
-        mapped.set_item('General.original_filename',
-                        os.path.split(filename)[1])
+        mapped.set_item("General.original_filename", os.path.split(filename)[1])
 
-    if 'acquisition.time' in meta_data:
-        timestamp = meta_data['acquisition.time']
-    elif 'camera.time' in meta_data :
-        timestamp = meta_data['camera.time']
-    if 'timestamp' in locals():
+    if "acquisition.time" in meta_data:
+        timestamp = meta_data["acquisition.time"]
+    elif "camera.time" in meta_data:
+        timestamp = meta_data["camera.time"]
+    if "timestamp" in locals():
         timestamp = dt.fromisoformat(timestamp)
-        mapped.set_item('General.date', timestamp.date().isoformat())
-        mapped.set_item('General.time', timestamp.time().isoformat())
+        mapped.set_item("General.date", timestamp.date().isoformat())
+        mapped.set_item("General.time", timestamp.time().isoformat())
 
-    if 'filter.aperture' in meta_data:
-        aperture = meta_data['filter.aperture']
-        if 'mm' in aperture:
-            aperture = aperture.split('mm')[0]
+    if "filter.aperture" in meta_data:
+        aperture = meta_data["filter.aperture"]
+        if "mm" in aperture:
+            aperture = aperture.split("mm")[0]
             aperture = aperture.rstrip()
         mapped.set_item(
-            'Acquisition_instrument.TEM.Detector.EELS.aperture_size',
-            float(aperture)
-            )
+            "Acquisition_instrument.TEM.Detector.EELS.aperture_size", float(aperture)
+        )
 
-    source_type = meta_data.get('source.type')
+    source_type = meta_data.get("source.type")
 
-    if source_type == 'scan_generator':
-        acquisition_mode = 'STEM'
-        key = 'scan_driver'
-    elif source_type == 'camera':
-        acquisition_mode = 'TEM'
-        key = 'projector'
+    if source_type == "scan_generator":
+        acquisition_mode = "STEM"
+        key = "scan_driver"
+    elif source_type == "camera":
+        acquisition_mode = "TEM"
+        key = "projector"
     else:
         acquisition_mode = None
         key = None
-    magnification = meta_data.get(f'{key}.magnification')
-    camera_length = meta_data.get('projector.camera_length')
+    magnification = meta_data.get(f"{key}.magnification")
+    camera_length = meta_data.get("projector.camera_length")
 
     if acquisition_mode is not None:
-        mapped.set_item('Acquisition_instrument.TEM.acquisition_mode', acquisition_mode)
+        mapped.set_item("Acquisition_instrument.TEM.acquisition_mode", acquisition_mode)
     if magnification is not None:
-        mapped.set_item('Acquisition_instrument.TEM.magnification', magnification)
+        mapped.set_item("Acquisition_instrument.TEM.magnification", magnification)
     if camera_length is not None:
-        mapped.set_item('Acquisition_instrument.TEM.camera_length', camera_length)
+        mapped.set_item("Acquisition_instrument.TEM.camera_length", camera_length)
 
     return mapped
 
@@ -321,74 +346,71 @@ def _metadata_converter_in(meta_data, axes, filename):
 def _metadata_converter_out(metadata, original_metadata=None):
     metadata = DTBox(metadata, box_dots=True)
     original_metadata = DTBox(original_metadata, box_dots=True)
-    original_fname = metadata.get('General.original_filename', '')
+    original_fname = metadata.get("General.original_filename", "")
     original_extension = os.path.splitext(original_fname)[1]
-    if original_metadata.get('ref_size'):
+    if original_metadata.get("ref_size"):
         PR_metadata_present = True
 
-    if original_extension == '.prz' and PR_metadata_present:
+    if original_extension == ".prz" and PR_metadata_present:
         meta_data = original_metadata
-        meta_data['ref_size'] = meta_data['ref_size'][::-1]
-        for key in ['content.types',
-                    'user.calib',
-                    'inherited.calib',
-                    'device.calib']:
+        meta_data["ref_size"] = meta_data["ref_size"][::-1]
+        for key in ["content.types", "user.calib", "inherited.calib", "device.calib"]:
             if key in meta_data:
                 assert isinstance(meta_data[key], (list, tuple))
                 if isinstance(meta_data[key], list):
                     old_meta_data = meta_data[key].copy()
-                else :
+                else:
                     old_meta_data = meta_data[key]
                 meta_data[key] = old_meta_data[::-1]
 
     else:
         meta_data = {}
-        if metadata.get('Signal.signal_type') == 'EELS':
-            meta_data['filter.mode'] = 'EELS'
+        if metadata.get("Signal.signal_type") == "EELS":
+            meta_data["filter.mode"] = "EELS"
 
-        name = metadata.get('General.title')
+        name = metadata.get("General.title")
         if name is not None:
-            meta_data['repo_id'] = name + '.0'
+            meta_data["repo_id"] = name + ".0"
 
-        date = metadata.get('General.date')
-        time = metadata.get('General.time')
+        date = metadata.get("General.date")
+        time = metadata.get("General.time")
         if date is not None and time is not None:
-            timestamp = date + 'T' + time
-            meta_data['acquisition.time'] = timestamp
+            timestamp = date + "T" + time
+            meta_data["acquisition.time"] = timestamp
 
-        md_TEM = metadata.get('Acquisition_instrument.TEM')
+        md_TEM = metadata.get("Acquisition_instrument.TEM")
         if md_TEM is not None:
-            beam_energy = md_TEM.get('beam_energy')
-            convergence_angle = md_TEM.get('convergence_angle')
-            collection_angle = md_TEM.get('Detector.EELS.collection_angle')
-            aperture = md_TEM.get('Detector.EELS.aperture_size')
-            acquisition_mode = md_TEM.get('acquisition_mode')
-            magnification = md_TEM.get('magnification')
-            camera_length = md_TEM.get('camera_length')
+            beam_energy = md_TEM.get("beam_energy")
+            convergence_angle = md_TEM.get("convergence_angle")
+            collection_angle = md_TEM.get("Detector.EELS.collection_angle")
+            aperture = md_TEM.get("Detector.EELS.aperture_size")
+            acquisition_mode = md_TEM.get("acquisition_mode")
+            magnification = md_TEM.get("magnification")
+            camera_length = md_TEM.get("camera_length")
 
             if aperture is not None:
                 if type(aperture) in (float, int):
-                    aperture = str(aperture) + ' mm'
-                meta_data['filter.aperture'] = aperture
+                    aperture = str(aperture) + " mm"
+                meta_data["filter.aperture"] = aperture
             if beam_energy is not None:
-                beam_energy_ev = beam_energy*1e3
-                meta_data['electron_gun.voltage'] = beam_energy_ev
+                beam_energy_ev = beam_energy * 1e3
+                meta_data["electron_gun.voltage"] = beam_energy_ev
             if convergence_angle is not None:
                 convergence_angle_rad = convergence_angle / 1e3
-                meta_data['condenser.convergence_semi_angle'] = convergence_angle_rad
+                meta_data["condenser.convergence_semi_angle"] = convergence_angle_rad
             if collection_angle is not None:
                 collection_angle_rad = collection_angle / 1e3
-                meta_data['filter.collection_semi_angle'] = collection_angle_rad
+                meta_data["filter.collection_semi_angle"] = collection_angle_rad
             if camera_length is not None:
-                meta_data['projector.camera_length'] = camera_length
-            if acquisition_mode == 'STEM':
-                key = 'scan_driver'
-                meta_data['source.type'] = 'scan_generator'
+                meta_data["projector.camera_length"] = camera_length
+            if acquisition_mode == "STEM":
+                key = "scan_driver"
+                meta_data["source.type"] = "scan_generator"
             else:
-                key = 'projector'
-                meta_data['source.type'] = 'camera'
+                key = "projector"
+                meta_data["source.type"] = "camera"
             if magnification is not None:
-                meta_data[f'{key}.magnification'] = magnification
+                meta_data[f"{key}.magnification"] = magnification
 
     return meta_data
 
@@ -410,10 +432,12 @@ def get_metadata_from_axes_info(axes_info, pixel_factors=None):
         PRZ files. They are relevant for Panta Rhei's internal handling of calibrations.
 
     """
-    axis_name_to_content_type = {'Energy loss': 'Energy',
-                                 'Energy': 'Energy',
-                                 'ScanX': 'ScanY',
-                                 'ScanY': 'ScanX'}
+    axis_name_to_content_type = {
+        "Energy loss": "Energy",
+        "Energy": "Energy",
+        "ScanX": "ScanY",
+        "ScanY": "ScanX",
+    }
     nr_axes = len(axes_info)
     imported_calibs = [None] * nr_axes
     content_types = [None] * nr_axes
@@ -422,16 +446,14 @@ def get_metadata_from_axes_info(axes_info, pixel_factors=None):
         # Add content types if axes names are known.
         axis_info = axes_info[i]
         axis_label = None
-        if 'name' in axis_info: # name is not always present
-            axis_label = axis_info['name']
+        if "name" in axis_info:  # name is not always present
+            axis_label = axis_info["name"]
 
         if axis_label in axis_name_to_content_type:
             content_types[i] = axis_name_to_content_type[axis_label]
 
-        imported_calib_dict = {'scale': None,
-                               'offset': None,
-                               'units': None}
-        for key in ('scale', 'offset', 'units'):
+        imported_calib_dict = {"scale": None, "offset": None, "units": None}
+        for key in ("scale", "offset", "units"):
             if key in axis_info:
                 imported_calib_dict[key] = axis_info[key]
         # If any part of a calibration is given
@@ -440,45 +462,44 @@ def get_metadata_from_axes_info(axes_info, pixel_factors=None):
         if any([v for k, v in imported_calib_dict.items()]):
             calib = {}
 
-            if imported_calib_dict['scale'] is not None:
-                calib['value'] = imported_calib_dict['scale']
+            if imported_calib_dict["scale"] is not None:
+                calib["value"] = imported_calib_dict["scale"]
                 # Apply pixel factor as calculated from meta data.
                 if pixel_factors:
-                    calib['value'] /= pixel_factors[i]
-            if imported_calib_dict['offset'] is not None:
-                calib['offset'] = imported_calib_dict['offset']
+                    calib["value"] /= pixel_factors[i]
+            if imported_calib_dict["offset"] is not None:
+                calib["offset"] = imported_calib_dict["offset"]
 
                 # PR expects offset in image pixels
                 # not in calibrated values.
-                calib['offset'] = calib['offset'] / calib['value']
-            if imported_calib_dict['units'] is not None:
-                imported_unit = imported_calib_dict['units']
+                calib["offset"] = calib["offset"] / calib["value"]
+            if imported_calib_dict["units"] is not None:
+                imported_unit = imported_calib_dict["units"]
                 # unit may be in SI unit *with* prefix
-                allowed_base_units = ['m', 'A', 'V', 'rad', 's', 'eV']
-                calib['value'], calib['unit'] = _guess_from_unit(
-                    calib['value'], imported_unit,
-                    allowed_base_units=allowed_base_units)
-                if calib['unit'] in allowed_base_units:
-                    calib['use_prefix'] = True
+                allowed_base_units = ["m", "A", "V", "rad", "s", "eV"]
+                calib["value"], calib["unit"] = _guess_from_unit(
+                    calib["value"], imported_unit, allowed_base_units=allowed_base_units
+                )
+                if calib["unit"] in allowed_base_units:
+                    calib["use_prefix"] = True
 
-            imported_calibs[i] = calib#['as_dict()
+            imported_calibs[i] = calib  # ['as_dict()
         # Get information whether axis is navigate axis
         # (which means 'display axis' in our terms).
-        if 'navigate' in axis_info:
-            navigate_axes[i] = axis_info['navigate']
-        display_axes = [i for i, is_display
-                        in enumerate(navigate_axes) if is_display]
+        if "navigate" in axis_info:
+            navigate_axes[i] = axis_info["navigate"]
+        display_axes = [i for i, is_display in enumerate(navigate_axes) if is_display]
     axes_meta_data = {}
     # Calibrations and content types must be in reversed order,
     # because hyperspy uses numpy order,
     # while PR expects image order.
     if any(imported_calibs):
-        axes_meta_data['inherited.calib'] = imported_calibs[::-1]
+        axes_meta_data["inherited.calib"] = imported_calibs[::-1]
     if any(content_types):
-        axes_meta_data['content.types'] = content_types[::-1]
+        axes_meta_data["content.types"] = content_types[::-1]
     else:
         if len([nav for nav in navigate_axes if not nav]) == 1:
-            axes_meta_data['type'] = '1D'
+            axes_meta_data["type"] = "1D"
 
     if display_axes:
         # Only add display axes tag, if not all axes are displayed
@@ -487,7 +508,7 @@ def get_metadata_from_axes_info(axes_info, pixel_factors=None):
         # because using plots as navigation tool for cubes
         # is currently not supported.
         if nr_axes > len(display_axes) and len(display_axes) > 1:
-            axes_meta_data['display_axes'] = tuple(display_axes[::-1])
+            axes_meta_data["display_axes"] = tuple(display_axes[::-1])
 
     return axes_meta_data
 
@@ -514,7 +535,7 @@ def _guess_from_unit(scale, unit, allowed_base_units=None):
     the base unit without the prefix
 
     """
-    prefixes = {'m': 1e-3, 'u': 1e-6, 'µ': 1e-6, 'n': 1e-9, 'p': 1e-12}
+    prefixes = {"m": 1e-3, "u": 1e-6, "µ": 1e-6, "n": 1e-9, "p": 1e-12}
     if isinstance(unit, str) and len(unit) > 1 and unit[0] in prefixes:
         if allowed_base_units is None or (unit[1:] in allowed_base_units):
             scale *= prefixes[unit[0]]

--- a/rsciio/ripple/api.py
+++ b/rsciio/ripple/api.py
@@ -36,84 +36,80 @@ _logger = logging.getLogger(__name__)
 
 file_extensions = ("rpl", "RPL")
 # The format only support the followng data types
-newline = ('\n', '\r\n')
-comment = ';'
-sep = '\t'
+newline = ("\n", "\r\n")
+comment = ";"
+sep = "\t"
 
 dtype2keys = {
-    'float64': ('float', 8),
-    'float32': ('float', 4),
-    'uint8': ('unsigned', 1),
-    'uint16': ('unsigned', 2),
-    'int32': ('signed', 4),
-    'int64': ('signed', 8), }
+    "float64": ("float", 8),
+    "float32": ("float", 4),
+    "uint8": ("unsigned", 1),
+    "uint16": ("unsigned", 2),
+    "int32": ("signed", 4),
+    "int64": ("signed", 8),
+}
 
-endianess2rpl = {
-    '=': 'dont-care',
-    '<': 'little-endian',
-    '>': 'big-endian'}
+endianess2rpl = {"=": "dont-care", "<": "little-endian", ">": "big-endian"}
 
 # Warning: for selection lists use tuples not lists.
 rpl_keys = {
     # spectrum/image keys
-    'width': int,
-    'height': int,
-    'depth': int,
-    'offset': int,
-    'data-length': ('1', '2', '4', '8'),
-    'data-type': ('signed', 'unsigned', 'float'),
-    'byte-order': ('little-endian', 'big-endian', 'dont-care'),
-    'record-by': ('image', 'vector', 'dont-care'),
+    "width": int,
+    "height": int,
+    "depth": int,
+    "offset": int,
+    "data-length": ("1", "2", "4", "8"),
+    "data-type": ("signed", "unsigned", "float"),
+    "byte-order": ("little-endian", "big-endian", "dont-care"),
+    "record-by": ("image", "vector", "dont-care"),
     # X-ray keys
-    'ev-per-chan': float,    # usually 5 or 10 eV
-    'detector-peak-width-ev': float,  # usually 150 eV
+    "ev-per-chan": float,  # usually 5 or 10 eV
+    "detector-peak-width-ev": float,  # usually 150 eV
     # HyperSpy-specific keys
-    'depth-origin': float,
-    'depth-scale': float,
-    'depth-units': str,
-    'width-origin': float,
-    'width-scale': float,
-    'width-units': str,
-    'height-origin': float,
-    'height-scale': float,
-    'height-units': str,
-    'signal': str,
+    "depth-origin": float,
+    "depth-scale": float,
+    "depth-units": str,
+    "width-origin": float,
+    "width-scale": float,
+    "width-units": str,
+    "height-origin": float,
+    "height-scale": float,
+    "height-units": str,
+    "signal": str,
     # EELS HyperSpy keys
-    'collection-angle': float,
+    "collection-angle": float,
     # TEM HyperSpy keys
-    'convergence-angle': float,
-    'beam-energy': float,
+    "convergence-angle": float,
+    "beam-energy": float,
     # EDS HyperSpy keys
-    'elevation-angle': float,
-    'azimuth-angle': float,
-    'live-time': float,
+    "elevation-angle": float,
+    "azimuth-angle": float,
+    "live-time": float,
     # From 0.8.5 energy-resolution is deprecated as it is a duplicate of
     # detector-peak-width-ev of the ripple standard format. We keep it here
     # to keep compatibility with rpl file written by HyperSpy < 0.8.4
-    'energy-resolution': float,
-    'tilt-stage': float,
-    'date': str,
-    'time': str,
-    'title': str,
+    "energy-resolution": float,
+    "tilt-stage": float,
+    "date": str,
+    "time": str,
+    "title": str,
 }
 
 
 def correct_INCA_format(fp):
     fp_list = list()
     fp.seek(0)
-    if '(' in fp.readline():
+    if "(" in fp.readline():
         for line in fp:
-            line = line.replace(
-                "(MLX::",
-                "").replace(
-                " : ",
-                "\t").replace(
-                " :",
-                "\t").replace(
-                " ",
-                "\t").lower().strip().replace(
-                ")",
-                "\n")
+            line = (
+                line.replace("(MLX::", "")
+                .replace(" : ", "\t")
+                .replace(" :", "\t")
+                .replace(" ", "\t")
+                .lower()
+                .strip()
+                .replace(")", "\n")
+            )
             if "record-by" in line:
                 if "image" in line:
                     line = "record-by\timage"
@@ -138,11 +134,11 @@ def parse_ripple(fp):
     rpl_info = {}
     for line in fp.readlines():
         # correct_brucker_format
-        line = line.replace('data-Length', 'data-length')
+        line = line.replace("data-Length", "data-length")
         if line[:2] not in newline and line[0] != comment:
-            line = line.strip('\r\n')
+            line = line.strip("\r\n")
             if comment in line:
-                line = line[:line.find(comment)]
+                line = line[: line.find(comment)]
             if sep not in line:
                 err = 'Separator in line "%s" is wrong, ' % line
                 err += 'it should be a <TAB> ("\\t")'
@@ -152,11 +148,12 @@ def parse_ripple(fp):
                 value_type = rpl_keys[line[0]]
                 if isinstance(value_type, tuple):  # is selection list
                     if line[1] not in value_type:
-                        err = \
-                            'Wrong value for key %s.\n' \
-                            'Value read is %s'  \
-                            ' but it should be one of %s' % \
-                            (line[0], line[1], str(value_type))
+                        err = (
+                            "Wrong value for key %s.\n"
+                            "Value read is %s"
+                            " but it should be one of %s"
+                            % (line[0], line[1], str(value_type))
+                        )
                         raise IOError(err)
                 else:
                     # rpl_keys[line[0]] must then be a type
@@ -164,27 +161,26 @@ def parse_ripple(fp):
 
             rpl_info[line[0]] = line[1]
 
-    if rpl_info['depth'] == 1 and rpl_info['record-by'] != 'dont-care':
+    if rpl_info["depth"] == 1 and rpl_info["record-by"] != "dont-care":
         err = '"depth" and "record-by" keys mismatch.\n'
         err += '"depth" cannot be "1" if "record-by" is "dont-care" '
-        err += 'and vice versa.'
-        err += 'Check %s' % fp.name
+        err += "and vice versa."
+        err += "Check %s" % fp.name
         raise IOError(err)
-    if rpl_info['data-type'] == 'float' and int(rpl_info['data-length']) < 4:
+    if rpl_info["data-type"] == "float" and int(rpl_info["data-length"]) < 4:
         err = '"data-length" for float "data-type" must be "4" or "8".\n'
-        err += 'Check %s' % fp.name
+        err += "Check %s" % fp.name
         raise IOError(err)
-    if (rpl_info['data-length'] == '1' and
-            rpl_info['byte-order'] != 'dont-care'):
+    if rpl_info["data-length"] == "1" and rpl_info["byte-order"] != "dont-care":
         err = '"data-length" and "byte-order" mismatch.\n'
         err += '"data-length" cannot be "1" if "byte-order" is not "dont-care"'
-        err += ' and vice versa.'
-        err += 'Check %s' % fp.name
+        err += " and vice versa."
+        err += "Check %s" % fp.name
         raise IOError(err)
     return rpl_info
 
 
-def read_raw(rpl_info, fp, mmap_mode='c'):
+def read_raw(rpl_info, fp, mmap_mode="c"):
     """Read the raw file object 'fp' based on the information given in the
     'rpl_info' dictionary.
 
@@ -205,54 +201,52 @@ def read_raw(rpl_info, fp, mmap_mode='c'):
 
 
     """
-    width = rpl_info['width']
-    height = rpl_info['height']
-    depth = rpl_info['depth']
-    offset = rpl_info['offset']
-    data_length = rpl_info['data-length']
-    data_type = rpl_info['data-type']
-    endian = rpl_info['byte-order']
-    record_by = rpl_info['record-by']
+    width = rpl_info["width"]
+    height = rpl_info["height"]
+    depth = rpl_info["depth"]
+    offset = rpl_info["offset"]
+    data_length = rpl_info["data-length"]
+    data_type = rpl_info["data-type"]
+    endian = rpl_info["byte-order"]
+    record_by = rpl_info["record-by"]
 
-    if data_type == 'signed':
-        data_type = 'int'
-    elif data_type == 'unsigned':
-        data_type = 'uint'
-    elif data_type == 'float':
+    if data_type == "signed":
+        data_type = "int"
+    elif data_type == "unsigned":
+        data_type = "uint"
+    elif data_type == "float":
         pass
     else:
         raise TypeError('Unknown "data-type" string.')
 
-    if endian == 'big-endian':
-        endian = '>'
-    elif endian == 'little-endian':
-        endian = '<'
+    if endian == "big-endian":
+        endian = ">"
+    elif endian == "little-endian":
+        endian = "<"
     else:
-        endian = '='
+        endian = "="
 
     data_type += str(int(data_length) * 8)
     data_type = np.dtype(data_type)
     data_type = data_type.newbyteorder(endian)
 
-    data = np.memmap(fp,
-                     offset=offset,
-                     dtype=data_type,
-                     mode=mmap_mode)
+    data = np.memmap(fp, offset=offset, dtype=data_type, mode=mmap_mode)
 
-    if record_by == 'vector':   # spectral image
+    if record_by == "vector":  # spectral image
         size = (height, width, depth)
         data = data.reshape(size)
-    elif record_by == 'image':  # stack of images
+    elif record_by == "image":  # stack of images
         size = (depth, height, width)
         data = data.reshape(size)
-    elif record_by == 'dont-care':  # stack of images
+    elif record_by == "dont-care":  # stack of images
         size = (height, width)
         data = data.reshape(size)
     return data
 
 
-def file_reader(filename, rpl_info=None, encoding="latin-1",
-                mmap_mode='c', *args, **kwds):
+def file_reader(
+    filename, rpl_info=None, encoding="latin-1", mmap_mode="c", *args, **kwds
+):
     """Parses a Lispix (https://www.nist.gov/services-resources/software/lispix) ripple (.rpl) file
     and reads the data from the corresponding raw (.raw) file;
     or, read a raw file if the dictionary rpl_info is provided.
@@ -360,303 +354,324 @@ def file_reader(filename, rpl_info=None, encoding="latin-1",
 
     if not rpl_info:
         if filename[-3:] in file_extensions:
-            with codecs.open(filename, encoding=encoding,
-                             errors='replace') as f:
+            with codecs.open(filename, encoding=encoding, errors="replace") as f:
                 rpl_info = parse_ripple(f)
         else:
             raise IOError('File has wrong extension: "%s"' % filename[-3:])
-    for ext in ['raw', 'RAW']:
+    for ext in ["raw", "RAW"]:
         rawfname = filename[:-3] + ext
         if os.path.exists(rawfname):
             break
         else:
-            rawfname = ''
+            rawfname = ""
     if not rawfname:
         raise IOError('RAW file "%s" does not exists' % rawfname)
     else:
-        lazy = kwds.pop('lazy', False)
+        lazy = kwds.pop("lazy", False)
         if lazy:
-            mmap_mode = 'r'
+            mmap_mode = "r"
         data = read_raw(rpl_info, rawfname, mmap_mode=mmap_mode)
 
-    if rpl_info['record-by'] == 'vector':
-        _logger.info('Loading as Signal1D')
-        record_by = 'spectrum'
-    elif rpl_info['record-by'] == 'image':
-        _logger.info('Loading as Signal2D')
-        record_by = 'image'
+    if rpl_info["record-by"] == "vector":
+        _logger.info("Loading as Signal1D")
+        record_by = "spectrum"
+    elif rpl_info["record-by"] == "image":
+        _logger.info("Loading as Signal2D")
+        record_by = "image"
     else:
         if len(data.shape) == 1:
-            _logger.info('Loading as Signal1D')
-            record_by = 'spectrum'
+            _logger.info("Loading as Signal1D")
+            record_by = "spectrum"
         else:
-            _logger.info('Loading as Signal2D')
-            record_by = 'image'
+            _logger.info("Loading as Signal2D")
+            record_by = "image"
 
-    if rpl_info['record-by'] == 'vector':
+    if rpl_info["record-by"] == "vector":
         idepth, iheight, iwidth = 2, 0, 1
-        names = ['height', 'width', 'depth', ]
+        names = [
+            "height",
+            "width",
+            "depth",
+        ]
     else:
         idepth, iheight, iwidth = 0, 1, 2
-        names = ['depth', 'height', 'width']
+        names = ["depth", "height", "width"]
 
     scales = [1, 1, 1]
     origins = [0, 0, 0]
-    units = ['', '', '']
+    units = ["", "", ""]
     sizes = [rpl_info[names[i]] for i in range(3)]
 
-    if 'date' not in rpl_info:
-        rpl_info['date'] = ""
+    if "date" not in rpl_info:
+        rpl_info["date"] = ""
 
-    if 'time' not in rpl_info:
-        rpl_info['time'] = ""
+    if "time" not in rpl_info:
+        rpl_info["time"] = ""
 
-    if 'signal' not in rpl_info:
-        rpl_info['signal'] = ""
+    if "signal" not in rpl_info:
+        rpl_info["signal"] = ""
 
-    if 'title' not in rpl_info:
-        rpl_info['title'] = ""
+    if "title" not in rpl_info:
+        rpl_info["title"] = ""
 
-    if 'depth-scale' in rpl_info:
-        scales[idepth] = rpl_info['depth-scale']
+    if "depth-scale" in rpl_info:
+        scales[idepth] = rpl_info["depth-scale"]
     # ev-per-chan is the only calibration supported by the original ripple
     # format
-    elif 'ev-per-chan' in rpl_info:
-        scales[idepth] = rpl_info['ev-per-chan']
+    elif "ev-per-chan" in rpl_info:
+        scales[idepth] = rpl_info["ev-per-chan"]
 
-    if 'depth-origin' in rpl_info:
-        origins[idepth] = rpl_info['depth-origin']
+    if "depth-origin" in rpl_info:
+        origins[idepth] = rpl_info["depth-origin"]
 
-    if 'depth-units' in rpl_info:
-        units[idepth] = rpl_info['depth-units']
+    if "depth-units" in rpl_info:
+        units[idepth] = rpl_info["depth-units"]
 
-    if 'depth-name' in rpl_info:
-        names[idepth] = rpl_info['depth-name']
+    if "depth-name" in rpl_info:
+        names[idepth] = rpl_info["depth-name"]
 
-    if 'width-origin' in rpl_info:
-        origins[iwidth] = rpl_info['width-origin']
+    if "width-origin" in rpl_info:
+        origins[iwidth] = rpl_info["width-origin"]
 
-    if 'width-scale' in rpl_info:
-        scales[iwidth] = rpl_info['width-scale']
+    if "width-scale" in rpl_info:
+        scales[iwidth] = rpl_info["width-scale"]
 
-    if 'width-units' in rpl_info:
-        units[iwidth] = rpl_info['width-units']
+    if "width-units" in rpl_info:
+        units[iwidth] = rpl_info["width-units"]
 
-    if 'width-name' in rpl_info:
-        names[iwidth] = rpl_info['width-name']
+    if "width-name" in rpl_info:
+        names[iwidth] = rpl_info["width-name"]
 
-    if 'height-origin' in rpl_info:
-        origins[iheight] = rpl_info['height-origin']
+    if "height-origin" in rpl_info:
+        origins[iheight] = rpl_info["height-origin"]
 
-    if 'height-scale' in rpl_info:
-        scales[iheight] = rpl_info['height-scale']
+    if "height-scale" in rpl_info:
+        scales[iheight] = rpl_info["height-scale"]
 
-    if 'height-units' in rpl_info:
-        units[iheight] = rpl_info['height-units']
+    if "height-units" in rpl_info:
+        units[iheight] = rpl_info["height-units"]
 
-    if 'height-name' in rpl_info:
-        names[iheight] = rpl_info['height-name']
+    if "height-name" in rpl_info:
+        names[iheight] = rpl_info["height-name"]
 
-    mp = DTBox({
-        'General': {'original_filename': os.path.split(filename)[1],
-                    'date': rpl_info['date'],
-                    'time': rpl_info['time'],
-                    'title': rpl_info['title']
-                    },
-        "Signal": {'signal_type': rpl_info['signal'],
-                   'record_by': record_by},
-    }, box_dots=True)
-    if 'convergence-angle' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.convergence_angle',
-                    rpl_info['convergence-angle'])
-    if 'tilt-stage' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.Stage.tilt_alpha',
-                    rpl_info['tilt-stage'])
-    if 'collection-angle' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.Detector.EELS.' +
-                    'collection_angle',
-                    rpl_info['collection-angle'])
-    if 'beam-energy' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.beam_energy',
-                    rpl_info['beam-energy'])
-    if 'elevation-angle' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.Detector.EDS.elevation_angle',
-                    rpl_info['elevation-angle'])
-    if 'azimuth-angle' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.Detector.EDS.azimuth_angle',
-                    rpl_info['azimuth-angle'])
-    if 'energy-resolution' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.Detector.EDS.' +
-                    'energy_resolution_MnKa',
-                    rpl_info['energy-resolution'])
-    if 'detector-peak-width-ev' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.Detector.EDS.' +
-                    'energy_resolution_MnKa',
-                    rpl_info['detector-peak-width-ev'])
-    if 'live-time' in rpl_info:
-        mp.set_item('Acquisition_instrument.TEM.Detector.EDS.live_time',
-                    rpl_info['live-time'])
+    mp = DTBox(
+        {
+            "General": {
+                "original_filename": os.path.split(filename)[1],
+                "date": rpl_info["date"],
+                "time": rpl_info["time"],
+                "title": rpl_info["title"],
+            },
+            "Signal": {"signal_type": rpl_info["signal"], "record_by": record_by},
+        },
+        box_dots=True,
+    )
+    if "convergence-angle" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.convergence_angle",
+            rpl_info["convergence-angle"],
+        )
+    if "tilt-stage" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.Stage.tilt_alpha", rpl_info["tilt-stage"]
+        )
+    if "collection-angle" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.Detector.EELS." + "collection_angle",
+            rpl_info["collection-angle"],
+        )
+    if "beam-energy" in rpl_info:
+        mp.set_item("Acquisition_instrument.TEM.beam_energy", rpl_info["beam-energy"])
+    if "elevation-angle" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.Detector.EDS.elevation_angle",
+            rpl_info["elevation-angle"],
+        )
+    if "azimuth-angle" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.Detector.EDS.azimuth_angle",
+            rpl_info["azimuth-angle"],
+        )
+    if "energy-resolution" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.Detector.EDS." + "energy_resolution_MnKa",
+            rpl_info["energy-resolution"],
+        )
+    if "detector-peak-width-ev" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.Detector.EDS." + "energy_resolution_MnKa",
+            rpl_info["detector-peak-width-ev"],
+        )
+    if "live-time" in rpl_info:
+        mp.set_item(
+            "Acquisition_instrument.TEM.Detector.EDS.live_time", rpl_info["live-time"]
+        )
 
-    units = [None if unit == '<undefined>' else unit for unit in units]
+    units = [None if unit == "<undefined>" else unit for unit in units]
 
     axes = []
     index_in_array = 0
     for i in range(3):
         if sizes[i] > 1:
-            axes.append({
-                'size': sizes[i],
-                'index_in_array': index_in_array,
-                'name': names[i],
-                'scale': scales[i],
-                'offset': origins[i],
-                'units': units[i],
-            })
+            axes.append(
+                {
+                    "size": sizes[i],
+                    "index_in_array": index_in_array,
+                    "name": names[i],
+                    "scale": scales[i],
+                    "offset": origins[i],
+                    "units": units[i],
+                }
+            )
             index_in_array += 1
 
     dictionary = {
-        'data': data.squeeze(),
-        'axes': axes,
-        'metadata': mp.to_dict(),
-        'original_metadata': rpl_info
+        "data": data.squeeze(),
+        "axes": axes,
+        "metadata": mp.to_dict(),
+        "original_metadata": rpl_info,
     }
-    return [dictionary, ]
+    return [
+        dictionary,
+    ]
 
 
-def file_writer(filename, signal, encoding='latin-1', *args, **kwds):
+def file_writer(filename, signal, encoding="latin-1", *args, **kwds):
 
     # Set the optional keys to None
     ev_per_chan = None
 
     # Check if the dtype is supported
-    dc = signal['data']
+    dc = signal["data"]
     md = DTBox(signal["metadata"], box_dots=True)
     dtype_name = dc.dtype.name
     if dtype_name not in dtype2keys.keys():
         raise IOError(
             "The ripple format does not support writting data of {dtype_name} type"
-            )
+        )
     # Check if the dimensions are supported
     dimension = len(dc.shape)
     if dimension > 3:
-        raise IOError(
-            f"This file format does not support {dimension} dimension data"
-            )
+        raise IOError(f"This file format does not support {dimension} dimension data")
 
     # Gather the information to write the rpl
     data_type, data_length = dtype2keys[dtype_name]
-    byte_order = endianess2rpl[dc.dtype.byteorder.replace('|', '=')]
+    byte_order = endianess2rpl[dc.dtype.byteorder.replace("|", "=")]
     offset = 0
 
-    signal_type = md.get('Signal.signal_type', "")
-    date = md.get('General.date', "")
-    time = md.get('General.time', "")
-    title = md.get('General.title', "")
+    signal_type = md.get("Signal.signal_type", "")
+    date = md.get("General.date", "")
+    time = md.get("General.time", "")
+    title = md.get("General.title", "")
 
-    sig_axes = [ax for ax in signal['axes'] if not ax['navigate']][::-1]
-    nav_axes = [ax for ax in signal['axes'] if ax['navigate']][::-1]
+    sig_axes = [ax for ax in signal["axes"] if not ax["navigate"]][::-1]
+    nav_axes = [ax for ax in signal["axes"] if ax["navigate"]][::-1]
 
     if len(sig_axes) == 1:
-        record_by = 'vector'
+        record_by = "vector"
         depth_axis = sig_axes[0]
-        ev_per_chan = int(round(depth_axis['scale']))
+        ev_per_chan = int(round(depth_axis["scale"]))
         if dimension == 3:
             width_axis, height_axis = nav_axes
-            depth, width, height = \
-                depth_axis['size'], width_axis['size'], height_axis['size']
+            depth, width, height = (
+                depth_axis["size"],
+                width_axis["size"],
+                height_axis["size"],
+            )
         elif dimension == 2:
             width_axis = nav_axes[0]
-            depth, width, height = depth_axis['size'], width_axis['size'], 1
+            depth, width, height = depth_axis["size"], width_axis["size"], 1
         elif dimension == 1:
-            record_by == 'dont-care'
-            depth, width, height = depth_axis['size'], 1, 1
+            record_by == "dont-care"
+            depth, width, height = depth_axis["size"], 1, 1
 
     elif len(sig_axes) == 2:
         width_axis, height_axis = sig_axes
         if dimension == 3:
             depth_axis = nav_axes[0]
-            record_by = 'image'
-            depth, width, height =  \
-                depth_axis['size'], width_axis['size'], height_axis['size']
+            record_by = "image"
+            depth, width, height = (
+                depth_axis["size"],
+                width_axis["size"],
+                height_axis["size"],
+            )
         elif dimension == 2:
-            record_by = 'dont-care'
-            width, height, depth = width_axis['size'], height_axis['size'], 1
+            record_by = "dont-care"
+            width, height, depth = width_axis["size"], height_axis["size"], 1
         elif dimension == 1:
-            record_by = 'dont-care'
-            depth, width, height = width_axis['size'], 1, 1
+            record_by = "dont-care"
+            depth, width, height = width_axis["size"], 1, 1
     else:
         _logger.info("Only Signal1D and Signal2D objects can be saved")
         return
 
     # Fill the keys dictionary
     keys_dictionary = {
-        'width': width,
-        'height': height,
-        'depth': depth,
-        'offset': offset,
-        'data-type': data_type,
-        'data-length': data_length,
-        'byte-order': byte_order,
-        'record-by': record_by,
-        'signal': signal_type,
-        'date': date,
-        'time': time,
-        'title': title
+        "width": width,
+        "height": height,
+        "depth": depth,
+        "offset": offset,
+        "data-type": data_type,
+        "data-length": data_length,
+        "byte-order": byte_order,
+        "record-by": record_by,
+        "signal": signal_type,
+        "date": date,
+        "time": time,
+        "title": title,
     }
     if ev_per_chan is not None:
-        keys_dictionary['ev-per-chan'] = ev_per_chan
-    keys = ['depth', 'height', 'width']
+        keys_dictionary["ev-per-chan"] = ev_per_chan
+    keys = ["depth", "height", "width"]
     for key in keys:
         if eval(key) > 1:
-            keys_dictionary[f'{key}-scale'] = eval(f"{key}_axis['scale']")
-            keys_dictionary[f'{key}-origin'] = eval(f"{key}_axis['offset']")
-            keys_dictionary[f'{key}-units'] = eval(f"{key}_axis['units']")
-            keys_dictionary[f'{key}-name'] = eval(f"{key}_axis['name']")
+            keys_dictionary[f"{key}-scale"] = eval(f"{key}_axis['scale']")
+            keys_dictionary[f"{key}-origin"] = eval(f"{key}_axis['offset']")
+            keys_dictionary[f"{key}-units"] = eval(f"{key}_axis['units']")
+            keys_dictionary[f"{key}-name"] = eval(f"{key}_axis['name']")
     if signal_type == "EELS":
         mp = md.get("Acquisition_instrument.TEM")
         if mp is not None:
-            if 'beam_energy' in mp:
-                keys_dictionary['beam-energy'] = mp.beam_energy
-            if 'convergence_angle' in mp:
-                keys_dictionary['convergence-angle'] = mp.convergence_angle
-            if 'Detector.EELS.collection_angle' in mp:
-                keys_dictionary[
-                    'collection-angle'] = mp.Detector.EELS.collection_angle
+            if "beam_energy" in mp:
+                keys_dictionary["beam-energy"] = mp.beam_energy
+            if "convergence_angle" in mp:
+                keys_dictionary["convergence-angle"] = mp.convergence_angle
+            if "Detector.EELS.collection_angle" in mp:
+                keys_dictionary["collection-angle"] = mp.Detector.EELS.collection_angle
     if "EDS" in signal_type:
         if signal_type == "EDS_SEM":
             mp = md.Acquisition_instrument.SEM
         elif signal_type == "EDS_TEM":
             mp = md.Acquisition_instrument.TEM
-        if 'beam_energy' in mp:
-            keys_dictionary['beam-energy'] = mp.beam_energy
-        if 'Detector.EDS.elevation_angle' in mp:
+        if "beam_energy" in mp:
+            keys_dictionary["beam-energy"] = mp.beam_energy
+        if "Detector.EDS.elevation_angle" in mp:
+            keys_dictionary["elevation-angle"] = mp.Detector.EDS.elevation_angle
+        if "Stage.tilt_alpha" in mp:
+            keys_dictionary["tilt-stage"] = mp.Stage.tilt_alpha
+        if "Detector.EDS.azimuth_angle" in mp:
+            keys_dictionary["azimuth-angle"] = mp.Detector.EDS.azimuth_angle
+        if "Detector.EDS.live_time" in mp:
+            keys_dictionary["live-time"] = mp.Detector.EDS.live_time
+        if "Detector.EDS.energy_resolution_MnKa" in mp:
             keys_dictionary[
-                'elevation-angle'] = mp.Detector.EDS.elevation_angle
-        if 'Stage.tilt_alpha' in mp:
-            keys_dictionary['tilt-stage'] = mp.Stage.tilt_alpha
-        if 'Detector.EDS.azimuth_angle' in mp:
-            keys_dictionary['azimuth-angle'] = mp.Detector.EDS.azimuth_angle
-        if 'Detector.EDS.live_time' in mp:
-            keys_dictionary['live-time'] = mp.Detector.EDS.live_time
-        if 'Detector.EDS.energy_resolution_MnKa' in mp:
-            keys_dictionary[
-                'detector-peak-width-ev'] = \
-                mp.Detector.EDS.energy_resolution_MnKa
+                "detector-peak-width-ev"
+            ] = mp.Detector.EDS.energy_resolution_MnKa
 
     write_rpl(filename, keys_dictionary, encoding)
     write_raw(filename, signal, record_by, sig_axes, nav_axes)
 
 
-def write_rpl(filename, keys_dictionary, encoding='ascii'):
-    f = codecs.open(filename, 'w', encoding=encoding,
-                    errors='ignore')
-    f.write(';File created by RosettaSciIO version %s\n' % __version__)
-    f.write('key\tvalue\n')
+def write_rpl(filename, keys_dictionary, encoding="ascii"):
+    f = codecs.open(filename, "w", encoding=encoding, errors="ignore")
+    f.write(";File created by RosettaSciIO version %s\n" % __version__)
+    f.write("key\tvalue\n")
     # Even if it is not necessary, we sort the keywords when writing
     # to make the rpl file more human friendly
     for key, value in iter(sorted(keys_dictionary.items())):
         if not isinstance(value, str):
             value = str(value)
-        f.write(key + '\t' + value + '\n')
+        f.write(key + "\t" + value + "\n")
     f.close()
 
 
@@ -672,21 +687,26 @@ def write_raw(filename, signal, record_by, sig_axes, nav_axes):
          'vector' or 'image'
 
     """
-    filename = os.path.splitext(filename)[0] + '.raw'
-    data = signal['data']
+    filename = os.path.splitext(filename)[0] + ".raw"
+    data = signal["data"]
     dshape = data.shape
     if len(dshape) == 3:
-        if record_by == 'vector':
-            np.rollaxis(data, signal['axes'].index(sig_axes[0]), 3
-            ).ravel().tofile(filename)
-        elif record_by == 'image':
-            data = np.rollaxis(data, signal['axes'].index(nav_axes[0]), 0
-            ).ravel().tofile(filename)
+        if record_by == "vector":
+            np.rollaxis(data, signal["axes"].index(sig_axes[0]), 3).ravel().tofile(
+                filename
+            )
+        elif record_by == "image":
+            data = (
+                np.rollaxis(data, signal["axes"].index(nav_axes[0]), 0)
+                .ravel()
+                .tofile(filename)
+            )
     elif len(dshape) == 2:
-        if record_by == 'vector':
-            np.rollaxis(data, signal['axes'].index(sig_axes[0]), 2
-            ).ravel().tofile(filename)
-        elif record_by in ('image', 'dont-care'):
+        if record_by == "vector":
+            np.rollaxis(data, signal["axes"].index(sig_axes[0]), 2).ravel().tofile(
+                filename
+            )
+        elif record_by in ("image", "dont-care"):
             data.ravel().tofile(filename)
     elif len(dshape) == 1:
         data.ravel().tofile(filename)

--- a/rsciio/semper_unf/api.py
+++ b/rsciio/semper_unf/api.py
@@ -87,7 +87,6 @@ from rsciio.utils.tools import sarray2dict, DTBox
 _logger = logging.getLogger(__name__)
 
 
-
 class SemperFormat(object):
 
     """Class for importing and exporting SEMPER `.unf`-files.
@@ -115,74 +114,83 @@ class SemperFormat(object):
 
     """
 
-    ICLASS_DICT = {1: 'image', 2: 'macro', 3: 'fourier', 4: 'spectrum',
-                   5: 'correlation', 6: None, 7: 'walsh',
-                   8: 'position list', 9: 'histogram',
-                   10: 'display look-up table'}
+    ICLASS_DICT = {
+        1: "image",
+        2: "macro",
+        3: "fourier",
+        4: "spectrum",
+        5: "correlation",
+        6: None,
+        7: "walsh",
+        8: "position list",
+        9: "histogram",
+        10: "display look-up table",
+    }
 
     ICLASS_DICT_INV = {v: k for k, v in ICLASS_DICT.items()}
 
-    IFORM_DICT = {
-        0: np.byte,
-        1: np.int16,
-        2: np.float32,
-        3: np.complex64,
-        4: np.int32}
+    IFORM_DICT = {0: np.byte, 1: np.int16, 2: np.float32, 3: np.complex64, 4: np.int32}
 
     IFORM_DICT_INV = {v: k for k, v in IFORM_DICT.items()}
 
-    HEADER_DTYPES = [('NCOL', '<i2'),
-                     ('NROW', '<i2'),
-                     ('NLAY', '<i2'),
-                     ('ICLASS', '<i2'),
-                     ('IFORM', '<i2'),
-                     ('IFLAG', '<i2'),
-                     ('IFORM', '<i2')]
+    HEADER_DTYPES = [
+        ("NCOL", "<i2"),
+        ("NROW", "<i2"),
+        ("NLAY", "<i2"),
+        ("ICLASS", "<i2"),
+        ("IFORM", "<i2"),
+        ("IFLAG", "<i2"),
+        ("IFORM", "<i2"),
+    ]
 
-    LABEL_DTYPES = [('SEMPER', ('<i2', 6)),   # Bytes 1-6
-                    ('NCOL', ('<i2', 2)),     # Bytes 7,8
-                    ('NROW', ('<i2', 2)),     # Bytes 9,10
-                    ('NLAY', ('<i2', 2)),     # Bytes 11,12
-                    ('ICCOLN', ('<i2', 2)),   # Bytes 13,14
-                    ('ICROWN', ('<i2', 2)),   # Bytes 15,16
-                    ('ICLAYN', ('<i2', 2)),   # Bytes 17,18
-                    ('ICLASS', '<i2'),        # Bytes 19
-                    ('IFORM', '<i2'),         # Bytes 20
-                    ('IWP', '<i2'),           # Bytes 21
-                    ('DATE', ('<i2', 6)),     # Bytes 22-27
-                    ('NCRANG', '<i2'),        # Bytes 28
-                    ('RANGE', ('<i2', 27)),   # Bytes 29-55
-                    ('IPLTYP', '<i2'),        # Bytes 56
-                    ('NCOLH', '<i2'),         # Bytes 57
-                    ('NROWH', '<i2'),         # Bytes 58
-                    ('NLAYH', '<i2'),         # Bytes 59
-                    ('ICCOLNH', '<i2'),       # Bytes 60
-                    ('ICROWNH', '<i2'),       # Bytes 61
-                    ('ICLAYNH', '<i2'),       # Bytes 62
-                    ('REALCO', '<i2'),        # Bytes 63
-                    ('NBLOCK', '<i2'),        # Bytes 64
-                    ('FREE', ('<i2', 3)),     # Bytes 65-67
-                    ('DATAV6', ('<i2', 4)),   # Bytes 68-71
-                    ('DATAV7', ('<i2', 4)),   # Bytes 72-75
-                    ('DZV5', ('<i2', 4)),     # Bytes 76-79
-                    ('Z0V4', ('<i2', 4)),     # Bytes 80-83
-                    ('DYV3', ('<i2', 4)),     # Bytes 84-87
-                    ('Y0V2', ('<i2', 4)),     # Bytes 88-91
-                    ('DXV1', ('<i2', 4)),     # Bytes 92-95
-                    ('X0V0', ('<i2', 4)),     # Bytes 96-99
-                    ('NTITLE', '<i2'),        # Bytes 100
-                    ('TITLE', ('<i2', 144)),  # Bytes 101-244
-                    ('XUNIT', ('<i2', 4)),    # Bytes 245-248
-                    ('YUNIT', ('<i2', 4)),    # Bytes 249-252
-                    ('ZUNIT', ('<i2', 4))]    # Bytes 253-256
+    LABEL_DTYPES = [
+        ("SEMPER", ("<i2", 6)),  # Bytes 1-6
+        ("NCOL", ("<i2", 2)),  # Bytes 7,8
+        ("NROW", ("<i2", 2)),  # Bytes 9,10
+        ("NLAY", ("<i2", 2)),  # Bytes 11,12
+        ("ICCOLN", ("<i2", 2)),  # Bytes 13,14
+        ("ICROWN", ("<i2", 2)),  # Bytes 15,16
+        ("ICLAYN", ("<i2", 2)),  # Bytes 17,18
+        ("ICLASS", "<i2"),  # Bytes 19
+        ("IFORM", "<i2"),  # Bytes 20
+        ("IWP", "<i2"),  # Bytes 21
+        ("DATE", ("<i2", 6)),  # Bytes 22-27
+        ("NCRANG", "<i2"),  # Bytes 28
+        ("RANGE", ("<i2", 27)),  # Bytes 29-55
+        ("IPLTYP", "<i2"),  # Bytes 56
+        ("NCOLH", "<i2"),  # Bytes 57
+        ("NROWH", "<i2"),  # Bytes 58
+        ("NLAYH", "<i2"),  # Bytes 59
+        ("ICCOLNH", "<i2"),  # Bytes 60
+        ("ICROWNH", "<i2"),  # Bytes 61
+        ("ICLAYNH", "<i2"),  # Bytes 62
+        ("REALCO", "<i2"),  # Bytes 63
+        ("NBLOCK", "<i2"),  # Bytes 64
+        ("FREE", ("<i2", 3)),  # Bytes 65-67
+        ("DATAV6", ("<i2", 4)),  # Bytes 68-71
+        ("DATAV7", ("<i2", 4)),  # Bytes 72-75
+        ("DZV5", ("<i2", 4)),  # Bytes 76-79
+        ("Z0V4", ("<i2", 4)),  # Bytes 80-83
+        ("DYV3", ("<i2", 4)),  # Bytes 84-87
+        ("Y0V2", ("<i2", 4)),  # Bytes 88-91
+        ("DXV1", ("<i2", 4)),  # Bytes 92-95
+        ("X0V0", ("<i2", 4)),  # Bytes 96-99
+        ("NTITLE", "<i2"),  # Bytes 100
+        ("TITLE", ("<i2", 144)),  # Bytes 101-244
+        ("XUNIT", ("<i2", 4)),  # Bytes 245-248
+        ("YUNIT", ("<i2", 4)),  # Bytes 249-252
+        ("ZUNIT", ("<i2", 4)),
+    ]  # Bytes 253-256
 
-    def __init__(self,
-                 data,
-                 title='',
-                 offsets=(0., ) * 3,
-                 scales=(1., ) * 3,
-                 units=(None, ) * 3,
-                 metadata=None):
+    def __init__(
+        self,
+        data,
+        title="",
+        offsets=(0.0,) * 3,
+        scales=(1.0,) * 3,
+        units=(None,) * 3,
+        metadata=None,
+    ):
         if metadata is None:
             metadata = {}
         # Make sure data is 3D!
@@ -193,132 +201,119 @@ class SemperFormat(object):
         self.scales = scales
         self.units = units
         self.metadata = metadata
-        _logger.debug('Created ' + str(self))
+        _logger.debug("Created " + str(self))
 
     @classmethod
     def _read_label(cls, unf_file):
         unpack = partial(
-            unpack_from_intbytes,
-            '<f')  # Unpacking function for 4 byte floats!
-        rec_length = np.fromfile(
-            unf_file,
-            dtype='<i',
-            count=1)[0]  # length of label
-        label = sarray2dict(
-            np.fromfile(
-                unf_file,
-                dtype=cls.LABEL_DTYPES,
-                count=1))
-        label['SEMPER'] = ''.join([str(chr(l)) for l in label['SEMPER']])
-        assert label['SEMPER'] == 'Semper'
+            unpack_from_intbytes, "<f"
+        )  # Unpacking function for 4 byte floats!
+        rec_length = np.fromfile(unf_file, dtype="<i", count=1)[0]  # length of label
+        label = sarray2dict(np.fromfile(unf_file, dtype=cls.LABEL_DTYPES, count=1))
+        label["SEMPER"] = "".join([str(chr(l)) for l in label["SEMPER"]])
+        assert label["SEMPER"] == "Semper"
         # Process dimensions:
-        for key in ['NCOL', 'NROW', 'NLAY', 'ICCOLN', 'ICROWN', 'ICLAYN']:
-            value = 256**2 * \
-                label.pop(key + 'H') + 256 * label[key][0] + label[key][1]
+        for key in ["NCOL", "NROW", "NLAY", "ICCOLN", "ICROWN", "ICLAYN"]:
+            value = (
+                256**2 * label.pop(key + "H") + 256 * label[key][0] + label[key][1]
+            )
             label[key] = value
         # Process date:
-        date = '{}-{}-{} {}:{}:{}'.format(label['DATE'][0] +
-                                          1900, *
-                                          label['DATE'][1:])
-        label['DATE'] = date
+        date = "{}-{}-{} {}:{}:{}".format(label["DATE"][0] + 1900, *label["DATE"][1:])
+        label["DATE"] = date
         # Process range:
-        if label['NCRANG'] == 255:
-            range_min = unpack(label['RANGE'][:4])
-            range_max = unpack(label['RANGE'][4:8])
-            range_string = '{:.6g},{:.6g}'.format(range_min, range_max)
+        if label["NCRANG"] == 255:
+            range_min = unpack(label["RANGE"][:4])
+            range_max = unpack(label["RANGE"][4:8])
+            range_string = "{:.6g},{:.6g}".format(range_min, range_max)
         else:
-            range_string = ''.join([str(chr(l))
-                                    for l in label['RANGE'][:label['NCRANG']]])
-        label['RANGE'] = range_string
+            range_string = "".join(
+                [str(chr(l)) for l in label["RANGE"][: label["NCRANG"]]]
+            )
+        label["RANGE"] = range_string
         # Process real coords:
-        x0 = unpack(label.pop('X0V0'))
-        dx = unpack(label.pop('DXV1'))
-        y0 = unpack(label.pop('Y0V2'))
-        dy = unpack(label.pop('DYV3'))
-        z0 = unpack(label.pop('Z0V4'))
-        dz = unpack(label.pop('DZV5'))
-        if label['REALCO'] == 1:
-            label.update({'X0V0': x0, 'Y0V2': y0, 'Z0V4': z0,
-                          'DXV1': dx, 'DYV3': dy, 'DZV5': dz})
+        x0 = unpack(label.pop("X0V0"))
+        dx = unpack(label.pop("DXV1"))
+        y0 = unpack(label.pop("Y0V2"))
+        dy = unpack(label.pop("DYV3"))
+        z0 = unpack(label.pop("Z0V4"))
+        dz = unpack(label.pop("DZV5"))
+        if label["REALCO"] == 1:
+            label.update(
+                {"X0V0": x0, "Y0V2": y0, "Z0V4": z0, "DXV1": dx, "DYV3": dy, "DZV5": dz}
+            )
         # Process additional commands (unused, not sure about the purpose):
-        data_v6 = unpack(label['DATAV6'])
-        data_v7 = unpack(label['DATAV7'])
-        label['DATAV6'] = data_v6
-        label['DATAV7'] = data_v7
+        data_v6 = unpack(label["DATAV6"])
+        data_v7 = unpack(label["DATAV7"])
+        label["DATAV6"] = data_v6
+        label["DATAV7"] = data_v7
         # Process title:
-        title = ''.join([str(chr(l))
-                         for l in label['TITLE'][:label['NTITLE']]])
-        label['TITLE'] = title
+        title = "".join([str(chr(l)) for l in label["TITLE"][: label["NTITLE"]]])
+        label["TITLE"] = title
         # Process units:
-        label['XUNIT'] = ''.join(
-            [chr(l) for l in label['XUNIT']]).replace('\x00', '')
-        label['YUNIT'] = ''.join(
-            [chr(l) for l in label['YUNIT']]).replace('\x00', '')
-        label['ZUNIT'] = ''.join(
-            [chr(l) for l in label['ZUNIT']]).replace('\x00', '')
+        label["XUNIT"] = "".join([chr(l) for l in label["XUNIT"]]).replace("\x00", "")
+        label["YUNIT"] = "".join([chr(l) for l in label["YUNIT"]]).replace("\x00", "")
+        label["ZUNIT"] = "".join([chr(l) for l in label["ZUNIT"]]).replace("\x00", "")
         # Sanity check:
-        assert np.fromfile(unf_file, dtype='<i4', count=1)[0] == rec_length
+        assert np.fromfile(unf_file, dtype="<i4", count=1)[0] == rec_length
         # Return label:
         return label
 
     def _get_label(self):
-        pack = partial(
-            pack_to_intbytes,
-            '<f')  # Packing function for 4 byte floats!
+        pack = partial(pack_to_intbytes, "<f")  # Packing function for 4 byte floats!
         nlay, nrow, ncol = self.data.shape
         data, iform = self._check_format(self.data)
         title = self.title
         # Create label:
         label = np.zeros((1,), dtype=self.LABEL_DTYPES)
         # Fill label:
-        label['SEMPER'] = [ord(c) for c in 'Semper']
-        label['NCOLH'], remain = divmod(ncol, 256**2)
-        label['NCOL'] = divmod(remain, 256)
-        label['NROWH'], remain = divmod(nrow, 256**2)
-        label['NROW'] = divmod(remain, 256)
-        label['NLAYH'], remain = divmod(nlay, 256**2)
-        label['NLAY'] = divmod(remain, 256)
-        iccoln = self.metadata.get('ICCOLN', self.data.shape[2] // 2 + 1)
-        label['ICCOLNH'], remain = divmod(iccoln, 256**2)
-        label['ICCOLN'] = divmod(remain, 256)
-        icrown = self.metadata.get('ICROWN', self.data.shape[1] // 2 + 1)
-        label['ICROWNH'], remain = divmod(icrown, 256**2)
-        label['ICROWN'] = divmod(remain, 256)
-        iclayn = self.metadata.get('ICLAYN', self.data.shape[0] // 2 + 1)
-        label['ICLAYNH'], remain = divmod(iclayn, 256**2)
-        label['ICLAYN'] = divmod(remain, 256)
-        label['ICLASS'] = self.metadata.get('ICLASS', 6)  # 6: Undefined!
-        label['IFORM'] = iform
-        label['IWP'] = self.metadata.get('IWP', 0)  # seems standard
-        date = self.metadata.get('DATE', "%s" % datetime.now())
-        year, time = date.split(' ')
-        date_ints = (list(map(int, year.split('-'))) +
-                     list(map(int, time.split(':'))))
+        label["SEMPER"] = [ord(c) for c in "Semper"]
+        label["NCOLH"], remain = divmod(ncol, 256**2)
+        label["NCOL"] = divmod(remain, 256)
+        label["NROWH"], remain = divmod(nrow, 256**2)
+        label["NROW"] = divmod(remain, 256)
+        label["NLAYH"], remain = divmod(nlay, 256**2)
+        label["NLAY"] = divmod(remain, 256)
+        iccoln = self.metadata.get("ICCOLN", self.data.shape[2] // 2 + 1)
+        label["ICCOLNH"], remain = divmod(iccoln, 256**2)
+        label["ICCOLN"] = divmod(remain, 256)
+        icrown = self.metadata.get("ICROWN", self.data.shape[1] // 2 + 1)
+        label["ICROWNH"], remain = divmod(icrown, 256**2)
+        label["ICROWN"] = divmod(remain, 256)
+        iclayn = self.metadata.get("ICLAYN", self.data.shape[0] // 2 + 1)
+        label["ICLAYNH"], remain = divmod(iclayn, 256**2)
+        label["ICLAYN"] = divmod(remain, 256)
+        label["ICLASS"] = self.metadata.get("ICLASS", 6)  # 6: Undefined!
+        label["IFORM"] = iform
+        label["IWP"] = self.metadata.get("IWP", 0)  # seems standard
+        date = self.metadata.get("DATE", "%s" % datetime.now())
+        year, time = date.split(" ")
+        date_ints = list(map(int, year.split("-"))) + list(map(int, time.split(":")))
         date_ints[0] -= 1900  # Modify year integer!
-        label['DATE'] = date_ints
-        range_string = '{:.4g},{:.4g}'.format(self.data.min(), self.data.max())
-        label['NCRANG'] = len(range_string)
-        label['RANGE'][:, :len(range_string)] = [ord(c) for c in range_string]
-        label['IPLTYP'] = self.metadata.get('IPLTYP', 248)  # seems standard
-        label['REALCO'] = 1  # Real coordinates are used!
-        label['NBLOCK'] = 4  # Always 4 64b blocks!
-        label['FREE'] = [0, 0, 0]
-        label['DATAV6'] = pack(0.)  # Not used!
-        label['DATAV7'] = pack(0.)  # Not used!
-        label['DZV5'] = pack(self.scales[2])   # DZ
-        label['Z0V4'] = pack(self.offsets[2])  # Z0
-        label['DYV3'] = pack(self.scales[1])   # DY
-        label['Y0V2'] = pack(self.offsets[1])  # Y0
-        label['DXV1'] = pack(self.scales[0])   # DX
-        label['X0V0'] = pack(self.offsets[0])  # X0
-        label['NTITLE'] = len(title)
-        label['TITLE'][:, :len(title)] = [ord(s) for s in title]
-        xunit = self.units[0] if self.units[0] is not None else ''
-        label['XUNIT'][:, :len(xunit)] = [ord(c) for c in xunit]
-        yunit = self.units[0] if self.units[0] is not None else ''
-        label['YUNIT'][:, :len(yunit)] = [ord(c) for c in yunit]
-        zunit = self.units[0] if self.units[0] is not None else ''
-        label['ZUNIT'][:, :len(zunit)] = [ord(c) for c in zunit]
+        label["DATE"] = date_ints
+        range_string = "{:.4g},{:.4g}".format(self.data.min(), self.data.max())
+        label["NCRANG"] = len(range_string)
+        label["RANGE"][:, : len(range_string)] = [ord(c) for c in range_string]
+        label["IPLTYP"] = self.metadata.get("IPLTYP", 248)  # seems standard
+        label["REALCO"] = 1  # Real coordinates are used!
+        label["NBLOCK"] = 4  # Always 4 64b blocks!
+        label["FREE"] = [0, 0, 0]
+        label["DATAV6"] = pack(0.0)  # Not used!
+        label["DATAV7"] = pack(0.0)  # Not used!
+        label["DZV5"] = pack(self.scales[2])  # DZ
+        label["Z0V4"] = pack(self.offsets[2])  # Z0
+        label["DYV3"] = pack(self.scales[1])  # DY
+        label["Y0V2"] = pack(self.offsets[1])  # Y0
+        label["DXV1"] = pack(self.scales[0])  # DX
+        label["X0V0"] = pack(self.offsets[0])  # X0
+        label["NTITLE"] = len(title)
+        label["TITLE"][:, : len(title)] = [ord(s) for s in title]
+        xunit = self.units[0] if self.units[0] is not None else ""
+        label["XUNIT"][:, : len(xunit)] = [ord(c) for c in xunit]
+        yunit = self.units[0] if self.units[0] is not None else ""
+        label["YUNIT"][:, : len(yunit)] = [ord(c) for c in yunit]
+        zunit = self.units[0] if self.units[0] is not None else ""
+        label["ZUNIT"][:, : len(zunit)] = [ord(c) for c in zunit]
         return label
 
     @classmethod
@@ -336,11 +331,11 @@ class SemperFormat(object):
         elif np.issubdtype(data.dtype, np.int32):
             iform = 4  # int32
         else:
-            supported_formats = [
-                np.dtype(i).name for i in cls.IFORM_DICT.values()]
-            msg = ('The SEMPER file format does not support '
-                   '{} data type. '.format(data.dtype.name))
-            msg += 'Supported data types are: ' + ', '.join(supported_formats)
+            supported_formats = [np.dtype(i).name for i in cls.IFORM_DICT.values()]
+            msg = "The SEMPER file format does not support " "{} data type. ".format(
+                data.dtype.name
+            )
+            msg += "Supported data types are: " + ", ".join(supported_formats)
             raise IOError(msg)
         return data, iform
 
@@ -361,68 +356,64 @@ class SemperFormat(object):
 
         """
         metadata = OrderedDict()
-        with open(filename, 'rb') as f:
+        with open(filename, "rb") as f:
             # Read header:
-            rec_length = np.fromfile(
-                f,
-                dtype='<i4',
-                count=1)[0]  # length of header
-            header = np.fromfile(
-                f,
-                dtype=cls.HEADER_DTYPES[
-                    :rec_length //
-                    2],
-                count=1)
+            rec_length = np.fromfile(f, dtype="<i4", count=1)[0]  # length of header
+            header = np.fromfile(f, dtype=cls.HEADER_DTYPES[: rec_length // 2], count=1)
             metadata.update(sarray2dict(header))
-            assert np.frombuffer(f.read(4), dtype=np.int32)[0] == rec_length, \
-                'Error while reading the header (length is not correct)!'
-            data_format = cls.IFORM_DICT[metadata['IFORM']]
-            iversn, remain = divmod(metadata['IFLAG'], 10000)
+            assert (
+                np.frombuffer(f.read(4), dtype=np.int32)[0] == rec_length
+            ), "Error while reading the header (length is not correct)!"
+            data_format = cls.IFORM_DICT[metadata["IFORM"]]
+            iversn, remain = divmod(metadata["IFLAG"], 10000)
             ilabel, ntitle = divmod(remain, 1000)
-            metadata.update(
-                {'IVERSN': iversn, 'ILABEL': ilabel, 'NTITLE': ntitle})
+            metadata.update({"IVERSN": iversn, "ILABEL": ilabel, "NTITLE": ntitle})
             # Read title:
-            title = ''
+            title = ""
             if ntitle > 0:
-                assert np.fromfile(
-                    f,
-                    dtype='<i4',
-                    count=1)[0] == ntitle  # length of title
-                title = b''.join(np.fromfile(f, dtype='c', count=ntitle))
+                assert (
+                    np.fromfile(f, dtype="<i4", count=1)[0] == ntitle
+                )  # length of title
+                title = b"".join(np.fromfile(f, dtype="c", count=ntitle))
                 title = title.decode()
-                metadata['TITLE'] = title
-                assert np.fromfile(f, dtype='<i4', count=1)[0] == ntitle
+                metadata["TITLE"] = title
+                assert np.fromfile(f, dtype="<i4", count=1)[0] == ntitle
             if ilabel:
                 try:
                     metadata.update(cls._read_label(f))
                 except Exception as e:
-                    warning = ('Could not read label, trying to proceed '
-                               'without it!')
-                    warning += ' (Error message: {})'.format(str(e))
+                    warning = "Could not read label, trying to proceed " "without it!"
+                    warning += " (Error message: {})".format(str(e))
                     warnings.warn(warning)
             # Read picture data:
             pos = f.tell()
-            shape = metadata['NLAY'], metadata['NROW'], metadata['NCOL']
+            shape = metadata["NLAY"], metadata["NROW"], metadata["NCOL"]
             if lazy:
                 from dask.array import from_delayed
                 from dask import delayed
-                task = delayed(_read_data)(f, filename, pos, data_format,
-                                           shape)
+
+                task = delayed(_read_data)(f, filename, pos, data_format, shape)
                 data = from_delayed(task, shape=shape, dtype=data_format)
             else:
                 data = _read_data(f, filename, pos, data_format, shape)
-        offsets = (metadata.get('X0V0', 0.),
-                   metadata.get('Y0V2', 0.),
-                   metadata.get('Z0V4', 0.))
-        scales = (metadata.get('DXV1', 1.),
-                  metadata.get('DYV3', 1.),
-                  metadata.get('DZV5', 1.))
-        units = (metadata.get('XUNIT', None),
-                 metadata.get('YUNIT', None),
-                 metadata.get('ZUNIT', None))
+        offsets = (
+            metadata.get("X0V0", 0.0),
+            metadata.get("Y0V2", 0.0),
+            metadata.get("Z0V4", 0.0),
+        )
+        scales = (
+            metadata.get("DXV1", 1.0),
+            metadata.get("DYV3", 1.0),
+            metadata.get("DZV5", 1.0),
+        )
+        units = (
+            metadata.get("XUNIT", None),
+            metadata.get("YUNIT", None),
+            metadata.get("ZUNIT", None),
+        )
         return cls(data, title, offsets, scales, units, metadata)
 
-    def save_to_unf(self, filename='semper.unf', skip_header=False):
+    def save_to_unf(self, filename="semper.unf", skip_header=False):
         """Save a :class:`~.SemperFormat` to a file.
 
         Parameters
@@ -440,69 +431,49 @@ class SemperFormat(object):
         """
         nlay, nrow, ncol = self.data.shape
         data, iform = self._check_format(self.data)
-        title = self.title if self.title is not None else ''
-        with open(filename, 'wb') as f:
+        title = self.title if self.title is not None else ""
+        with open(filename, "wb") as f:
             if not skip_header:
                 # Create header:
                 header = np.zeros(
-                    (1,), dtype=self.HEADER_DTYPES[
-                        :-1])  # IFORMAT is not used!
+                    (1,), dtype=self.HEADER_DTYPES[:-1]
+                )  # IFORMAT is not used!
                 # Fill header:
-                header['NCOL'] = self.data.shape[2]
-                header['NROW'] = self.data.shape[1]
-                header['NLAY'] = self.data.shape[0]
-                header['ICLASS'] = self.metadata.get(
-                    'ICLASS',
-                    6)  # 6: Undefined!
-                header['IFORM'] = iform
+                header["NCOL"] = self.data.shape[2]
+                header["NROW"] = self.data.shape[1]
+                header["NLAY"] = self.data.shape[0]
+                header["ICLASS"] = self.metadata.get("ICLASS", 6)  # 6: Undefined!
+                header["IFORM"] = iform
                 # IVERSN: 2; ILABEL:1 (True)
-                header['IFLAG'] = 2 * 10000 + 1000 + len(title)
+                header["IFLAG"] = 2 * 10000 + 1000 + len(title)
                 # Write header:
-                f.write(
-                    struct.pack(
-                        '<i',
-                        12))  # record length, 4 byte format!
+                f.write(struct.pack("<i", 12))  # record length, 4 byte format!
                 f.write(header.tobytes())
-                f.write(
-                    struct.pack(
-                        '<i',
-                        12))  # record length, 4 byte format!
+                f.write(struct.pack("<i", 12))  # record length, 4 byte format!
                 # Write title:
                 if len(title) > 0:
                     f.write(
-                        struct.pack(
-                            '<i',
-                            len(title)))  # record length, 4 byte format!
+                        struct.pack("<i", len(title))
+                    )  # record length, 4 byte format!
                     f.write(title.encode())
                     f.write(
-                        struct.pack(
-                            '<i',
-                            len(title)))  # record length, 4 byte format!
+                        struct.pack("<i", len(title))
+                    )  # record length, 4 byte format!
                 # Create label:
                 label = self._get_label()
                 # Write label:
-                f.write(
-                    struct.pack(
-                        '<i',
-                        2 *
-                        256))  # record length, 4 byte format!
+                f.write(struct.pack("<i", 2 * 256))  # record length, 4 byte format!
                 f.write(label.tobytes())
-                f.write(
-                    struct.pack(
-                        '<i',
-                        2 *
-                        256))  # record length, 4 byte format!
+                f.write(struct.pack("<i", 2 * 256))  # record length, 4 byte format!
             # Write picture data:
             for k in range(nlay):
                 for j in range(nrow):
                     row = self.data[k, j, :]
                     # Record length = bytes per entry * ncol:
-                    record_length = np.dtype(
-                        self.IFORM_DICT[iform]).itemsize * ncol
+                    record_length = np.dtype(self.IFORM_DICT[iform]).itemsize * ncol
                     f.write(
-                        struct.pack(
-                            '<i',
-                            record_length))  # record length, 4 byte format!
+                        struct.pack("<i", record_length)
+                    )  # record length, 4 byte format!
                     f.write(row.tobytes())
                     # SEMPER always expects an even number of bytes per row,
                     # which is only a problem for writing single byte data
@@ -511,7 +482,7 @@ class SemperFormat(object):
                     if self.data.dtype == np.byte and ncol % 2 != 0:
                         np.zeros(1, dtype=np.byte).tobytes()
                     # record length, 4 byte format!
-                    f.write(struct.pack('<i', record_length))
+                    f.write(struct.pack("<i", record_length))
 
     @classmethod
     def from_signal(cls, signal):
@@ -530,17 +501,17 @@ class SemperFormat(object):
         """
         data = signal["data"]
         smetadata = DTBox(signal["metadata"], box_dots=True)
-        assert len(data.shape) <= 3, \
-            'Only up to 3-dimensional datasets can be handled!'
-        scales, offsets, units = [1.] * 3, [0.] * \
-            3, [None] * 3  # Defaults!
+        assert len(data.shape) <= 3, "Only up to 3-dimensional datasets can be handled!"
+        scales, offsets, units = [1.0] * 3, [0.0] * 3, [None] * 3  # Defaults!
         for i in range(len(data.shape)):
             scales[i] = signal["axes"][i]["scale"]
             offsets[i] = signal["axes"][i]["offset"]
             units[i] = signal["axes"][i]["units"]
         # Make sure data is 3D!
         data = data[tuple(None for _ in range(3 - len(data.shape)))]
-        signal_dimension = len([axis for axis in signal["axes"] if not axis["navigate"]])
+        signal_dimension = len(
+            [axis for axis in signal["axes"] if not axis["navigate"]]
+        )
         if signal_dimension == 1:
             record_by = "spectrum"
         elif signal_dimension == 2:
@@ -549,27 +520,28 @@ class SemperFormat(object):
             record_by = ""
         iclass = cls.ICLASS_DICT_INV.get(record_by, 6)  # 6: undefined
         data, iform = cls._check_format(data)
-        title = smetadata.General.to_dict().get('title', None)
+        title = smetadata.General.to_dict().get("title", None)
         metadata = OrderedDict()
-        if 'date' in smetadata.General.keys(
-        ) and 'time' in smetadata.General.keys():
-            dt = "%s %s" % (smetadata.General.date,
-                            smetadata.General.time)
+        if "date" in smetadata.General.keys() and "time" in smetadata.General.keys():
+            dt = "%s %s" % (smetadata.General.date, smetadata.General.time)
         else:
             dt = "%s" % datetime.now()
 
-        metadata.update({'DATE': "%s" % dt.split('.')[0],
-                         'ICLASS': iclass,
-                         'IFORM': iform,
-                         'IVERSN': 2,  # Current standard
-                         'ILABEL': 1,  # True
-                         'IWP': 0,  # Seems standard
-                         'IPLTYP': 248,  # Seems standard
-                         'ICCOLN': data.shape[2] // 2 + 1,
-                         'ICROWN': data.shape[1] // 2 + 1,
-                         'ICLAYN': data.shape[0] // 2 + 1})
+        metadata.update(
+            {
+                "DATE": "%s" % dt.split(".")[0],
+                "ICLASS": iclass,
+                "IFORM": iform,
+                "IVERSN": 2,  # Current standard
+                "ILABEL": 1,  # True
+                "IWP": 0,  # Seems standard
+                "IPLTYP": 248,  # Seems standard
+                "ICCOLN": data.shape[2] // 2 + 1,
+                "ICROWN": data.shape[1] // 2 + 1,
+                "ICLAYN": data.shape[0] // 2 + 1,
+            }
+        )
         return cls(data, title, offsets, scales, units, metadata)
-
 
     def to_dictionary(self, lazy=False):
         """Export a :class:`~.SemperFormat` object to a
@@ -587,42 +559,44 @@ class SemperFormat(object):
         """
         data = self.data.squeeze()  # Reduce unneeded dimensions!
         axes = []
-        for name, scale, offset, units, size in zip(("x", "y", "z"), self.scales, self.offsets, self.units, data.shape):
+        for name, scale, offset, units, size in zip(
+            ("x", "y", "z"), self.scales, self.offsets, self.units, data.shape
+        ):
             axes.append(
                 {
-                    '_type': 'UniformDataAxis',
-                    'name': name,
-                    'units': units,
-                    'navigate': False,
-                    'is_binned': False,
-                    'size': size,
-                    'scale': scale,
-                    'offset': offset,
+                    "_type": "UniformDataAxis",
+                    "name": name,
+                    "units": units,
+                    "navigate": False,
+                    "is_binned": False,
+                    "size": size,
+                    "scale": scale,
+                    "offset": offset,
                 }
             )
         metadata = {}
         metadata["General"] = {}
         metadata["General"]["title"] = self.title
-        if 'DATE' in self.metadata.keys():
+        if "DATE" in self.metadata.keys():
             date, time = self._convert_date_time_from_label()
-            metadata['General']['date'] = date
-            metadata['General']['time'] = time
+            metadata["General"]["date"] = date
+            metadata["General"]["time"] = time
 
         signal_dic = {
             "data": data,
             "metadata": metadata,
             "original_metadata": self.metadata,
             "axes": axes,
-            'attributes': {'_lazy': lazy, 'ragged': False},
+            "attributes": {"_lazy": lazy, "ragged": False},
         }
         return signal_dic
 
     def _convert_date_time_from_label(self):
         # Convert the label['DATE'] to ISO 8601 for metadata
         try:
-            dt = datetime.strptime(self.metadata['DATE'], "%Y-%m-%d %H:%M:%S")
+            dt = datetime.strptime(self.metadata["DATE"], "%Y-%m-%d %H:%M:%S")
         except ValueError:
-            dt = datetime.strptime(self.metadata['DATE'], "%y-%m-%d %H:%M:%S")
+            dt = datetime.strptime(self.metadata["DATE"], "%y-%m-%d %H:%M:%S")
         return dt.date().isoformat(), dt.time().isoformat()
 
     def log_info(self):
@@ -639,19 +613,17 @@ class SemperFormat(object):
 
         """
         info_str = (
-            "Semper info:\n" +
-            ("\t%s\n" % self.title) +
-            ('\tdimensions: x: {}, y: {}, z: {}\n'.format(
-                *reversed(self.data.shape))) +
-            ('\tscaling:    x: {:.3g}, y: {:.3g}, z: {:.3g}\n'.format(
-                *self.scales)) +
-            ('\toffsets:    x: {:.3g}, y: {:.3g}, z: {:.3g}'.format(
-                *self.offsets)) +
-            ('\tunits:      x: {}, y: {}, z: {}'.format(*self.units)) +
-            ('\tdata range: %s %s\n' % (self.data.min(), self.data.max())) +
-            ('\tmetadata:\n'))
+            "Semper info:\n"
+            + ("\t%s\n" % self.title)
+            + ("\tdimensions: x: {}, y: {}, z: {}\n".format(*reversed(self.data.shape)))
+            + ("\tscaling:    x: {:.3g}, y: {:.3g}, z: {:.3g}\n".format(*self.scales))
+            + ("\toffsets:    x: {:.3g}, y: {:.3g}, z: {:.3g}".format(*self.offsets))
+            + ("\tunits:      x: {}, y: {}, z: {}".format(*self.units))
+            + ("\tdata range: %s %s\n" % (self.data.min(), self.data.max()))
+            + ("\tmetadata:\n")
+        )
         for k, v in self.metadata.items():
-            info_str += '\t\t{}: {}'.format(k, v)
+            info_str += "\t\t{}: {}".format(k, v)
         _logger.info(info_str)
 
 
@@ -659,8 +631,7 @@ def unpack_from_intbytes(fmt, byte_list):
     """Read in a list of bytes (as int with range 0-255) and unpack them with
     format `fmt`.
     """
-    return struct.unpack(fmt, b''.join(
-        map(bytes, [[byte] for byte in byte_list])))[0]
+    return struct.unpack(fmt, b"".join(map(bytes, [[byte] for byte in byte_list])))[0]
 
 
 def pack_to_intbytes(fmt, value):
@@ -672,13 +643,13 @@ def pack_to_intbytes(fmt, value):
 
 def _read_data(fobj, fname, position, data_format, shape):
     if fobj.closed:
-        fobj = open(fname, 'rb')
+        fobj = open(fname, "rb")
     fobj.seek(position)
     nlay, nrow, ncol = shape
     data = np.empty(shape, dtype=data_format)
     for k in range(nlay):
         for j in range(nrow):
-            rec_length = np.fromfile(fobj, dtype='<i4', count=1)[0]
+            rec_length = np.fromfile(fobj, dtype="<i4", count=1)[0]
             # Not always ncol, see below
             count = rec_length // np.dtype(data_format).itemsize
             row = np.fromfile(fobj, dtype=data_format, count=count)
@@ -687,13 +658,13 @@ def _read_data(fobj, fname, position, data_format, shape):
             # bytes (IFORM = 0, np.byte). If ncol is odd, an empty
             # byte (0) is added which has to be skipped during read in:
             data[k, j, :] = row[:ncol]
-            test = np.fromfile(fobj, dtype='<i4', count=1)[0]
+            test = np.fromfile(fobj, dtype="<i4", count=1)[0]
             assert test == rec_length
     return data
 
 
 def file_reader(filename, **kwds):
-    lazy = kwds.get('lazy', False)
+    lazy = kwds.get("lazy", False)
     semper = SemperFormat.load_from_unf(filename, lazy=lazy)
     semper.log_info()
     return [semper.to_dictionary(lazy=lazy)]

--- a/rsciio/sur/api.py
+++ b/rsciio/sur/api.py
@@ -16,19 +16,21 @@
 # along with  HyperSpy.  If not, see <https://www.gnu.org/licenses/#GPL>.
 
 # Plugin to read the mountainsmap surface format (sur)
-#Current state can bring support to the surface format if the file is an
-#attolight hyperspectral map, but cannot bring write nor support for other
-#mountainsmap files (.pro etc.). I need to write some tests, check whether the
-#comments can be systematically parsed into metadata and write a support for
-#original_metadata or other
+# Current state can bring support to the surface format if the file is an
+# attolight hyperspectral map, but cannot bring write nor support for other
+# mountainsmap files (.pro etc.). I need to write some tests, check whether the
+# comments can be systematically parsed into metadata and write a support for
+# original_metadata or other
 
 import logging
-#Dateutil allows to parse date but I don't think it's useful here
-#import dateutil.parser
+
+# Dateutil allows to parse date but I don't think it's useful here
+# import dateutil.parser
 
 import numpy as np
-#Commented for now because I don't know what purpose it serves
-#import traits.api as t
+
+# Commented for now because I don't know what purpose it serves
+# import traits.api as t
 
 from copy import deepcopy
 import struct
@@ -37,22 +39,22 @@ import zlib
 import os
 import warnings
 
-#Maybe later we can implement reading the class with the io utils tools instead
-#of re-defining read functions in the class
-#import rsciio.utils.utils_readfile as iou
+# Maybe later we can implement reading the class with the io utils tools instead
+# of re-defining read functions in the class
+# import rsciio.utils.utils_readfile as iou
 
-#This module will prove useful when we write the export function
-#import rsciio.utils.tools
+# This module will prove useful when we write the export function
+# import rsciio.utils.tools
 
-#DictionaryTreeBrowser class handles the fancy metadata dictionnaries
-#from hyperspy.misc.utils import DictionaryTreeBrowser
+# DictionaryTreeBrowser class handles the fancy metadata dictionnaries
+# from hyperspy.misc.utils import DictionaryTreeBrowser
 from rsciio.exceptions import MountainsMapFileError
 
 _logger = logging.getLogger(__name__)
 
 
 class DigitalSurfHandler(object):
-    """ Class to read Digital Surf MountainsMap files.
+    """Class to read Digital Surf MountainsMap files.
 
     Attributes
     ----------
@@ -68,439 +70,378 @@ class DigitalSurfHandler(object):
     _object_type : dict key: int containing the mountainsmap object types
 
     """
-    #Object types
+
+    # Object types
     _mountains_object_types = {
-                                -1: "_ERROR"              ,
-                                 0: "_UNKNOWN"            ,
-                                 1: "_PROFILE"            ,
-                                 2: "_SURFACE"            ,
-                                 3: "_BINARYIMAGE"        ,
-                                 4: "_PROFILESERIE"       ,
-                                 5: "_SURFACESERIE"       ,
-                                 6: "_MERIDIANDISC"       ,
-                                 7: "_MULTILAYERPROFILE"  ,
-                                 8: "_MULTILAYERSURFACE"  ,
-                                 9: "_PARALLELDISC"       ,
-                                10: "_INTENSITYIMAGE"     ,
-                                11: "_INTENSITYSURFACE"   ,
-                                12: "_RGBIMAGE"           ,
-                                13: "_RGBSURFACE"         ,
-                                14: "_FORCECURVE"         ,
-                                15: "_SERIEOFFORCECURVE"  ,
-                                16: "_RGBINTENSITYSURFACE",
-                                20: "_SPECTRUM"           ,
-                                21: "_HYPCARD"            ,
-                                }
+        -1: "_ERROR",
+        0: "_UNKNOWN",
+        1: "_PROFILE",
+        2: "_SURFACE",
+        3: "_BINARYIMAGE",
+        4: "_PROFILESERIE",
+        5: "_SURFACESERIE",
+        6: "_MERIDIANDISC",
+        7: "_MULTILAYERPROFILE",
+        8: "_MULTILAYERSURFACE",
+        9: "_PARALLELDISC",
+        10: "_INTENSITYIMAGE",
+        11: "_INTENSITYSURFACE",
+        12: "_RGBIMAGE",
+        13: "_RGBSURFACE",
+        14: "_FORCECURVE",
+        15: "_SERIEOFFORCECURVE",
+        16: "_RGBINTENSITYSURFACE",
+        20: "_SPECTRUM",
+        21: "_HYPCARD",
+    }
 
     def __init__(self, filename=None):
 
-        #We do not need to check for file existence here because
-        #io module implements it in the load function
+        # We do not need to check for file existence here because
+        # io module implements it in the load function
         self.filename = filename
 
-        #The signal_dict dictionnary has to be returned by the
-        #file_reader function. Apparently original_metadata needs
-        #to be set
-        self.signal_dict = {'data': np.empty((0,0,0)),
-                            'axes': [],
-                            'metadata': {},
-                            'original_metadata': {}
-                            }
+        # The signal_dict dictionnary has to be returned by the
+        # file_reader function. Apparently original_metadata needs
+        # to be set
+        self.signal_dict = {
+            "data": np.empty((0, 0, 0)),
+            "axes": [],
+            "metadata": {},
+            "original_metadata": {},
+        }
 
-        #Dictionary to store, read and write fields in the binary file
-        #defined in the MountainsMap SDK. Structure is
+        # Dictionary to store, read and write fields in the binary file
+        # defined in the MountainsMap SDK. Structure is
         # _work_dict['Field']['value'] : access field value
         # _work_dict['Field']['b_unpack_fn'](f) : unpack value from file f
         # _work_dict['Field']['b_pack_fn'](f,v): pack value v in file f
-        self._work_dict = \
-            {
-            "_01_Signature":
-                {
-                'value':"DSCOMPRESSED",
-                'b_unpack_fn': lambda f: self._get_str(f,12,"DSCOMPRESSED"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,12),
-                },
-            "_02_Format":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_03_Number_of_Objects":
-                {
-                'value':1,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_04_Version":
-                {
-                'value':1,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_05_Object_Type":
-                {
-                'value':2,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_06_Object_Name":
-                {
-                'value':"",
-                'b_unpack_fn': lambda f: self._get_str(f,30,"DOSONLY"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,30),
-                },
-            "_07_Operator_Name":
-                {
-                'value':"",
-                'b_unpack_fn': lambda f: self._get_str(f,30,""),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,30),
-                },
-            "_08_P_Size":
-                {
-                'value':1,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_09_Acquisition_Type":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_10_Range_Type":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_11_Special_Points":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_12_Absolute":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_13_Gauge_Resolution":
-                {
-                'value':0.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_14_W_Size":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int32,
-                'b_pack_fn': self._set_int32,
-                },
-            "_15_Size_of_Points":
-                {
-                'value':16,
-                'b_unpack_fn':lambda f: self._get_int16(f,32),
-                'b_pack_fn': self._set_int16,
-                },
-            "_16_Zmin":
-                {
-                'value':0,
-                'b_unpack_fn':self._get_int32,
-                'b_pack_fn':self._set_int32,
-                },
-            "_17_Zmax":
-                {
-                'value':0,
-                'b_unpack_fn':self._get_int32,
-                'b_pack_fn': self._set_int32,
-                },
-            "_18_Number_of_Points":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int32,
-                'b_pack_fn': self._set_int32,
-                },
-            "_19_Number_of_Lines":
-                {
-                'value':0,
-                'b_unpack_fn':self._get_int32,
-                'b_pack_fn':self._set_int32,
-                },
-            "_20_Total_Nb_of_Pts":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int32,
-                'b_pack_fn': self._set_int32
-                },
-            "_21_X_Spacing":
-                {
-                'value':1.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_22_Y_Spacing":
-                {
-                'value':1.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                 },
-            "_23_Z_Spacing":
-                {
-                'value':1.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_24_Name_of_X_Axis":
-                {
-                'value':'X',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"X"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_25_Name_of_Y_Axis":
-                {
-                'value':'Y',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"Y"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_26_Name_of_Z_Axis":
-                {
-                'value':'Z',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"Z"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_27_X_Step_Unit":
-                {
-                'value':'um',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"um"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_28_Y_Step_Unit":
-                {
-                'value':'um',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"um"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_29_Z_Step_Unit":
-                {
-                'value':'um',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"um"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_30_X_Length_Unit":
-                {
-                'value':'um',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"um"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_31_Y_Length_Unit":
-                {
-                'value':'um',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"um"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_32_Z_Length_Unit":
-                {
-                'value':'um',
-                'b_unpack_fn': lambda f: self._get_str(f,16,"um"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,16),
-                },
-            "_33_X_Unit_Ratio":
-                {
-                'value':1.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_34_Y_Unit_Ratio":
-                {
-                'value':1.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_35_Z_Unit_Ratio":
-                {
-                'value':1.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_36_Imprint":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_37_Inverted":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_38_Levelled":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_39_Obsolete":
-                {
-                'value':0,
-                'b_unpack_fn': lambda f: self._get_bytes(f,12),
-                'b_pack_fn': lambda f,v: self._set_bytes(f,v,12),
-                },
-            "_40_Seconds":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_41_Minutes":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_42_Hours":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_43_Day":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_44_Month":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_45_Year":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_46_Day_of_week":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_47_Measurement_duration":
-                {
-                'value':0.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_48_Compressed_data_size":
-                {
-                'value':0,
-                'b_unpack_fn':self._get_uint32,
-                'b_pack_fn':self._set_uint32,
-                },
-            "_49_Obsolete":
-                {
-                'value':0,
-                'b_unpack_fn': lambda f: self._get_bytes(f,6),
-                'b_pack_fn': lambda f,v: self._set_bytes(f,v,6),
-                },
-            "_50_Comment_size":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_51_Private_size":
-                {
-                'value':0,
-                'b_unpack_fn': self._get_int16,
-                'b_pack_fn': self._set_int16,
-                },
-            "_52_Client_zone":
-                {
-                'value':0,
-                'b_unpack_fn': lambda f: self._get_bytes(f,128),
-                'b_pack_fn': lambda f,v: self._set_bytes(f,v,128),
-                },
-            "_53_X_Offset":
-                {
-                'value':0.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_54_Y_Offset":
-                {
-                'value':0.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_55_Z_Offset":
-                {
-                'value':0.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_56_T_Spacing":\
-                {
-                'value':0.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_57_T_Offset":
-                {
-                'value':0.0,
-                'b_unpack_fn': self._get_float,
-                'b_pack_fn': self._set_float,
-                },
-            "_58_T_Axis_Name":
-                {
-                'value':'T',
-                'b_unpack_fn': lambda f: self._get_str(f,13,"Wavelength"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,13),
-                },
-            "_59_T_Step_Unit":
-                {
-                'value':'um',
-                'b_unpack_fn': lambda f: self._get_str(f,13,"nm"),
-                'b_pack_fn': lambda f,v: self._set_str(f,v,13),
-                },
-            "_60_Comment":
-                {
-                'value':0,
-                'b_unpack_fn': self._unpack_comment,
-                'b_pack_fn': self._pack_comment,
-                },
-            "_61_Private_zone":
-                {
-                'value':0,
-                'b_unpack_fn': self._unpack_private,
-                'b_pack_fn': self._pack_private,
-                },
-            "_62_points":
-                {
-                'value':0,
-                'b_unpack_fn': self._unpack_data,
-                'b_pack_fn': lambda f,v: 0, #Not implemented
-                },
-            }
+        self._work_dict = {
+            "_01_Signature": {
+                "value": "DSCOMPRESSED",
+                "b_unpack_fn": lambda f: self._get_str(f, 12, "DSCOMPRESSED"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 12),
+            },
+            "_02_Format": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_03_Number_of_Objects": {
+                "value": 1,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_04_Version": {
+                "value": 1,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_05_Object_Type": {
+                "value": 2,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_06_Object_Name": {
+                "value": "",
+                "b_unpack_fn": lambda f: self._get_str(f, 30, "DOSONLY"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 30),
+            },
+            "_07_Operator_Name": {
+                "value": "",
+                "b_unpack_fn": lambda f: self._get_str(f, 30, ""),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 30),
+            },
+            "_08_P_Size": {
+                "value": 1,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_09_Acquisition_Type": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_10_Range_Type": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_11_Special_Points": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_12_Absolute": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_13_Gauge_Resolution": {
+                "value": 0.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_14_W_Size": {
+                "value": 0,
+                "b_unpack_fn": self._get_int32,
+                "b_pack_fn": self._set_int32,
+            },
+            "_15_Size_of_Points": {
+                "value": 16,
+                "b_unpack_fn": lambda f: self._get_int16(f, 32),
+                "b_pack_fn": self._set_int16,
+            },
+            "_16_Zmin": {
+                "value": 0,
+                "b_unpack_fn": self._get_int32,
+                "b_pack_fn": self._set_int32,
+            },
+            "_17_Zmax": {
+                "value": 0,
+                "b_unpack_fn": self._get_int32,
+                "b_pack_fn": self._set_int32,
+            },
+            "_18_Number_of_Points": {
+                "value": 0,
+                "b_unpack_fn": self._get_int32,
+                "b_pack_fn": self._set_int32,
+            },
+            "_19_Number_of_Lines": {
+                "value": 0,
+                "b_unpack_fn": self._get_int32,
+                "b_pack_fn": self._set_int32,
+            },
+            "_20_Total_Nb_of_Pts": {
+                "value": 0,
+                "b_unpack_fn": self._get_int32,
+                "b_pack_fn": self._set_int32,
+            },
+            "_21_X_Spacing": {
+                "value": 1.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_22_Y_Spacing": {
+                "value": 1.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_23_Z_Spacing": {
+                "value": 1.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_24_Name_of_X_Axis": {
+                "value": "X",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "X"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_25_Name_of_Y_Axis": {
+                "value": "Y",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "Y"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_26_Name_of_Z_Axis": {
+                "value": "Z",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "Z"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_27_X_Step_Unit": {
+                "value": "um",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "um"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_28_Y_Step_Unit": {
+                "value": "um",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "um"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_29_Z_Step_Unit": {
+                "value": "um",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "um"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_30_X_Length_Unit": {
+                "value": "um",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "um"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_31_Y_Length_Unit": {
+                "value": "um",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "um"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_32_Z_Length_Unit": {
+                "value": "um",
+                "b_unpack_fn": lambda f: self._get_str(f, 16, "um"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 16),
+            },
+            "_33_X_Unit_Ratio": {
+                "value": 1.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_34_Y_Unit_Ratio": {
+                "value": 1.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_35_Z_Unit_Ratio": {
+                "value": 1.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_36_Imprint": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_37_Inverted": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_38_Levelled": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_39_Obsolete": {
+                "value": 0,
+                "b_unpack_fn": lambda f: self._get_bytes(f, 12),
+                "b_pack_fn": lambda f, v: self._set_bytes(f, v, 12),
+            },
+            "_40_Seconds": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_41_Minutes": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_42_Hours": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_43_Day": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_44_Month": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_45_Year": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_46_Day_of_week": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_47_Measurement_duration": {
+                "value": 0.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_48_Compressed_data_size": {
+                "value": 0,
+                "b_unpack_fn": self._get_uint32,
+                "b_pack_fn": self._set_uint32,
+            },
+            "_49_Obsolete": {
+                "value": 0,
+                "b_unpack_fn": lambda f: self._get_bytes(f, 6),
+                "b_pack_fn": lambda f, v: self._set_bytes(f, v, 6),
+            },
+            "_50_Comment_size": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_51_Private_size": {
+                "value": 0,
+                "b_unpack_fn": self._get_int16,
+                "b_pack_fn": self._set_int16,
+            },
+            "_52_Client_zone": {
+                "value": 0,
+                "b_unpack_fn": lambda f: self._get_bytes(f, 128),
+                "b_pack_fn": lambda f, v: self._set_bytes(f, v, 128),
+            },
+            "_53_X_Offset": {
+                "value": 0.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_54_Y_Offset": {
+                "value": 0.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_55_Z_Offset": {
+                "value": 0.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_56_T_Spacing": {
+                "value": 0.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_57_T_Offset": {
+                "value": 0.0,
+                "b_unpack_fn": self._get_float,
+                "b_pack_fn": self._set_float,
+            },
+            "_58_T_Axis_Name": {
+                "value": "T",
+                "b_unpack_fn": lambda f: self._get_str(f, 13, "Wavelength"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 13),
+            },
+            "_59_T_Step_Unit": {
+                "value": "um",
+                "b_unpack_fn": lambda f: self._get_str(f, 13, "nm"),
+                "b_pack_fn": lambda f, v: self._set_str(f, v, 13),
+            },
+            "_60_Comment": {
+                "value": 0,
+                "b_unpack_fn": self._unpack_comment,
+                "b_pack_fn": self._pack_comment,
+            },
+            "_61_Private_zone": {
+                "value": 0,
+                "b_unpack_fn": self._unpack_private,
+                "b_pack_fn": self._pack_private,
+            },
+            "_62_points": {
+                "value": 0,
+                "b_unpack_fn": self._unpack_data,
+                "b_pack_fn": lambda f, v: 0,  # Not implemented
+            },
+        }
 
-        #List of all measurement
+        # List of all measurement
         self._list_sur_file_content = []
 
-        #The surface files convention is that when saving multiple data
-        #objects at once, they are all packed in the same binary file.
-        #Every single object contains a full header with all the sections,
+        # The surface files convention is that when saving multiple data
+        # objects at once, they are all packed in the same binary file.
+        # Every single object contains a full header with all the sections,
         # but only the first one contains the relevant infos about
-        #object type, the number of objects in the file and other.
-        #Hence they will be made attributes.
-        #Object type
+        # object type, the number of objects in the file and other.
+        # Hence they will be made attributes.
+        # Object type
         self._Object_type = "_UNKNOWN"
 
-        #Number of data objects in the file.
+        # Number of data objects in the file.
         self._N_data_object = 1
         self._N_data_channels = 1
 
@@ -509,65 +450,66 @@ class DigitalSurfHandler(object):
         """Read the binary, possibly compressed, content of the surface
         file. Surface files can be encoded as single or a succession
         of objects. The file is thus read iteratively and from metadata of the
-        first file """
+        first file"""
 
-        with open(self.filename,'rb') as f:
-            #We read the first object
+        with open(self.filename, "rb") as f:
+            # We read the first object
             self._read_single_sur_object(f)
-            #We append the first object to the content list
+            # We append the first object to the content list
             self._append_work_dict_to_content()
-            #Lookup how many objects are stored in the file and save
+            # Lookup how many objects are stored in the file and save
             self._N_data_object = self._get_work_dict_key_value("_03_Number_of_Objects")
-            self._N_data_channels = self._get_work_dict_key_value('_08_P_Size')
+            self._N_data_channels = self._get_work_dict_key_value("_08_P_Size")
 
-            #Determine how many objects we need to read
-            if self._N_data_channels>0 and self._N_data_object>0:
-                N_objects_to_read = self._N_data_channels*self._N_data_object
-            elif self._N_data_channels>0:
+            # Determine how many objects we need to read
+            if self._N_data_channels > 0 and self._N_data_object > 0:
+                N_objects_to_read = self._N_data_channels * self._N_data_object
+            elif self._N_data_channels > 0:
                 N_objects_to_read = self._N_data_channels
-            elif self._N_data_object>0:
+            elif self._N_data_object > 0:
                 N_objects_to_read = self._N_data_object
             else:
                 N_objects_to_read = 1
 
-            #Lookup what object type we are dealing with and save
-            self._Object_type = \
-                DigitalSurfHandler._mountains_object_types[ \
-                    self._get_work_dict_key_value("_05_Object_Type")]
+            # Lookup what object type we are dealing with and save
+            self._Object_type = DigitalSurfHandler._mountains_object_types[
+                self._get_work_dict_key_value("_05_Object_Type")
+            ]
 
-            #if more than 1
+            # if more than 1
             if N_objects_to_read > 1:
-                #continue reading until everything is done
-                for i in range(1,N_objects_to_read):
-                    #We read an object
+                # continue reading until everything is done
+                for i in range(1, N_objects_to_read):
+                    # We read an object
                     self._read_single_sur_object(f)
-                    #We append it to content list
+                    # We append it to content list
                     self._append_work_dict_to_content()
 
-    def _read_single_sur_object(self,file):
-        for key,val in self._work_dict.items():
-            self._work_dict[key]['value'] = val['b_unpack_fn'](file)
+    def _read_single_sur_object(self, file):
+        for key, val in self._work_dict.items():
+            self._work_dict[key]["value"] = val["b_unpack_fn"](file)
 
     def _append_work_dict_to_content(self):
         """Save the values stored in the work dict in the surface file list"""
-        datadict = deepcopy( \
-            {key:val['value'] for key,val in self._work_dict.items()})
+        datadict = deepcopy({key: val["value"] for key, val in self._work_dict.items()})
         self._list_sur_file_content.append(datadict)
 
-    def _get_work_dict_key_value(self,key):
-        return self._work_dict[key]['value']
+    def _get_work_dict_key_value(self, key):
+        return self._work_dict[key]["value"]
 
     ### Signal dictionary methods
     def _build_sur_dict(self):
         """Create a signal dict with an unpacked object"""
 
-        #If the signal is of the type spectrum or hypercard
-        if self._Object_type in ["_HYPCARD",]:
+        # If the signal is of the type spectrum or hypercard
+        if self._Object_type in [
+            "_HYPCARD",
+        ]:
             self._build_hyperspectral_map()
-            #self._build_hyperspectral_signal_type()
+            # self._build_hyperspectral_signal_type()
         elif self._Object_type in ["_SPECTRUM"]:
             self._build_spectrum()
-            #self._build_spectrum_signal_type()
+            # self._build_spectrum_signal_type()
         elif self._Object_type in ["_PROFILE"]:
             self._build_general_1D_data()
         elif self._Object_type in ["_PROFILESERIE"]:
@@ -587,289 +529,302 @@ class DigitalSurfHandler(object):
         elif self._Object_type in ["_BINARYIMAGE"]:
             self._build_surface()
         else:
-            raise MountainsMapFileError(self._Object_type \
-                + "is not a supported mountain object.")
+            raise MountainsMapFileError(
+                self._Object_type + "is not a supported mountain object."
+            )
 
         return self.signal_dict
 
-    def _build_Xax(self,unpacked_dict,ind=0,nav=False,binned=False):
+    def _build_Xax(self, unpacked_dict, ind=0, nav=False, binned=False):
         """Return X axis dictionary from an unpacked dict. index int and navigate
         boolean can be optionally passed. Default 0 and False respectively."""
-        Xax = { 'name': unpacked_dict['_24_Name_of_X_Axis'],
-                'size': unpacked_dict['_18_Number_of_Points'],
-                'index_in_array': ind,
-                'scale': unpacked_dict['_21_X_Spacing'],
-                'offset': unpacked_dict['_53_X_Offset'],
-                'units': unpacked_dict['_27_X_Step_Unit'],
-                'navigate':nav,
-                'is_binned':binned,
-                }
+        Xax = {
+            "name": unpacked_dict["_24_Name_of_X_Axis"],
+            "size": unpacked_dict["_18_Number_of_Points"],
+            "index_in_array": ind,
+            "scale": unpacked_dict["_21_X_Spacing"],
+            "offset": unpacked_dict["_53_X_Offset"],
+            "units": unpacked_dict["_27_X_Step_Unit"],
+            "navigate": nav,
+            "is_binned": binned,
+        }
         return Xax
 
-    def _build_Yax(self,unpacked_dict,ind=1,nav=False,binned=False):
+    def _build_Yax(self, unpacked_dict, ind=1, nav=False, binned=False):
         """Return X axis dictionary from an unpacked dict. index int and navigate
         boolean can be optionally passed. Default 1 and False respectively."""
-        Yax = { 'name': unpacked_dict['_25_Name_of_Y_Axis'],
-                'size': unpacked_dict['_19_Number_of_Lines'],
-                'index_in_array': ind,
-                'scale': unpacked_dict['_22_Y_Spacing'],
-                'offset': unpacked_dict['_54_Y_Offset'],
-                'units': unpacked_dict['_28_Y_Step_Unit'],
-                'navigate':nav,
-                'is_binned':binned,
-                }
+        Yax = {
+            "name": unpacked_dict["_25_Name_of_Y_Axis"],
+            "size": unpacked_dict["_19_Number_of_Lines"],
+            "index_in_array": ind,
+            "scale": unpacked_dict["_22_Y_Spacing"],
+            "offset": unpacked_dict["_54_Y_Offset"],
+            "units": unpacked_dict["_28_Y_Step_Unit"],
+            "navigate": nav,
+            "is_binned": binned,
+        }
         return Yax
 
-    def _build_Tax(self,unpacked_dict,size_key,ind=0,nav=True,binned=False):
+    def _build_Tax(self, unpacked_dict, size_key, ind=0, nav=True, binned=False):
         """Return T axis dictionary from an unpacked surface object dict.
         Unlike x and y axes, the size key can be determined from various keys:
         _14_W_Size, _15_Size_of_Points or _03_Number_of_Objects. index int
         and navigate boolean can be optionally passed. Default 0 and
         True respectively."""
 
-        #The T axis is somewhat special because it is only defined on series
-        #and is thus only navigation. It is only defined on the first object
-        #in a serie.
-        #Here it needs to be checked that the T axis scale is not 0 Otherwise
-        #it raises hyperspy errors
-        scale = unpacked_dict['_56_T_Spacing']
+        # The T axis is somewhat special because it is only defined on series
+        # and is thus only navigation. It is only defined on the first object
+        # in a serie.
+        # Here it needs to be checked that the T axis scale is not 0 Otherwise
+        # it raises hyperspy errors
+        scale = unpacked_dict["_56_T_Spacing"]
         if scale == 0:
-            scale =1
+            scale = 1
 
-        Tax = { 'name': unpacked_dict['_58_T_Axis_Name'],
-                'size': unpacked_dict[size_key],
-                'index_in_array': ind,
-                'scale': scale,
-                'offset': unpacked_dict['_57_T_Offset'],
-                'units': unpacked_dict['_59_T_Step_Unit'],
-                'navigate':nav,
-                'is_binned':binned,
-                }
+        Tax = {
+            "name": unpacked_dict["_58_T_Axis_Name"],
+            "size": unpacked_dict[size_key],
+            "index_in_array": ind,
+            "scale": scale,
+            "offset": unpacked_dict["_57_T_Offset"],
+            "units": unpacked_dict["_59_T_Step_Unit"],
+            "navigate": nav,
+            "is_binned": binned,
+        }
         return Tax
 
     ### Build methods for individual surface objects
-    def _build_hyperspectral_map(self,):
+    def _build_hyperspectral_map(
+        self,
+    ):
         """Build a hyperspectral map. Hyperspectral maps are single-object
         files with datapoints of _14_W_Size length"""
 
-        #Check that the object contained only one object.
-        #Probably overkill at this point but better safe than sorry
+        # Check that the object contained only one object.
+        # Probably overkill at this point but better safe than sorry
         if len(self._list_sur_file_content) != 1:
-            raise MountainsMapFileError("Input {:s} File is not of Hyperspectral type".format(self._Object_type))
-
-        #We get the dictionary with all the data
-        hypdic = self._list_sur_file_content[0]
-
-        #Add all the axes to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Yax(hypdic,ind=0,nav=True))
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=1,nav=True))
-        #Wavelength axis in hyperspectral surface files are stored as T Axis
-        #with length set as _14_W_Size
-        self.signal_dict['axes'].append(\
-            self._build_Tax(hypdic,'_14_W_Size',ind=2,nav=False))
-
-        #We reshape the data in the correct format
-        self.signal_dict['data'] = hypdic['_62_points'].reshape(\
-            hypdic['_19_Number_of_Lines'],
-            hypdic['_18_Number_of_Points'],
-            hypdic['_14_W_Size'],
+            raise MountainsMapFileError(
+                "Input {:s} File is not of Hyperspectral type".format(self._Object_type)
             )
 
-        self.signal_dict['metadata'] = self._build_metadata(hypdic)
+        # We get the dictionary with all the data
+        hypdic = self._list_sur_file_content[0]
 
-        self.signal_dict['original_metadata'] = self._build_original_metadata()
+        # Add all the axes to the signal dict
+        self.signal_dict["axes"].append(self._build_Yax(hypdic, ind=0, nav=True))
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=1, nav=True))
+        # Wavelength axis in hyperspectral surface files are stored as T Axis
+        # with length set as _14_W_Size
+        self.signal_dict["axes"].append(
+            self._build_Tax(hypdic, "_14_W_Size", ind=2, nav=False)
+        )
 
-    def _build_general_1D_data(self,):
+        # We reshape the data in the correct format
+        self.signal_dict["data"] = hypdic["_62_points"].reshape(
+            hypdic["_19_Number_of_Lines"],
+            hypdic["_18_Number_of_Points"],
+            hypdic["_14_W_Size"],
+        )
+
+        self.signal_dict["metadata"] = self._build_metadata(hypdic)
+
+        self.signal_dict["original_metadata"] = self._build_original_metadata()
+
+    def _build_general_1D_data(
+        self,
+    ):
         """Build general 1D Data objects. Currently work with spectra"""
 
-        #Check that the object contained only one object.
-        #Probably overkill at this point but better safe than sorry
+        # Check that the object contained only one object.
+        # Probably overkill at this point but better safe than sorry
         if len(self._list_sur_file_content) != 1:
             raise MountainsMapFileError("Corrupt file")
 
-        #We get the dictionary with all the data
+        # We get the dictionary with all the data
         hypdic = self._list_sur_file_content[0]
 
-        #Add the axe to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=0,nav=False))
+        # Add the axe to the signal dict
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=0, nav=False))
 
-        #We reshape the data in the correct format
-        self.signal_dict['data'] = hypdic['_62_points']
+        # We reshape the data in the correct format
+        self.signal_dict["data"] = hypdic["_62_points"]
 
-        #Build the metadata
+        # Build the metadata
         self._set_metadata_and_original_metadata(hypdic)
 
-    def _build_spectrum(self,):
+    def _build_spectrum(
+        self,
+    ):
         """Build spectra objects. Spectra and 1D series of spectra are
         saved in the same object."""
 
-        #We get the dictionary with all the data
+        # We get the dictionary with all the data
         hypdic = self._list_sur_file_content[0]
 
-        #Add the signal axis_src to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=1,nav=False))
+        # Add the signal axis_src to the signal dict
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=1, nav=False))
 
-        #If there is more than 1 spectrum also add the navigation axis
-        if hypdic['_19_Number_of_Lines'] != 1:
-            self.signal_dict['axes'].append(\
-                self._build_Yax(hypdic,ind=0,nav=True))
+        # If there is more than 1 spectrum also add the navigation axis
+        if hypdic["_19_Number_of_Lines"] != 1:
+            self.signal_dict["axes"].append(self._build_Yax(hypdic, ind=0, nav=True))
 
-        #We reshape the data in the correct format.
-        #Edit: the data is now squeezed for unneeded dimensions
-        self.signal_dict['data'] = np.squeeze(hypdic['_62_points'].reshape(\
-            hypdic['_19_Number_of_Lines'],
-            hypdic['_18_Number_of_Points'],
-            ))
+        # We reshape the data in the correct format.
+        # Edit: the data is now squeezed for unneeded dimensions
+        self.signal_dict["data"] = np.squeeze(
+            hypdic["_62_points"].reshape(
+                hypdic["_19_Number_of_Lines"],
+                hypdic["_18_Number_of_Points"],
+            )
+        )
 
         self._set_metadata_and_original_metadata(hypdic)
 
-    def _build_1D_series(self,):
+    def _build_1D_series(
+        self,
+    ):
         """Build a series of 1D objects. The T axis is navigation and set from
         the first object"""
 
-        #First object dictionary
+        # First object dictionary
         hypdic = self._list_sur_file_content[0]
 
-        #Metadata are set from first dictionary
+        # Metadata are set from first dictionary
         self._set_metadata_and_original_metadata(hypdic)
 
-        #Add the series-axis to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Tax(hypdic,'_03_Number_of_Objects',ind=0,nav=True))
+        # Add the series-axis to the signal dict
+        self.signal_dict["axes"].append(
+            self._build_Tax(hypdic, "_03_Number_of_Objects", ind=0, nav=True)
+        )
 
-        #All objects must share the same signal axis
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=1,nav=False))
+        # All objects must share the same signal axis
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=1, nav=False))
 
-        #We put all the data together
+        # We put all the data together
         data = []
         for obj in self._list_sur_file_content:
-            data.append(obj['_62_points'])
+            data.append(obj["_62_points"])
 
-        self.signal_dict['data'] = np.stack(data)
+        self.signal_dict["data"] = np.stack(data)
 
-    def _build_surface(self,):
+    def _build_surface(
+        self,
+    ):
         """Build a surface"""
 
-        #Check that the object contained only one object.
-        #Probably overkill at this point but better safe than sorry
+        # Check that the object contained only one object.
+        # Probably overkill at this point but better safe than sorry
         if len(self._list_sur_file_content) != 1:
             raise MountainsMapFileError("CORRUPT {:s} FILE".format(self._Object_type))
 
-        #We get the dictionary with all the data
+        # We get the dictionary with all the data
         hypdic = self._list_sur_file_content[0]
 
-        #Add all the axes to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Yax(hypdic,ind=0,nav=False))
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=1,nav=False))
+        # Add all the axes to the signal dict
+        self.signal_dict["axes"].append(self._build_Yax(hypdic, ind=0, nav=False))
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=1, nav=False))
 
-
-
-        #We reshape the data in the correct format
-        shape = (hypdic['_19_Number_of_Lines'],hypdic['_18_Number_of_Points'])
-        self.signal_dict['data'] = hypdic['_62_points'].reshape(shape)
+        # We reshape the data in the correct format
+        shape = (hypdic["_19_Number_of_Lines"], hypdic["_18_Number_of_Points"])
+        self.signal_dict["data"] = hypdic["_62_points"].reshape(shape)
 
         self._set_metadata_and_original_metadata(hypdic)
 
-    def _build_surface_series(self,):
+    def _build_surface_series(
+        self,
+    ):
         """Build a series of surfaces. The T axis is navigation and set from
         the first object"""
 
-        #First object dictionary
+        # First object dictionary
         hypdic = self._list_sur_file_content[0]
 
-        #Metadata are set from first dictionary
+        # Metadata are set from first dictionary
         self._set_metadata_and_original_metadata(hypdic)
 
-        #Add the series-axis to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Tax(hypdic,'_03_Number_of_Objects',ind=0,nav=True))
+        # Add the series-axis to the signal dict
+        self.signal_dict["axes"].append(
+            self._build_Tax(hypdic, "_03_Number_of_Objects", ind=0, nav=True)
+        )
 
-        #All objects must share the same signal axes
-        self.signal_dict['axes'].append(\
-                self._build_Yax(hypdic,ind=1,nav=False))
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=2,nav=False))
+        # All objects must share the same signal axes
+        self.signal_dict["axes"].append(self._build_Yax(hypdic, ind=1, nav=False))
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=2, nav=False))
 
-        #shape of the surfaces in the series
-        shape = (hypdic['_19_Number_of_Lines'],hypdic['_18_Number_of_Points'])
-        #We put all the data together
+        # shape of the surfaces in the series
+        shape = (hypdic["_19_Number_of_Lines"], hypdic["_18_Number_of_Points"])
+        # We put all the data together
         data = []
         for obj in self._list_sur_file_content:
-            data.append(obj['_62_points'].reshape(shape))
+            data.append(obj["_62_points"].reshape(shape))
 
-        self.signal_dict['data'] = np.stack(data)
+        self.signal_dict["data"] = np.stack(data)
 
-    def _build_RGB_surface(self,):
+    def _build_RGB_surface(
+        self,
+    ):
         """Build a series of surfaces. The T axis is navigation and set from
         P Size"""
 
-        #First object dictionary
+        # First object dictionary
         hypdic = self._list_sur_file_content[0]
 
-        #Metadata are set from first dictionary
+        # Metadata are set from first dictionary
         self._set_metadata_and_original_metadata(hypdic)
 
-        #Add the series-axis to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Tax(hypdic,'_08_P_Size',ind=0,nav=True))
+        # Add the series-axis to the signal dict
+        self.signal_dict["axes"].append(
+            self._build_Tax(hypdic, "_08_P_Size", ind=0, nav=True)
+        )
 
-        #All objects must share the same signal axes
-        self.signal_dict['axes'].append(\
-                self._build_Yax(hypdic,ind=1,nav=False))
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=2,nav=False))
+        # All objects must share the same signal axes
+        self.signal_dict["axes"].append(self._build_Yax(hypdic, ind=1, nav=False))
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=2, nav=False))
 
-        #shape of the surfaces in the series
-        shape = (hypdic['_19_Number_of_Lines'],hypdic['_18_Number_of_Points'])
-        #We put all the data together
+        # shape of the surfaces in the series
+        shape = (hypdic["_19_Number_of_Lines"], hypdic["_18_Number_of_Points"])
+        # We put all the data together
         data = []
         for obj in self._list_sur_file_content:
-            data.append(obj['_62_points'].reshape(shape))
+            data.append(obj["_62_points"].reshape(shape))
 
-        #Pushing data into the dictionary
-        self.signal_dict['data'] = np.stack(data)
+        # Pushing data into the dictionary
+        self.signal_dict["data"] = np.stack(data)
 
-    def _build_RGB_image(self,):
+    def _build_RGB_image(
+        self,
+    ):
         """Build an RGB image. The T axis is navigation and set from
         P Size"""
 
-        #First object dictionary
+        # First object dictionary
         hypdic = self._list_sur_file_content[0]
 
-        #Metadata are set from first dictionary
+        # Metadata are set from first dictionary
         self._set_metadata_and_original_metadata(hypdic)
 
-        #Add the series-axis to the signal dict
-        self.signal_dict['axes'].append(\
-            self._build_Tax(hypdic,'_08_P_Size',ind=0,nav=True))
+        # Add the series-axis to the signal dict
+        self.signal_dict["axes"].append(
+            self._build_Tax(hypdic, "_08_P_Size", ind=0, nav=True)
+        )
 
-        #All objects must share the same signal axes
-        self.signal_dict['axes'].append(\
-                self._build_Yax(hypdic,ind=1,nav=False))
-        self.signal_dict['axes'].append(\
-            self._build_Xax(hypdic,ind=2,nav=False))
+        # All objects must share the same signal axes
+        self.signal_dict["axes"].append(self._build_Yax(hypdic, ind=1, nav=False))
+        self.signal_dict["axes"].append(self._build_Xax(hypdic, ind=2, nav=False))
 
-        #shape of the surfaces in the series
-        shape = (hypdic['_19_Number_of_Lines'],hypdic['_18_Number_of_Points'])
-        #We put all the data together
+        # shape of the surfaces in the series
+        shape = (hypdic["_19_Number_of_Lines"], hypdic["_18_Number_of_Points"])
+        # We put all the data together
         data = []
         for obj in self._list_sur_file_content:
-            data.append(obj['_62_points'].reshape(shape))
+            data.append(obj["_62_points"].reshape(shape))
 
-        #Pushing data into the dictionary
-        self.signal_dict['data'] = np.stack(data)
+        # Pushing data into the dictionary
+        self.signal_dict["data"] = np.stack(data)
 
-        self.signal_dict.update({'post_process':[self.post_process_RGB]})
+        self.signal_dict.update({"post_process": [self.post_process_RGB]})
 
     ### Metadata utility methods
-    def _build_metadata(self,unpacked_dict):
+    def _build_metadata(self, unpacked_dict):
         """Return a minimalistic metadata dictionary according to hyperspy
         format. Accept a dictionary as an input because dictionary with the
         headers of a mountians object.
@@ -884,98 +839,105 @@ class DigitalSurfHandler(object):
 
         """
 
-        #Formatting for complicated strings. We add parentheses to units
-        qty_unit = unpacked_dict['_29_Z_Step_Unit']
-        #We strip unit from any character that might pre-format it
-        qty_unit = qty_unit.strip(' \t\n()[]')
-        #If unit string is still truthy after strip we add parentheses
+        # Formatting for complicated strings. We add parentheses to units
+        qty_unit = unpacked_dict["_29_Z_Step_Unit"]
+        # We strip unit from any character that might pre-format it
+        qty_unit = qty_unit.strip(" \t\n()[]")
+        # If unit string is still truthy after strip we add parentheses
         if qty_unit:
             qty_unit = "({:s})".format(qty_unit)
 
+        quantity_str = " ".join([unpacked_dict["_26_Name_of_Z_Axis"], qty_unit]).strip()
 
-        quantity_str = " ".join([
-            unpacked_dict['_26_Name_of_Z_Axis'],qty_unit]).strip()
+        # Date and time are set in metadata only if all values are not set to 0
 
-        #Date and time are set in metadata only if all values are not set to 0
-
-        date = [unpacked_dict['_45_Year'],
-                unpacked_dict['_44_Month'],
-                unpacked_dict['_43_Day']]
+        date = [
+            unpacked_dict["_45_Year"],
+            unpacked_dict["_44_Month"],
+            unpacked_dict["_43_Day"],
+        ]
         if not all(v == 0 for v in date):
-            date_str =  "{:4d}-{:2d}-{:2d}".format(date[0],date[1],date[2])
+            date_str = "{:4d}-{:2d}-{:2d}".format(date[0], date[1], date[2])
         else:
             date_str = ""
 
-        time = [unpacked_dict['_42_Hours'],
-                unpacked_dict['_41_Minutes'],
-                unpacked_dict['_40_Seconds']]
+        time = [
+            unpacked_dict["_42_Hours"],
+            unpacked_dict["_41_Minutes"],
+            unpacked_dict["_40_Seconds"],
+        ]
 
         if not all(v == 0 for v in time):
-            time_str = "{:d}:{:d}:{:d}".format(time[0],time[1],time[2])
+            time_str = "{:d}:{:d}:{:d}".format(time[0], time[1], time[2])
         else:
             time_str = ""
 
-        #Metadata dictionary initialization
+        # Metadata dictionary initialization
         metadict = {
-            "General":{
-                "authors": unpacked_dict['_07_Operator_Name'],
-                "date":date_str,
+            "General": {
+                "authors": unpacked_dict["_07_Operator_Name"],
+                "date": date_str,
                 "original_filename": os.path.split(self.filename)[1],
                 "time": time_str,
-                },
+            },
             "Signal": {
                 "quantity": quantity_str,
                 "signal_type": "",
-                },
-            }
+            },
+        }
 
         return metadict
 
-    def _build_original_metadata(self,):
+    def _build_original_metadata(
+        self,
+    ):
         """Builds a metadata dictionnary from the header"""
         original_metadata_dict = {}
 
-        Ntot = (self._N_data_object+1)*(self._N_data_channels+1)
+        Ntot = (self._N_data_object + 1) * (self._N_data_channels + 1)
 
-        #Iteration over Number of data objects
+        # Iteration over Number of data objects
         for i in range(self._N_data_object):
-            #Iteration over the Number of Data channels
+            # Iteration over the Number of Data channels
             for j in range(self._N_data_channels):
-                #Creating a dictionary key for each object
-                k = (i+1)*(j+1)
-                key = "Object_{:d}_Channel_{:d}".format(i,j)
-                original_metadata_dict.update({key:{}})
+                # Creating a dictionary key for each object
+                k = (i + 1) * (j + 1)
+                key = "Object_{:d}_Channel_{:d}".format(i, j)
+                original_metadata_dict.update({key: {}})
 
-                #We load one full object header
-                a = self._list_sur_file_content[k-1]
+                # We load one full object header
+                a = self._list_sur_file_content[k - 1]
 
-                #Save it as original metadata dictionary
-                headerdict = {"H"+l.lstrip('_'):a[l] for l in a if l not in \
-                    ("_62_points",'_61_Private_zone')}
-                original_metadata_dict[key].update({"Header" : headerdict})
+                # Save it as original metadata dictionary
+                headerdict = {
+                    "H" + l.lstrip("_"): a[l]
+                    for l in a
+                    if l not in ("_62_points", "_61_Private_zone")
+                }
+                original_metadata_dict[key].update({"Header": headerdict})
 
-                #The second dictionary might contain custom mountainsmap params
+                # The second dictionary might contain custom mountainsmap params
                 parsedict = {}
 
-                #Check if it is the case and append it to
-                #original metadata if yes
+                # Check if it is the case and append it to
+                # original metadata if yes
 
-                valid_comment = self._check_comments(a["_60_Comment"],'$','=')
+                valid_comment = self._check_comments(a["_60_Comment"], "$", "=")
                 if valid_comment:
-                    parsedict = self._MS_parse(a["_60_Comment"],'$','=')
-                    parsedict = {l.lstrip('_'):m for l,m in parsedict.items()}
-                    original_metadata_dict[key].update({"Parsed" : parsedict})
+                    parsedict = self._MS_parse(a["_60_Comment"], "$", "=")
+                    parsedict = {l.lstrip("_"): m for l, m in parsedict.items()}
+                    original_metadata_dict[key].update({"Parsed": parsedict})
 
         return original_metadata_dict
 
-    def _set_metadata_and_original_metadata(self,unpacked_dict):
+    def _set_metadata_and_original_metadata(self, unpacked_dict):
         """Run successively _build_metadata and _build_original_metadata
         and set signal dictionary with results"""
 
-        self.signal_dict['metadata'] = self._build_metadata(unpacked_dict)
-        self.signal_dict['original_metadata'] = self._build_original_metadata()
+        self.signal_dict["metadata"] = self._build_metadata(unpacked_dict)
+        self.signal_dict["original_metadata"] = self._build_original_metadata()
 
-    def _check_comments(self,commentsstr,prefix,delimiter):
+    def _check_comments(self, commentsstr, prefix, delimiter):
         """Check if comment string is parsable into metadata dictionary.
         Some specific lines (empty or starting with @@) will be ignored,
         but any non-ignored line must conform to being a title line (beginning
@@ -996,44 +958,44 @@ class DigitalSurfHandler(object):
         valid: boolean
         """
 
-        #Titlestart markers start with Prefix ($) followed by underscore
-        TITLESTART = '{:s}_'.format(prefix)
+        # Titlestart markers start with Prefix ($) followed by underscore
+        TITLESTART = "{:s}_".format(prefix)
 
-        #We start by assuming that the comment string is valid
-        #but contains 0 valid (= parsable) lines
+        # We start by assuming that the comment string is valid
+        # but contains 0 valid (= parsable) lines
         valid = True
         N_valid_lines = 0
 
         for line in commentsstr.splitlines():
-            #Here we ignore any empty line or line starting with @@
+            # Here we ignore any empty line or line starting with @@
             ignore = False
-            if not line.strip() or line.startswith('@@'):
+            if not line.strip() or line.startswith("@@"):
                 ignore = True
-            #If the line must not be ignored
+            # If the line must not be ignored
             if not ignore:
-                #If line starts with a titlestart marker we it counts as valid
+                # If line starts with a titlestart marker we it counts as valid
                 if line.startswith(TITLESTART):
                     N_valid_lines += 1
                 # if it does not we check that it has the delimiter and
                 # starts with prefix
                 else:
-                    #We check that line contains delimiter and prefix
-                    #if it does the count of valid line is increased
+                    # We check that line contains delimiter and prefix
+                    # if it does the count of valid line is increased
                     if delimiter in line and line.startswith(prefix):
                         N_valid_lines += 1
-                    #Otherwise the whole comment string is thrown out
+                    # Otherwise the whole comment string is thrown out
                     else:
                         valid = False
 
-        #finally, it total number of valid line is 0 we throw out this comments
-        if N_valid_lines ==0:
+        # finally, it total number of valid line is 0 we throw out this comments
+        if N_valid_lines == 0:
             valid = False
 
-        #return falsiness of the string.
+        # return falsiness of the string.
         return valid
 
     def _MS_parse(self, strMS, prefix, delimiter):
-        """ Parses a string containing metadata information. The string can be
+        """Parses a string containing metadata information. The string can be
         read from the comment section of a .sur file, or, alternatively, a file
         containing them with a similar formatting.
 
@@ -1049,123 +1011,131 @@ class DigitalSurfHandler(object):
         dictMS: dictionnary in the correct hyperspy metadata format
 
         """
-        #dictMS is created as an empty dictionnary
+        # dictMS is created as an empty dictionnary
         dictMS = {}
-        #Title lines start with an underscore
-        TITLESTART = '{:s}_'.format(prefix)
+        # Title lines start with an underscore
+        TITLESTART = "{:s}_".format(prefix)
 
-        for line in strMS.splitlines() :
-            #Here we ignore any empty line or line starting with @@
+        for line in strMS.splitlines():
+            # Here we ignore any empty line or line starting with @@
             ignore = False
-            if not line.strip() or line.startswith('@@'):
+            if not line.strip() or line.startswith("@@"):
                 ignore = True
-            #If the line must not be ignored
+            # If the line must not be ignored
             if not ignore:
                 if line.startswith(TITLESTART):
-                    #We strip keys from whitespace at the end and beginning
-                    keyMain = line[len(TITLESTART):].strip()
+                    # We strip keys from whitespace at the end and beginning
+                    keyMain = line[len(TITLESTART) :].strip()
                     dictMS[keyMain] = {}
                 elif line.startswith(prefix):
                     key, *liValue = line.split(delimiter)
-                    #Key is also stripped from beginning or end whitespace
-                    key = key[len(prefix):].strip()
-                    strValue = liValue[0] if len(liValue)>0 else ""
+                    # Key is also stripped from beginning or end whitespace
+                    key = key[len(prefix) :].strip()
+                    strValue = liValue[0] if len(liValue) > 0 else ""
                     # remove whitespace at the beginning of value
                     strValue = strValue.strip()
-                    liValue = strValue.split(' ')
-                    try :
+                    liValue = strValue.split(" ")
+                    try:
                         if key == "Grating":
-                            dictMS[keyMain][key] = liValue[0] # we don't want to eval this one
-                        else :
+                            dictMS[keyMain][key] = liValue[
+                                0
+                            ]  # we don't want to eval this one
+                        else:
                             dictMS[keyMain][key] = eval(liValue[0])
-                    except :
+                    except:
                         dictMS[keyMain][key] = liValue[0]
                     if len(liValue) > 1:
-                        dictMS[keyMain][key+'_units'] = liValue[1]
+                        dictMS[keyMain][key + "_units"] = liValue[1]
         return dictMS
 
     ### Post processing
-    def post_process_RGB(self,signal):
+    def post_process_RGB(self, signal):
         signal = signal.transpose()
         max_data = np.nanmax(signal.data)
-        if max_data <=256:
-            signal.change_dtype('uint8')
-            signal.change_dtype('rgb8')
-        elif max_data <=65536:
-            signal.change_dtype('uint8')
-            signal.change_dtype('rgb8')
+        if max_data <= 256:
+            signal.change_dtype("uint8")
+            signal.change_dtype("rgb8")
+        elif max_data <= 65536:
+            signal.change_dtype("uint8")
+            signal.change_dtype("rgb8")
         else:
-            warnings.warn("""RGB-announced data could not be converted to
-            uint8 or uint16 datatype""")
+            warnings.warn(
+                """RGB-announced data could not be converted to
+            uint8 or uint16 datatype"""
+            )
 
         return signal
 
     ### pack/unpack binary quantities
-    def _get_int16(self,file, default=None, signed=True):
+    def _get_int16(self, file, default=None, signed=True):
         """Read a 16-bits int with a user-definable default value if
         no file is given"""
-        if file is None :
+        if file is None:
             return default
         b = file.read(2)
-        if sys.byteorder == 'big' :
-            return struct.unpack('>h', b)[0]
-        else :
-            return struct.unpack('<h', b)[0]
+        if sys.byteorder == "big":
+            return struct.unpack(">h", b)[0]
+        else:
+            return struct.unpack("<h", b)[0]
 
     def _set_int16(self, file, val):
-	       file.write(struct.pack('<h', val))
+        file.write(struct.pack("<h", val))
 
-    def _get_str(self, file, size, default=None, encoding='latin-1'):
+    def _get_str(self, file, size, default=None, encoding="latin-1"):
         """Read a str of defined size in bytes with a user-definable default
         value if no file is given"""
-        if file is None :
+        if file is None:
             return default
         read_str = file.read(size).decode(encoding)
-        return read_str.strip(' \t\n')
+        return read_str.strip(" \t\n")
 
-    def _set_str(self, file, val, size, encoding='latin-1'):
+    def _set_str(self, file, val, size, encoding="latin-1"):
         """Write a str of defined size in bytes to a file. struct.pack
         will automatically trim the string if it is too long"""
-        file.write(struct.pack('<{:d}s'.format(size),
-            '{{:<{:d}s}}'.format(size).format(val).encode(encoding)))
+        file.write(
+            struct.pack(
+                "<{:d}s".format(size),
+                "{{:<{:d}s}}".format(size).format(val).encode(encoding),
+            )
+        )
 
-    def _get_int32(self,file, default=None):
+    def _get_int32(self, file, default=None):
         """Read a 32-bits int with a user-definable default value if no
         file is given"""
-        if file is None :
+        if file is None:
             return default
         b = file.read(4)
-        if sys.byteorder == 'big' :
-            return struct.unpack('>i', b)[0]
-        else :
-            return struct.unpack('<i', b)[0]
+        if sys.byteorder == "big":
+            return struct.unpack(">i", b)[0]
+        else:
+            return struct.unpack("<i", b)[0]
 
     def _set_int32(self, file, val):
-        """Write a 32-bits int in a file f """
-        file.write(struct.pack('<i', val))
+        """Write a 32-bits int in a file f"""
+        file.write(struct.pack("<i", val))
 
-    def _get_float(self,file,default=None):
+    def _get_float(self, file, default=None):
         """Read a 4-bytes (single precision) float from a binary file f with a
         default value if no file is given"""
         if file is None:
             return default
-        return struct.unpack('<f', file.read(4))[0]
+        return struct.unpack("<f", file.read(4))[0]
 
     def _set_float(file, val):
         """write a 4-bytes (single precision) float in a file"""
-        file.write(struct.pack('<f', val))
+        file.write(struct.pack("<f", val))
 
     def _get_uint32(self, file, default=None):
-    	if file is None :
-    		return default
-    	b = file.read(4)
-    	if sys.byteorder == 'big' :
-    		return struct.unpack('>I', b)[0]
-    	else :
-    		return struct.unpack('<I', b)[0]
+        if file is None:
+            return default
+        b = file.read(4)
+        if sys.byteorder == "big":
+            return struct.unpack(">I", b)[0]
+        else:
+            return struct.unpack("<I", b)[0]
 
     def _set_uint32(self, file, val):
-	       file.write(struct.pack('<I', val))
+        file.write(struct.pack("<I", val))
 
     def _get_bytes(self, file, size, default=None):
         if file is None:
@@ -1174,103 +1144,107 @@ class DigitalSurfHandler(object):
             return file.read(size)
 
     def _set_bytes(self, file, val, size):
-    	file.write(struct.pack('<{:d}s'.format(size), val))
+        file.write(struct.pack("<{:d}s".format(size), val))
 
-    def _unpack_comment(self,file,encoding='latin-1'):
+    def _unpack_comment(self, file, encoding="latin-1"):
         commentsize = self._get_work_dict_key_value("_50_Comment_size")
-        return self._get_str(file,commentsize,encoding)
+        return self._get_str(file, commentsize, encoding)
 
-    def _pack_comment(self,file,val,encoding='latin-1'):
+    def _pack_comment(self, file, val, encoding="latin-1"):
         commentsize = self._get_work_dict_key_value("_50_Comment_size")
-        self._set_str(file,val,commentsize)
+        self._set_str(file, val, commentsize)
 
-    def _unpack_private(self,file,encoding='latin-1'):
+    def _unpack_private(self, file, encoding="latin-1"):
         privatesize = self._get_work_dict_key_value("_51_Private_size")
-        return self._get_str(file,privatesize,encoding)
+        return self._get_str(file, privatesize, encoding)
 
-    def _pack_private(self,file,val,encoding='latin-1'):
+    def _pack_private(self, file, val, encoding="latin-1"):
         privatesize = self._get_work_dict_key_value("_51_Private_size")
-        self._set_str(file,val,commentsize)
+        self._set_str(file, val, commentsize)
 
-    def _unpack_data(self,file,encoding='latin-1'):
+    def _unpack_data(self, file, encoding="latin-1"):
         """This needs to be special because it reads until the end of
         file. This causes an error in the series of data"""
 
-        #Size of datapoints in bytes. Always int16 (==2) or 32 (==4)
-        Psize = int(self._get_work_dict_key_value('_15_Size_of_Points')/8)
+        # Size of datapoints in bytes. Always int16 (==2) or 32 (==4)
+        Psize = int(self._get_work_dict_key_value("_15_Size_of_Points") / 8)
         dtype = np.int16 if Psize == 2 else np.int32
 
-        if self._get_work_dict_key_value('_01_Signature') != 'DSCOMPRESSED' :
-            #If the points are not compressed we need to read the exact
-            #size occupied by datapoints
+        if self._get_work_dict_key_value("_01_Signature") != "DSCOMPRESSED":
+            # If the points are not compressed we need to read the exact
+            # size occupied by datapoints
 
-            #Datapoints in X and Y dimensions
-            Npts_tot = self._get_work_dict_key_value('_20_Total_Nb_of_Pts')
-            #Datasize in WL
-            Wsize = self._get_work_dict_key_value('_14_W_Size')
+            # Datapoints in X and Y dimensions
+            Npts_tot = self._get_work_dict_key_value("_20_Total_Nb_of_Pts")
+            # Datasize in WL
+            Wsize = self._get_work_dict_key_value("_14_W_Size")
 
-            #We need to take into account the fact that Wsize is often
-            #set to 0 instead of 1 in non-spectral data to compute the
-            #space occupied by data in the file
-            readsize = Npts_tot*Psize
+            # We need to take into account the fact that Wsize is often
+            # set to 0 instead of 1 in non-spectral data to compute the
+            # space occupied by data in the file
+            readsize = Npts_tot * Psize
             if Wsize != 0:
-                readsize*=Wsize
-            #if Npts_channel is not 0:
+                readsize *= Wsize
+            # if Npts_channel is not 0:
             #    readsize*=Npts_channel
 
-            #Read the exact size of the data
-            _points = np.frombuffer(file.read(readsize),dtype=dtype)
-            #_points = np.fromstring(file.read(readsize),dtype=dtype)
+            # Read the exact size of the data
+            _points = np.frombuffer(file.read(readsize), dtype=dtype)
+            # _points = np.fromstring(file.read(readsize),dtype=dtype)
 
         else:
-            #If the points are compressed do the uncompress magic. There
-            #the space occupied by datapoints is self-taken care of.
-            #Number of streams
+            # If the points are compressed do the uncompress magic. There
+            # the space occupied by datapoints is self-taken care of.
+            # Number of streams
             _directoryCount = self._get_uint32(file)
 
-            #empty lists to store the read sizes
+            # empty lists to store the read sizes
             rawLengthData = []
             zipLengthData = []
             for i in range(_directoryCount):
-                #Size of raw and compressed data sizes in each stream
+                # Size of raw and compressed data sizes in each stream
                 rawLengthData.append(self._get_uint32(file))
                 zipLengthData.append(self._get_uint32(file))
 
-            #We now initialize an empty binary string to store the results
-            rawData = b''
+            # We now initialize an empty binary string to store the results
+            rawData = b""
             for i in range(_directoryCount):
-                #And for each stream we uncompress using zip lib
-                #and add it to raw string
+                # And for each stream we uncompress using zip lib
+                # and add it to raw string
                 rawData += zlib.decompress(file.read(zipLengthData[i]))
 
-            #Finally numpy converts it to a numeric object
+            # Finally numpy converts it to a numeric object
             _points = np.frombuffer(rawData, dtype=dtype)
-            #_points = np.fromstring(rawData, dtype=dtype)
+            # _points = np.fromstring(rawData, dtype=dtype)
 
         # rescale data
-        #We set non measured points to nan according to .sur ways
+        # We set non measured points to nan according to .sur ways
         nm = []
-        if self._get_work_dict_key_value("_11_Special_Points") == 1 :
+        if self._get_work_dict_key_value("_11_Special_Points") == 1:
             # has unmeasured points
-            nm = _points == self._get_work_dict_key_value("_16_Zmin")-2
+            nm = _points == self._get_work_dict_key_value("_16_Zmin") - 2
 
-        #We set the point in the numeric scale
-        _points = _points.astype(float) \
-            * self._get_work_dict_key_value("_23_Z_Spacing") \
-            * self._get_work_dict_key_value("_35_Z_Unit_Ratio") \
-            + self._get_work_dict_key_value("_55_Z_Offset")
+        # We set the point in the numeric scale
+        _points = _points.astype(float) * self._get_work_dict_key_value(
+            "_23_Z_Spacing"
+        ) * self._get_work_dict_key_value(
+            "_35_Z_Unit_Ratio"
+        ) + self._get_work_dict_key_value(
+            "_55_Z_Offset"
+        )
 
         _points[nm] = np.nan
-        #Return the points, rescaled
+        # Return the points, rescaled
         return _points
 
-    def _pack_data(self,file,val,encoding='latin-1'):
+    def _pack_data(self, file, val, encoding="latin-1"):
         """This needs to be special because it writes until the end of
         file."""
         datasize = self._get_work_dict_key_value("_62_points")
-        self._set_str(file,val,datasize)
+        self._set_str(file, val, datasize)
 
-def file_reader(filename,**kwds):
+
+def file_reader(filename, **kwds):
     """Read a mountainsmap .sur file and return a dictionnary containing the
     information necessary for creating the data object
 
@@ -1291,4 +1265,6 @@ def file_reader(filename,**kwds):
 
     surdict = ds._build_sur_dict()
 
-    return [surdict,]
+    return [
+        surdict,
+    ]

--- a/rsciio/tests/generate_dm_testing_files.py
+++ b/rsciio/tests/generate_dm_testing_files.py
@@ -22,39 +22,39 @@
 import numpy as np
 
 dm3_data_types = {
-    1: '<i2',  # 2 byte integer signed ("short")
-    2: '<f4',  # 4 byte real (IEEE 754)
-    3: '<c8',  # 8 byte complex
-    5: '<c8',  # 8 byte complex (packed)
-    6: '<u1',  # 1 byte integer unsigned ("byte")
-    7: '<i4',  # 4 byte integer signed ("long")
-    8: np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1'), ('A', 'u1')]),
-    9: '<i1',  # byte integer signed
-    10: '<u2',  # 2 byte integer unsigned
-    11: '<u4',  # 4 byte integer unsigned
-    12: '<f8',  # 8 byte real
-    13: '<c16',  # byte complex
-    14: 'bool',  # 1 byte binary (ie 0 or 1)
-    23: np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1'), ('A', 'u1')]),
+    1: "<i2",  # 2 byte integer signed ("short")
+    2: "<f4",  # 4 byte real (IEEE 754)
+    3: "<c8",  # 8 byte complex
+    5: "<c8",  # 8 byte complex (packed)
+    6: "<u1",  # 1 byte integer unsigned ("byte")
+    7: "<i4",  # 4 byte integer signed ("long")
+    8: np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1"), ("A", "u1")]),
+    9: "<i1",  # byte integer signed
+    10: "<u2",  # 2 byte integer unsigned
+    11: "<u4",  # 4 byte integer unsigned
+    12: "<f8",  # 8 byte real
+    13: "<c16",  # byte complex
+    14: "bool",  # 1 byte binary (ie 0 or 1)
+    23: np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1"), ("A", "u1")]),
 }
 
 dm4_data_types = {
-    1: '<i2',  # 2 byte integer signed ("short")
-    2: '<f4',  # 4 byte real (IEEE 754)
-    3: '<c8',  # 8 byte complex
-    5: '<c8',  # 8 byte complex (packed)
-    6: '<u1',  # 1 byte integer unsigned ("byte")
-    7: '<i4',  # 4 byte integer signed ("long")
-    8: np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1'), ('A', 'u1')]),
-    9: '<i1',  # byte integer signed
-    10: '<u2',  # 2 byte integer unsigned
-    11: '<u4',  # 4 byte integer unsigned
-    12: '<f8',  # 8 byte real
-    13: '<c16',  # byte complex
-    14: 'bool',  # 1 byte binary (ie 0 or 1)
-    23: np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1'), ('A', 'u1')]),
-    27: 'complex64',  # not numpy: 8-Byte packed complex (FFT data)
-    28: 'complex128',  # not numpy: 16-Byte packed complex (FFT data)
+    1: "<i2",  # 2 byte integer signed ("short")
+    2: "<f4",  # 4 byte real (IEEE 754)
+    3: "<c8",  # 8 byte complex
+    5: "<c8",  # 8 byte complex (packed)
+    6: "<u1",  # 1 byte integer unsigned ("byte")
+    7: "<i4",  # 4 byte integer signed ("long")
+    8: np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1"), ("A", "u1")]),
+    9: "<i1",  # byte integer signed
+    10: "<u2",  # 2 byte integer unsigned
+    11: "<u4",  # 4 byte integer unsigned
+    12: "<f8",  # 8 byte real
+    13: "<c16",  # byte complex
+    14: "bool",  # 1 byte binary (ie 0 or 1)
+    23: np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1"), ("A", "u1")]),
+    27: "complex64",  # not numpy: 8-Byte packed complex (FFT data)
+    28: "complex128",  # not numpy: 16-Byte packed complex (FFT data)
 }
 
 
@@ -66,9 +66,10 @@ def generate_1D_files(f, data_types, dmversion):
             'filename = path+"'
             f'\\\\{subfolder}\\\\test-{key}.dm{dmversion}"\n'
             f'im := NewImage("test", {key}, 2)\n'
-            'im[0,1] = 1\n'
-            'im[1,2] = 2\n'
-            'im.SaveAsGatan(filename)\n')
+            "im[0,1] = 1\n"
+            "im[1,2] = 2\n"
+            "im.SaveAsGatan(filename)\n"
+        )
 
 
 def generate_2D_files(f, data_types, dmversion):
@@ -79,11 +80,12 @@ def generate_2D_files(f, data_types, dmversion):
             'filename = path+"'
             f'\\\\{subfolder}\\\\test-{key}.dm{dmversion}"\n'
             f'im := NewImage("test", {key}, 2, 2)\n'
-            'im[0,0,1,1] = 1\n'
-            'im[0,1,1,2] = 2\n'
-            'im[1,0,2,1] = 3\n'
-            'im[1,1,2,2] = 4\n'
-            'im.SaveAsGatan(filename)\n')
+            "im[0,0,1,1] = 1\n"
+            "im[0,1,1,2] = 2\n"
+            "im[1,0,2,1] = 3\n"
+            "im[1,1,2,2] = 4\n"
+            "im.SaveAsGatan(filename)\n"
+        )
 
 
 def generate_3D_files(f, data_types, dmversion):
@@ -94,15 +96,16 @@ def generate_3D_files(f, data_types, dmversion):
             'filename = path+"'
             f'\\\\{subfolder}\\\\test-{key}.dm{dmversion}"\n'
             f'im := NewImage("test", {key}, 2, 2,2)\n'
-            'im[0,0,0,1,1,1] = 1\n'
-            'im[1,0,0,2,1,1] = 2\n'
-            'im[0,1,0,1,2,1] = 3\n'
-            'im[1,1,0,2,2,1] = 4\n'
-            'im[0,0,1,1,1,2] = 5\n'
-            'im[1,0,1,2,1,2] = 6\n'
-            'im[0,1,1,1,2,2] = 7\n'
-            'im[1,1,1,2,2,2] = 8\n'
-            'im.SaveAsGatan(filename)\n')
+            "im[0,0,0,1,1,1] = 1\n"
+            "im[1,0,0,2,1,1] = 2\n"
+            "im[0,1,0,1,2,1] = 3\n"
+            "im[1,1,0,2,2,1] = 4\n"
+            "im[0,0,1,1,1,2] = 5\n"
+            "im[1,0,1,2,1,2] = 6\n"
+            "im[0,1,1,1,2,2] = 7\n"
+            "im[1,1,1,2,2,2] = 8\n"
+            "im.SaveAsGatan(filename)\n"
+        )
 
 
 def generate_4D_files(f, data_types, dmversion):
@@ -113,33 +116,36 @@ def generate_4D_files(f, data_types, dmversion):
             'filename = path+"'
             f'\\\\{subfolder}\\\\test-{key}.dm{dmversion}"\n'
             f'im := NewImage("test", %i, 2,2,2,2)\n'
-            'im[0,0,0,0,1,1,1,1] = 1\n'
-            'im[1,0,0,0,2,1,1,1] = 2\n'
-            'im[0,1,0,0,1,2,1,1] = 3\n'
-            'im[1,1,0,0,2,2,1,1] = 4\n'
-            'im[0,0,1,0,1,1,2,1] = 5\n'
-            'im[1,0,1,0,2,1,2,1] = 6\n'
-            'im[0,1,1,0,1,2,2,1] = 7\n'
-            'im[1,1,1,0,2,2,2,1] = 8\n'
-            'im[0,0,0,1,1,1,1,2] = 9\n'
-            'im[1,0,0,1,2,1,1,2] = 10\n'
-            'im[0,1,0,1,1,2,1,2] = 11\n'
-            'im[1,1,0,1,2,2,1,2] = 12\n'
-            'im[0,0,1,1,1,1,2,2] = 13\n'
-            'im[1,0,1,1,2,1,2,2] = 14\n'
-            'im[0,1,1,1,1,2,2,2] = 15\n'
-            'im[1,1,1,1,2,2,2,2] = 16\n'
-            'im.SaveAsGatan(filename)\n' % (dmversion, key, dmversion, key))
+            "im[0,0,0,0,1,1,1,1] = 1\n"
+            "im[1,0,0,0,2,1,1,1] = 2\n"
+            "im[0,1,0,0,1,2,1,1] = 3\n"
+            "im[1,1,0,0,2,2,1,1] = 4\n"
+            "im[0,0,1,0,1,1,2,1] = 5\n"
+            "im[1,0,1,0,2,1,2,1] = 6\n"
+            "im[0,1,1,0,1,2,2,1] = 7\n"
+            "im[1,1,1,0,2,2,2,1] = 8\n"
+            "im[0,0,0,1,1,1,1,2] = 9\n"
+            "im[1,0,0,1,2,1,1,2] = 10\n"
+            "im[0,1,0,1,1,2,1,2] = 11\n"
+            "im[1,1,0,1,2,2,1,2] = 12\n"
+            "im[0,0,1,1,1,1,2,2] = 13\n"
+            "im[1,0,1,1,2,1,2,2] = 14\n"
+            "im[0,1,1,1,1,2,2,2] = 15\n"
+            "im[1,1,1,1,2,2,2,2] = 16\n"
+            "im.SaveAsGatan(filename)\n" % (dmversion, key, dmversion, key)
+        )
 
-if __name__ == '__main__':
-    with open("generate_dm3_test_files.s", "w") as f1, open("generate_dm4_test_files.s", "w") as f2:
+
+if __name__ == "__main__":
+    with open("generate_dm3_test_files.s", "w") as f1, open(
+        "generate_dm4_test_files.s", "w"
+    ) as f2:
         for f in (f1, f2):
-            f.write('image im\n')
-            f.write('string filename, path\n')
-            f.write('path = GetApplicationDirectory(2, 0)\n')
+            f.write("image im\n")
+            f.write("string filename, path\n")
+            f.write("path = GetApplicationDirectory(2, 0)\n")
             f.write('result("\\nThe file will be saved to: " + path + "\\n")\n')
-        for f, dmv, dt in zip(
-                (f1, f2), (3, 4), (dm3_data_types, dm4_data_types)):
+        for f, dmv, dt in zip((f1, f2), (3, 4), (dm3_data_types, dm4_data_types)):
             generate_1D_files(f, dt, dmv)
             generate_2D_files(f, dt, dmv)
             generate_3D_files(f, dt, dmv)

--- a/rsciio/tests/test_blockfile.py
+++ b/rsciio/tests/test_blockfile.py
@@ -290,12 +290,12 @@ def test_save_load_cycle(save_path, convert_units):
     )
     # assert file reading tests here, then delete so we can compare
     # entire metadata structure at once:
-    plugin = 'rsciio.blockfile.api'
-    assert signal.metadata.General.FileIO.Number_0.operation == 'load'
+    plugin = "rsciio.blockfile.api"
+    assert signal.metadata.General.FileIO.Number_0.operation == "load"
     assert signal.metadata.General.FileIO.Number_0.io_plugin == plugin
-    assert signal.metadata.General.FileIO.Number_1.operation == 'save'
+    assert signal.metadata.General.FileIO.Number_1.operation == "save"
     assert signal.metadata.General.FileIO.Number_1.io_plugin == plugin
-    assert sig_reload.metadata.General.FileIO.Number_0.operation == 'load'
+    assert sig_reload.metadata.General.FileIO.Number_0.operation == "load"
     assert sig_reload.metadata.General.FileIO.Number_0.io_plugin == plugin
     del signal.metadata.General.FileIO
     del sig_reload.metadata.General.FileIO
@@ -445,7 +445,8 @@ def test_load_readonly():
             # The or statement with both "array-original" and "original-array"
             # is due to dask changing the name of this key. After dask-2022.1.1
             # the key is "original-array", before it is "array-original"
-            lambda x: isinstance(x, str) and (x.startswith("original-array") or x.startswith("array-original")),
+            lambda x: isinstance(x, str)
+            and (x.startswith("original-array") or x.startswith("array-original")),
             s.data.dask.keys(),
         )
     )

--- a/rsciio/tests/test_bruker.py
+++ b/rsciio/tests/test_bruker.py
@@ -9,17 +9,18 @@ from hyperspy import signals
 from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 
-test_files = ['30x30_instructively_packed_16bit_compressed.bcf',
-              '16x16_12bit_packed_8bit.bcf',
-              'P45_the_default_job.bcf',
-              'test_TEM.bcf',
-              'Hitachi_TM3030Plus.bcf',
-              'over16bit.bcf',
-              'bcf_v2_50x50px.bcf',
-              'bcf-edx-ebsd.bcf']
-np_file = ['30x30_16bit.npy', '30x30_16bit_ds.npy']
-spx_files = ['extracted_from_bcf.spx',
-             'bruker_nano.spx']
+test_files = [
+    "30x30_instructively_packed_16bit_compressed.bcf",
+    "16x16_12bit_packed_8bit.bcf",
+    "P45_the_default_job.bcf",
+    "test_TEM.bcf",
+    "Hitachi_TM3030Plus.bcf",
+    "over16bit.bcf",
+    "bcf_v2_50x50px.bcf",
+    "bcf-edx-ebsd.bcf",
+]
+np_file = ["30x30_16bit.npy", "30x30_16bit_ds.npy"]
+spx_files = ["extracted_from_bcf.spx", "bruker_nano.spx"]
 
 my_path = os.path.dirname(__file__)
 
@@ -28,136 +29,165 @@ def test_load_16bit():
     # test bcf from hyperspy load function level
     # some of functions can be not covered
     # it cant use cython parsing implementation, as it is not compiled
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    print('testing bcf instructively packed 16bit...')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    print("testing bcf instructively packed 16bit...")
     s = load(filename)
     bse, hype = s
     # Bruker saves all images in true 16bit:
     assert bse.data.dtype == np.uint16
     assert bse.data.shape == (30, 30)
-    np_filename = os.path.join(my_path, 'bruker_data', np_file[0])
-    np.testing.assert_array_equal(hype.data[:, :, 222:224],
-                                  np.load(np_filename))
+    np_filename = os.path.join(my_path, "bruker_data", np_file[0])
+    np.testing.assert_array_equal(hype.data[:, :, 222:224], np.load(np_filename))
     assert hype.data.shape == (30, 30, 2048)
-    assert bse.metadata.get_item('Stage.x', full_path=False) == 66940.81
-    assert hype.metadata.get_item('Stage.x', full_path=False) == 66940.81
+    assert bse.metadata.get_item("Stage.x", full_path=False) == 66940.81
+    assert hype.metadata.get_item("Stage.x", full_path=False) == 66940.81
 
 
 def test_load_16bit_reduced():
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    print('testing downsampled 16bit bcf...')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    print("testing downsampled 16bit bcf...")
     s = load(filename, downsample=4, cutoff_at_kV=10)
     bse, hype = s
     # sem images are never downsampled
     assert bse.data.shape == (30, 30)
-    np_filename = os.path.join(my_path, 'bruker_data', np_file[1])
-    np.testing.assert_array_equal(hype.data[:, :, 222:224],
-                                  np.load(np_filename))
+    np_filename = os.path.join(my_path, "bruker_data", np_file[1])
+    np.testing.assert_array_equal(hype.data[:, :, 222:224], np.load(np_filename))
     assert hype.data.shape == (8, 8, 1047)
     # Bruker saves all images in true 16bit:
     assert bse.data.dtype == np.uint16
     # hypermaps should always return unsigned integers:
-    assert str(hype.data.dtype)[0] == 'u'
+    assert str(hype.data.dtype)[0] == "u"
 
 
 def test_load_16bit_cutoff_zealous():
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    print('testing downsampled 16bit bcf with cutoff_at_kV=zealous...')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    print("testing downsampled 16bit bcf with cutoff_at_kV=zealous...")
     hype = load(filename, cutoff_at_kV="zealous", select_type="spectrum_image")
     assert hype.data.shape == (30, 30, 2048)
 
 
 def test_load_16bit_cutoff_auto():
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    print('testing downsampled 16bit bcf with cutoff_at_kV=auto...')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    print("testing downsampled 16bit bcf with cutoff_at_kV=auto...")
     hype = load(filename, cutoff_at_kV="auto", select_type="spectrum_image")
     assert hype.data.shape == (30, 30, 2048)
 
 
 def test_load_8bit():
     for bcffile in test_files[1:3]:
-        filename = os.path.join(my_path, 'bruker_data', bcffile)
-        print('testing simple 8bit bcf...')
+        filename = os.path.join(my_path, "bruker_data", bcffile)
+        print("testing simple 8bit bcf...")
         s = load(filename)
         bse, hype = s[0], s[-1]
         # Bruker saves all images in true 16bit:
         assert bse.data.dtype == np.uint16
         # hypermaps should always return unsigned integers:
-        assert str(hype.data.dtype)[0] == 'u'
+        assert str(hype.data.dtype)[0] == "u"
 
 
 def test_hyperspy_wrap():
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    print('testing bcf wrap to hyperspy signal...')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    print("testing bcf wrap to hyperspy signal...")
     from rsciio.exceptions import VisibleDeprecationWarning
+
     with pytest.warns(VisibleDeprecationWarning):
-        hype = load(filename, select_type='spectrum')
-    hype = load(filename, select_type='spectrum_image')
-    np.testing.assert_allclose(
-        hype.axes_manager[0].scale,
-        1.66740910949362,
-        atol=1E-12)
-    np.testing.assert_allclose(
-        hype.axes_manager[1].scale,
-        1.66740910949362,
-        atol=1E-12)
-    assert hype.axes_manager[1].units == 'µm'
+        hype = load(filename, select_type="spectrum")
+    hype = load(filename, select_type="spectrum_image")
+    np.testing.assert_allclose(hype.axes_manager[0].scale, 1.66740910949362, atol=1e-12)
+    np.testing.assert_allclose(hype.axes_manager[1].scale, 1.66740910949362, atol=1e-12)
+    assert hype.axes_manager[1].units == "µm"
     np.testing.assert_allclose(hype.axes_manager[2].scale, 0.009999)
     np.testing.assert_allclose(hype.axes_manager[2].offset, -0.47225277)
-    assert hype.axes_manager[2].units == 'keV'
+    assert hype.axes_manager[2].units == "keV"
     assert hype.axes_manager[2].is_binned == True
 
     md_ref = {
-        'Acquisition_instrument': {
-            'SEM': {
-                'beam_energy': 20,
-                'magnification': 1819.22595,
-                'Detector': {
-                    'EDS': {
-                        'elevation_angle': 35.0,
-                        'detector_type': 'XFlash 6|10',
-                        'azimuth_angle': 90.0,
-                        'real_time': 70.07298,
-                        'energy_resolution_MnKa': 130.0}},
-            'Stage': {
-                'tilt_alpha': 0.0,
-                'rotation': 326.10089,
-                'x': 66940.81,
-                'y': 54233.16,
-                'z': 39194.77}}},
-        'General': {
-            'original_filename':
-                '30x30_instructively_packed_16bit_compressed.bcf',
-            'title': 'EDX',
-            'date': '2018-10-04',
-            'time': '13:02:07',
-            'FileIO': {
-                '0': {
-                    'operation': 'load',
-                    'hyperspy_version': hs_version,
-                    'io_plugin': 'rsciio.bruker.api',
+        "Acquisition_instrument": {
+            "SEM": {
+                "beam_energy": 20,
+                "magnification": 1819.22595,
+                "Detector": {
+                    "EDS": {
+                        "elevation_angle": 35.0,
+                        "detector_type": "XFlash 6|10",
+                        "azimuth_angle": 90.0,
+                        "real_time": 70.07298,
+                        "energy_resolution_MnKa": 130.0,
+                    }
+                },
+                "Stage": {
+                    "tilt_alpha": 0.0,
+                    "rotation": 326.10089,
+                    "x": 66940.81,
+                    "y": 54233.16,
+                    "z": 39194.77,
+                },
+            }
+        },
+        "General": {
+            "original_filename": "30x30_instructively_packed_16bit_compressed.bcf",
+            "title": "EDX",
+            "date": "2018-10-04",
+            "time": "13:02:07",
+            "FileIO": {
+                "0": {
+                    "operation": "load",
+                    "hyperspy_version": hs_version,
+                    "io_plugin": "rsciio.bruker.api",
                 }
-            }},
-        'Sample': {
-            'name': 'chevkinite',
-            'elements': ['Al', 'C', 'Ca', 'Ce', 'Fe', 'Gd', 'K', 'Mg', 'Na',
-                         'Nd', 'O', 'P', 'Si', 'Sm', 'Th', 'Ti'],
-            'xray_lines': ['Al_Ka', 'C_Ka', 'Ca_Ka', 'Ce_La', 'Fe_Ka',
-                           'Gd_La', 'K_Ka', 'Mg_Ka', 'Na_Ka', 'Nd_La',
-                           'O_Ka', 'P_Ka', 'Si_Ka', 'Sm_La', 'Th_Ma',
-                           'Ti_Ka']},
-        'Signal': {
-            'quantity': 'X-rays (Counts)',
-            'signal_type': 'EDS_SEM'},
-        '_HyperSpy': {
-            'Folding': {'original_axes_manager': None,
-            'original_shape': None,
-            'signal_unfolded': False,
-            'unfolded': False}}}
+            },
+        },
+        "Sample": {
+            "name": "chevkinite",
+            "elements": [
+                "Al",
+                "C",
+                "Ca",
+                "Ce",
+                "Fe",
+                "Gd",
+                "K",
+                "Mg",
+                "Na",
+                "Nd",
+                "O",
+                "P",
+                "Si",
+                "Sm",
+                "Th",
+                "Ti",
+            ],
+            "xray_lines": [
+                "Al_Ka",
+                "C_Ka",
+                "Ca_Ka",
+                "Ce_La",
+                "Fe_Ka",
+                "Gd_La",
+                "K_Ka",
+                "Mg_Ka",
+                "Na_Ka",
+                "Nd_La",
+                "O_Ka",
+                "P_Ka",
+                "Si_Ka",
+                "Sm_La",
+                "Th_Ma",
+                "Ti_Ka",
+            ],
+        },
+        "Signal": {"quantity": "X-rays (Counts)", "signal_type": "EDS_SEM"},
+        "_HyperSpy": {
+            "Folding": {
+                "original_axes_manager": None,
+                "original_shape": None,
+                "signal_unfolded": False,
+                "unfolded": False,
+            }
+        },
+    }
 
-    filename_omd = os.path.join(my_path,
-                                'bruker_data',
-                                '30x30_original_metadata.json')
+    filename_omd = os.path.join(my_path, "bruker_data", "30x30_original_metadata.json")
     with open(filename_omd) as fn:
         # original_metadata:
         omd_ref = json.load(fn)
@@ -171,44 +201,42 @@ def test_hyperspy_wrap():
 
 
 def test_hyperspy_wrap_downsampled():
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    print('testing bcf wrap to hyperspy signal...')
-    hype = load(filename, select_type='spectrum_image', downsample=5)
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    print("testing bcf wrap to hyperspy signal...")
+    hype = load(filename, select_type="spectrum_image", downsample=5)
     np.testing.assert_allclose(
-        hype.axes_manager[0].scale,
-        8.337045547468101,
-        atol=1E-12)
+        hype.axes_manager[0].scale, 8.337045547468101, atol=1e-12
+    )
     np.testing.assert_allclose(
-        hype.axes_manager[1].scale,
-        8.337045547468101,
-        atol=1E-12)
-    assert hype.axes_manager[1].units == 'µm'
+        hype.axes_manager[1].scale, 8.337045547468101, atol=1e-12
+    )
+    assert hype.axes_manager[1].units == "µm"
 
 
 def test_get_mode():
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    s = load(filename, select_type='spectrum_image', instrument='SEM')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    s = load(filename, select_type="spectrum_image", instrument="SEM")
     assert s.metadata.Signal.signal_type == "EDS_SEM"
     assert isinstance(s, signals.EDSSEMSpectrum)
 
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    s = load(filename, select_type='spectrum_image', instrument='TEM')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    s = load(filename, select_type="spectrum_image", instrument="TEM")
     assert s.metadata.Signal.signal_type == "EDS_TEM"
     assert isinstance(s, signals.EDSTEMSpectrum)
 
-    filename = os.path.join(my_path, 'bruker_data', test_files[0])
-    s = load(filename, select_type='spectrum_image')
+    filename = os.path.join(my_path, "bruker_data", test_files[0])
+    s = load(filename, select_type="spectrum_image")
     assert s.metadata.Signal.signal_type == "EDS_SEM"
     assert isinstance(s, signals.EDSSEMSpectrum)
 
-    filename = os.path.join(my_path, 'bruker_data', test_files[3])
-    s = load(filename, select_type='spectrum_image')
+    filename = os.path.join(my_path, "bruker_data", test_files[3])
+    s = load(filename, select_type="spectrum_image")
     assert s.metadata.Signal.signal_type == "EDS_TEM"
     assert isinstance(s, signals.EDSTEMSpectrum)
 
 
 def test_wrong_file():
-    filename = os.path.join(my_path, 'bruker_data', 'Nope.bcf')
+    filename = os.path.join(my_path, "bruker_data", "Nope.bcf")
     with pytest.raises(TypeError):
         load(filename)
 
@@ -216,53 +244,60 @@ def test_wrong_file():
 def test_fast_bcf():
     thingy = pytest.importorskip("rsciio.bruker.unbcf_fast")
     from rsciio.bruker import api as bruker
+
     for bcffile in test_files:
-        filename = os.path.join(my_path, 'bruker_data', bcffile)
+        filename = os.path.join(my_path, "bruker_data", bcffile)
         thingy = bruker.BCF_reader(filename)
         for j in range(2, 5, 1):
-            print('downsampling:', j)
-            bruker.fast_unbcf = True              # manually enabling fast parsing
-            hmap1 = thingy.parse_hypermap(downsample=j)    # using cython
-            bruker.fast_unbcf = False            # manually disabling fast parsing
-            hmap2 = thingy.parse_hypermap(downsample=j)    # py implementation
+            print("downsampling:", j)
+            bruker.fast_unbcf = True  # manually enabling fast parsing
+            hmap1 = thingy.parse_hypermap(downsample=j)  # using cython
+            bruker.fast_unbcf = False  # manually disabling fast parsing
+            hmap2 = thingy.parse_hypermap(downsample=j)  # py implementation
             np.testing.assert_array_equal(hmap1, hmap2)
 
 
 def test_decimal_regex():
     from rsciio.bruker.api import fix_dec_patterns
-    dummy_xml_positive = [b'<dummy_tag>85,658</dummy_tag>',
-                          b'<dummy_tag>85,658E-8</dummy_tag>',
-                          b'<dummy_tag>-85,658E-8</dummy_tag>',
-                          b'<dum_tag>-85.658</dum_tag>',  # negative check
-                          b'<dum_tag>85.658E-8</dum_tag>']  # negative check
-    dummy_xml_negative = [b'<dum_tag>12,25,23,45,56,12,45</dum_tag>',
-                          b'<dum_tag>12e1,23,-24E-5</dum_tag>']
+
+    dummy_xml_positive = [
+        b"<dummy_tag>85,658</dummy_tag>",
+        b"<dummy_tag>85,658E-8</dummy_tag>",
+        b"<dummy_tag>-85,658E-8</dummy_tag>",
+        b"<dum_tag>-85.658</dum_tag>",  # negative check
+        b"<dum_tag>85.658E-8</dum_tag>",
+    ]  # negative check
+    dummy_xml_negative = [
+        b"<dum_tag>12,25,23,45,56,12,45</dum_tag>",
+        b"<dum_tag>12e1,23,-24E-5</dum_tag>",
+    ]
     for i in dummy_xml_positive:
-        assert b'85.658' in fix_dec_patterns.sub(b'\\1.\\2', i)
+        assert b"85.658" in fix_dec_patterns.sub(b"\\1.\\2", i)
     for j in dummy_xml_negative:
-        assert b'.' not in fix_dec_patterns.sub(b'\\1.\\2', j)
+        assert b"." not in fix_dec_patterns.sub(b"\\1.\\2", j)
 
 
 def test_all_spx_loads():
     for spxfile in spx_files:
-        filename = os.path.join(my_path, 'bruker_data', spxfile)
+        filename = os.path.join(my_path, "bruker_data", spxfile)
         s = load(filename)
         assert s.data.dtype == np.uint64
-        assert s.metadata.Signal.signal_type == 'EDS_SEM'
+        assert s.metadata.Signal.signal_type == "EDS_SEM"
 
 
 def test_stand_alone_spx():
-    filename = os.path.join(my_path, 'bruker_data', 'bruker_nano.spx')
+    filename = os.path.join(my_path, "bruker_data", "bruker_nano.spx")
     s = load(filename)
-    assert s.metadata.Sample.elements == ['Fe', 'S', 'Cu']
+    assert s.metadata.Sample.elements == ["Fe", "S", "Cu"]
     assert s.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time == 7.385
 
 
 def test_bruker_XRF():
     # See https://github.com/hyperspy/hyperspy/issues/2689
     # Bruker M6 Jetstream SPX
-    filename = os.path.join(my_path, 'bruker_data',
-                            'bruker_m6_jetstream_file_example.spx')
+    filename = os.path.join(
+        my_path, "bruker_data", "bruker_m6_jetstream_file_example.spx"
+    )
     s = load(filename)
     assert s.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time == 28.046
     assert s.metadata.Acquisition_instrument.TEM.beam_energy == 50

--- a/rsciio/tests/test_de5.py
+++ b/rsciio/tests/test_de5.py
@@ -26,7 +26,7 @@ import numpy as np
 
 
 def test_de5_write_load_cycle(tmp_path):
-    fname = tmp_path / 'test_file.de5'
+    fname = tmp_path / "test_file.de5"
     data = np.arange(20).reshape(2, 10)
     s = hs.signals.Signal1D(data)
     s.save(fname)

--- a/rsciio/tests/test_dens.py
+++ b/rsciio/tests/test_dens.py
@@ -26,9 +26,9 @@ import hyperspy.api as hs
 
 dirpath = os.path.dirname(__file__)
 
-file1 = os.path.join(dirpath, 'dens_data', 'file1.dens')
-file2 = os.path.join(dirpath, 'dens_data', 'file2.dens')
-file3 = os.path.join(dirpath, 'dens_data', 'file3.dens')
+file1 = os.path.join(dirpath, "dens_data", "file1.dens")
+file2 = os.path.join(dirpath, "dens_data", "file2.dens")
+file3 = os.path.join(dirpath, "dens_data", "file3.dens")
 
 ref_T = np.array([15.091, 16.828, 13.232, 50.117, 49.927, 49.986, 49.981])
 ref_t = np.array([15.091, 16.828, 13.232, 50.117, 49.927, 49.986, 49.981])
@@ -39,7 +39,7 @@ def test_read1():
     np.testing.assert_allclose(s.data, ref_T)
     np.testing.assert_allclose(s.axes_manager[0].scale, 0.33)
     np.testing.assert_allclose(s.axes_manager[0].offset, 50077.68)
-    assert s.axes_manager[0].units == 's'
+    assert s.axes_manager[0].units == "s"
     ref_date, ref_time = "2015-04-16", "13:53:00"
     assert s.metadata.General.date == ref_date
     assert s.metadata.General.time == ref_time
@@ -52,18 +52,18 @@ def test_read_convert_units():
     np.testing.assert_allclose(s.data, ref_T)
     np.testing.assert_allclose(s.axes_manager[0].scale, 0.33)
     np.testing.assert_allclose(s.axes_manager[0].offset, 50077.68)
-    assert s.axes_manager[0].units == 's'
+    assert s.axes_manager[0].units == "s"
 
     s = hs.load(file1, convert_units=False)
     np.testing.assert_allclose(s.axes_manager[0].scale, 0.33)
     np.testing.assert_allclose(s.axes_manager[0].offset, 50077.68)
-    assert s.axes_manager[0].units == 's'
+    assert s.axes_manager[0].units == "s"
 
     s = hs.load(file1, convert_units=True)
     np.testing.assert_allclose(s.data, ref_T)
     np.testing.assert_allclose(s.axes_manager[0].scale, 330.0)
     np.testing.assert_allclose(s.axes_manager[0].offset, 50077680.0)
-    assert s.axes_manager[0].units == 'ms'
+    assert s.axes_manager[0].units == "ms"
 
 
 def test_read2():

--- a/rsciio/tests/test_dm3.py
+++ b/rsciio/tests/test_dm3.py
@@ -25,17 +25,14 @@ import pytest
 
 from hyperspy import __version__ as hs_version
 from hyperspy.io import load
-from rsciio.digital_micrograph.api import (DigitalMicrographReader,
-                                                    ImageObject)
+from rsciio.digital_micrograph.api import DigitalMicrographReader, ImageObject
 from hyperspy.signals import Signal1D, Signal2D
-from rsciio.tests.generate_dm_testing_files import (dm3_data_types,
-                                                         dm4_data_types)
+from rsciio.tests.generate_dm_testing_files import dm3_data_types, dm4_data_types
 
 MY_PATH = os.path.dirname(__file__)
 
 
-class TestImageObject():
-
+class TestImageObject:
     def setup_method(self, method):
         self.imageobject = ImageObject({}, "")
 
@@ -47,19 +44,18 @@ class TestImageObject():
         return [ImageObject(imdict, fname) for imdict in self.imdict]
 
     def test_get_microscope_name(self):
-        fname = os.path.join(MY_PATH, "dm3_2D_data",
-                             "test_diffraction_pattern_tags_removed.dm3")
+        fname = os.path.join(
+            MY_PATH, "dm3_2D_data", "test_diffraction_pattern_tags_removed.dm3"
+        )
         images = self._load_file(fname)
         image = images[0]
         # Should return None because the tags are missing
         assert image._get_microscope_name(image.imdict.ImageTags) is None
 
-        fname = os.path.join(MY_PATH, "dm3_2D_data",
-                             "test_diffraction_pattern.dm3")
+        fname = os.path.join(MY_PATH, "dm3_2D_data", "test_diffraction_pattern.dm3")
         images = self._load_file(fname)
         image = images[0]
-        assert image._get_microscope_name(
-            image.imdict.ImageTags) == "FEI Tecnai"
+        assert image._get_microscope_name(image.imdict.ImageTags) == "FEI Tecnai"
 
     def test_get_date(self):
         assert self.imageobject._get_date("11/13/2016") == "2016-11-13"
@@ -72,14 +68,15 @@ class TestImageObject():
         assert self.imageobject._parse_string("string") == "string"
 
     def test_parse_string_convert_float(self):
-        assert self.imageobject._parse_string("5", False) == '5'
+        assert self.imageobject._parse_string("5", False) == "5"
         assert self.imageobject._parse_string("5", True) == 5
         assert self.imageobject._parse_string("Imaging", True) == None
 
 
 def test_missing_tag():
-    fname = os.path.join(MY_PATH, "dm3_2D_data",
-                         "test_diffraction_pattern_tags_removed.dm3")
+    fname = os.path.join(
+        MY_PATH, "dm3_2D_data", "test_diffraction_pattern_tags_removed.dm3"
+    )
     s = load(fname)
     md = s.metadata
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
@@ -107,10 +104,7 @@ def test_read_TEM_metadata():
 
 
 def test_read_Diffraction_metadata():
-    fname = os.path.join(
-        MY_PATH,
-        "dm3_2D_data",
-        "test_diffraction_pattern.dm3")
+    fname = os.path.join(MY_PATH, "dm3_2D_data", "test_diffraction_pattern.dm3")
     s = load(fname)
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "TEM"
@@ -119,9 +113,7 @@ def test_read_Diffraction_metadata():
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 320.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Tecnai"
     assert md.General.date == "2014-07-09"
-    assert (
-        md.General.original_filename ==
-        "test_diffraction_pattern.dm3")
+    assert md.General.original_filename == "test_diffraction_pattern.dm3"
     assert md.General.title == "test_diffraction_pattern"
     assert md.General.time == "18:56:37"
     assert md.Signal.quantity == "Intensity"
@@ -134,11 +126,9 @@ def test_read_STEM_metadata():
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
-    np.testing.assert_allclose(md.Acquisition_instrument.TEM.dwell_time, 3.5E-6)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.dwell_time, 3.5e-6)
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
-    np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.magnification,
-        225000.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.magnification, 225000.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Titan"
     assert md.General.date == "2016-08-08"
     assert md.General.original_filename == "test_STEM_image.dm3"
@@ -156,32 +146,31 @@ def test_read_EELS_metadata():
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Titan"
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.magnification, 640000.0)
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.magnification,
-        640000.0)
-    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95,
-                    atol=1E-2)
-    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.x, -0.478619,
-                    atol=1E-2)
-    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.y, 0.0554612,
-                    atol=1E-2)
-    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.z, 0.036348,
-                    atol=1E-2)
+        md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95, atol=1e-2
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.convergence_angle, 21.0)
+        md.Acquisition_instrument.TEM.Stage.x, -0.478619, atol=1e-2
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EELS.collection_angle, 0.0)
+        md.Acquisition_instrument.TEM.Stage.y, 0.0554612, atol=1e-2
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EELS.exposure,
-        0.0035)
+        md.Acquisition_instrument.TEM.Stage.z, 0.036348, atol=1e-2
+    )
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.convergence_angle, 21.0)
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EELS.frame_number, 50)
-    assert (
-        md.Acquisition_instrument.TEM.Detector.EELS.spectrometer ==
-        'GIF Quantum ER')
-    assert (
-        md.Acquisition_instrument.TEM.Detector.EELS.aperture_size ==
-        5.0)
+        md.Acquisition_instrument.TEM.Detector.EELS.collection_angle, 0.0
+    )
+    np.testing.assert_allclose(
+        md.Acquisition_instrument.TEM.Detector.EELS.exposure, 0.0035
+    )
+    np.testing.assert_allclose(
+        md.Acquisition_instrument.TEM.Detector.EELS.frame_number, 50
+    )
+    assert md.Acquisition_instrument.TEM.Detector.EELS.spectrometer == "GIF Quantum ER"
+    assert md.Acquisition_instrument.TEM.Detector.EELS.aperture_size == 5.0
     assert md.General.date == "2016-08-08"
     assert md.General.original_filename == "test-EELS_spectrum.dm3"
     assert md.General.title == "EELS Acquire"
@@ -189,11 +178,11 @@ def test_read_EELS_metadata():
     assert md.Signal.quantity == "Electrons (Counts)"
     assert md.Signal.signal_type == "EELS"
     np.testing.assert_allclose(
-        md.Signal.Noise_properties.Variance_linear_model.gain_factor,
-        0.1285347)
+        md.Signal.Noise_properties.Variance_linear_model.gain_factor, 0.1285347
+    )
     np.testing.assert_allclose(
-        md.Signal.Noise_properties.Variance_linear_model.gain_offset,
-        0.0)
+        md.Signal.Noise_properties.Variance_linear_model.gain_offset, 0.0
+    )
 
 
 def test_read_SI_metadata():
@@ -204,16 +193,18 @@ def test_read_SI_metadata():
     assert md.General.date == "2019-05-14"
     assert md.General.time == "20:50:13"
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EELS.aperture_size, 5.0)
+        md.Acquisition_instrument.TEM.Detector.EELS.aperture_size, 5.0
+    )
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.convergence_angle, 21.0)
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.convergence_angle, 21.0)
+        md.Acquisition_instrument.TEM.Detector.EELS.collection_angle, 62.0
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EELS.collection_angle, 62.0)
+        md.Acquisition_instrument.TEM.Detector.EELS.frame_number, 1
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EELS.frame_number, 1)
-    np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EELS.dwell_time,
-        1.9950125E-2)
+        md.Acquisition_instrument.TEM.Detector.EELS.dwell_time, 1.9950125e-2
+    )
 
 
 def test_read_EDS_metadata():
@@ -222,23 +213,27 @@ def test_read_EDS_metadata():
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EDS.azimuth_angle, 45.0)
+        md.Acquisition_instrument.TEM.Detector.EDS.azimuth_angle, 45.0
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EDS.elevation_angle, 18.0)
+        md.Acquisition_instrument.TEM.Detector.EDS.elevation_angle, 18.0
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EDS.energy_resolution_MnKa, 130.0)
+        md.Acquisition_instrument.TEM.Detector.EDS.energy_resolution_MnKa, 130.0
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EDS.live_time, 3.806)
+        md.Acquisition_instrument.TEM.Detector.EDS.live_time, 3.806
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.Detector.EDS.real_time, 4.233)
-    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95,
-                    atol=1E-2)
+        md.Acquisition_instrument.TEM.Detector.EDS.real_time, 4.233
+    )
+    np.testing.assert_allclose(
+        md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95, atol=1e-2
+    )
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Titan"
     np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
-    np.testing.assert_allclose(
-        md.Acquisition_instrument.TEM.magnification,
-        320000.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.magnification, 320000.0)
     assert md.General.date == "2016-08-08"
     assert md.General.original_filename == "test-EDS_spectrum.dm3"
     assert md.General.title == "EDS Spectrum"
@@ -246,12 +241,13 @@ def test_read_EDS_metadata():
     assert md.Signal.quantity == "X-rays (Counts)"
     assert md.Signal.signal_type == "EDS_TEM"
     np.testing.assert_allclose(
-        md.Signal.Noise_properties.Variance_linear_model.gain_factor,
-        1.0)
+        md.Signal.Noise_properties.Variance_linear_model.gain_factor, 1.0
+    )
     np.testing.assert_allclose(
-        md.Signal.Noise_properties.Variance_linear_model.gain_offset,
-        0.0)
+        md.Signal.Noise_properties.Variance_linear_model.gain_offset, 0.0
+    )
     assert s.axes_manager[-1].units == "keV"
+
 
 def test_read_MonoCL_pmt_metadata():
     fname = os.path.join(MY_PATH, "dm4_1D_data", "test-MonoCL_spectrum-pmt.dm4")
@@ -263,13 +259,17 @@ def test_read_MonoCL_pmt_metadata():
     assert md.General.date == "2020-10-27"
     assert md.General.original_filename == "test-MonoCL_spectrum-pmt.dm4"
     assert md.General.title == "test-CL_spectrum-pmt"
-    assert md.Acquisition_instrument.Spectrometer.acquisition_mode == "Serial dispersive"
+    assert (
+        md.Acquisition_instrument.Spectrometer.acquisition_mode == "Serial dispersive"
+    )
     assert md.Acquisition_instrument.Detector.detector_type == "PMT"
     assert md.Acquisition_instrument.Spectrometer.Grating.groove_density == 1200
     assert md.Acquisition_instrument.Detector.integration_time == 1.0
     assert md.Acquisition_instrument.Spectrometer.step_size == 0.5
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Spectrometer.start_wavelength, 166.233642)
+        md.Acquisition_instrument.Spectrometer.start_wavelength, 166.233642
+    )
+
 
 def test_read_MonarcCL_pmt_metadata():
     fname = os.path.join(MY_PATH, "dm4_1D_data", "test-MonarcCL_spectrum-pmt.dm4")
@@ -281,13 +281,17 @@ def test_read_MonarcCL_pmt_metadata():
     assert md.General.date == "2022-01-17"
     assert md.General.original_filename == "test-MonarcCL_spectrum-pmt.dm4"
     assert md.General.title == "CL_15kX_3-60_pmt2s"
-    assert md.Acquisition_instrument.Spectrometer.acquisition_mode == "Serial dispersive"
+    assert (
+        md.Acquisition_instrument.Spectrometer.acquisition_mode == "Serial dispersive"
+    )
     assert md.Acquisition_instrument.Detector.detector_type == "PMT"
     assert md.Acquisition_instrument.Spectrometer.Grating.groove_density == 300
     assert md.Acquisition_instrument.Detector.integration_time == 2.0
     assert md.Acquisition_instrument.Spectrometer.step_size == 1.0
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Spectrometer.start_wavelength, 160.067505)
+        md.Acquisition_instrument.Spectrometer.start_wavelength, 160.067505
+    )
+
 
 def test_read_MonoCL_ccd_metadata():
     fname = os.path.join(MY_PATH, "dm4_1D_data", "test-MonoCL_spectrum-ccd.dm4")
@@ -305,19 +309,24 @@ def test_read_MonoCL_ccd_metadata():
     assert md.Acquisition_instrument.SEM.microscope == "Ultra55"
     assert md.Acquisition_instrument.SEM.beam_energy == 5.0
     assert md.Acquisition_instrument.SEM.magnification == 10104.515625
-    assert md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+    assert (
+        md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+    )
     assert md.Acquisition_instrument.Spectrometer.Grating.groove_density == 300.0
     assert md.Acquisition_instrument.Detector.exposure_per_frame == 30.0
     assert md.Acquisition_instrument.Detector.frames == 1.0
     assert md.Acquisition_instrument.Detector.integration_time == 30.0
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Spectrometer.central_wavelength, 949.974182)
+        md.Acquisition_instrument.Spectrometer.central_wavelength, 949.974182
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.saturation_fraction, 0.01861909)
+        md.Acquisition_instrument.Detector.saturation_fraction, 0.01861909
+    )
     assert md.Acquisition_instrument.Detector.binning == (1, 100)
     assert md.Acquisition_instrument.Detector.processing == "Dark Subtracted"
     assert md.Acquisition_instrument.Detector.sensor_roi == (0, 0, 100, 1336)
     assert md.Acquisition_instrument.Detector.pixel_size == 20.0
+
 
 def test_read_MonarcCL_ccd_metadata():
     fname = os.path.join(MY_PATH, "dm4_1D_data", "test-MonarcCL_spectrum-ccd.dm4")
@@ -335,20 +344,25 @@ def test_read_MonarcCL_ccd_metadata():
     assert md.Acquisition_instrument.SEM.microscope == "Ultra55"
     assert md.Acquisition_instrument.SEM.beam_energy == 3.0
     assert md.Acquisition_instrument.SEM.magnification == 15000.0
-    assert md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+    assert (
+        md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Spectrometer.central_wavelength, 320.049683)
+        md.Acquisition_instrument.Spectrometer.central_wavelength, 320.049683
+    )
     assert md.Acquisition_instrument.Spectrometer.Grating.groove_density == 300.0
     assert md.Acquisition_instrument.Detector.exposure_per_frame == 300.0
     assert md.Acquisition_instrument.Detector.frames == 1.0
     assert md.Acquisition_instrument.Detector.integration_time == 300.0
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.saturation_fraction, 0.08890307)
+        md.Acquisition_instrument.Detector.saturation_fraction, 0.08890307
+    )
     assert md.Acquisition_instrument.Detector.binning == (2, 100)
     assert md.Acquisition_instrument.Detector.processing == "Dark Subtracted"
     assert md.Acquisition_instrument.Detector.sensor_roi == (0, 0, 100, 1336)
     assert md.Acquisition_instrument.Detector.pixel_size == 20.0
-    #assert md.Acquisition_instrument.Spectrometer.entrance_slit_width == 1
+    # assert md.Acquisition_instrument.Spectrometer.entrance_slit_width == 1
+
 
 def test_read_MonoCL_SI_metadata():
     fname = os.path.join(MY_PATH, "dm4_2D_data", "test-MonoCL_spectrum-SI.dm4")
@@ -366,25 +380,35 @@ def test_read_MonoCL_SI_metadata():
     assert md.Acquisition_instrument.SEM.microscope == "Ultra55"
     assert md.Acquisition_instrument.SEM.beam_energy == 5.0
     np.testing.assert_allclose(
-        md.Acquisition_instrument.SEM.magnification, 31661.427734)
-    assert md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+        md.Acquisition_instrument.SEM.magnification, 31661.427734
+    )
+    assert (
+        md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+    )
     assert md.Acquisition_instrument.Spectrometer.Grating.groove_density == 600.0
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.exposure_per_frame, 0.05)
+        md.Acquisition_instrument.Detector.exposure_per_frame, 0.05
+    )
     assert md.Acquisition_instrument.Detector.frames == 1
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.integration_time, 0.05)
+        md.Acquisition_instrument.Detector.integration_time, 0.05
+    )
     assert md.Acquisition_instrument.Detector.pixel_size == 20.0
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Spectrometer.central_wavelength, 869.983825)
+        md.Acquisition_instrument.Spectrometer.central_wavelength, 869.983825
+    )
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.saturation_fraction[0], 0.09676377)
+        md.Acquisition_instrument.Detector.saturation_fraction[0], 0.09676377
+    )
     assert md.Acquisition_instrument.Detector.binning == (1, 100)
     assert md.Acquisition_instrument.Detector.processing == "Dark Subtracted"
     assert md.Acquisition_instrument.Detector.sensor_roi == (0, 0, 100, 1336)
     assert md.Acquisition_instrument.Spectrum_image.drift_correction_periodicity == 1
-    assert md.Acquisition_instrument.Spectrum_image.drift_correction_units == "second(s)"
+    assert (
+        md.Acquisition_instrument.Spectrum_image.drift_correction_units == "second(s)"
+    )
     assert md.Acquisition_instrument.Spectrum_image.mode == "LineScan"
+
 
 def test_read_MonarcCL_SI_metadata():
     fname = os.path.join(MY_PATH, "dm4_2D_data", "test-MonarcCL_spectrum-SI.dm4")
@@ -401,28 +425,33 @@ def test_read_MonarcCL_SI_metadata():
     assert md.Acquisition_instrument.SEM.acquisition_mode == "SEM"
     assert md.Acquisition_instrument.SEM.microscope == "Zeiss SEM COM"
     assert md.Acquisition_instrument.SEM.beam_energy == 5.0
-    np.testing.assert_allclose(
-        md.Acquisition_instrument.SEM.magnification, 5884.540039)
-    assert md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+    np.testing.assert_allclose(md.Acquisition_instrument.SEM.magnification, 5884.540039)
+    assert (
+        md.Acquisition_instrument.Spectrometer.acquisition_mode == "Parallel dispersive"
+    )
     assert md.Acquisition_instrument.Spectrometer.Grating.groove_density == 1200.0
     assert md.Acquisition_instrument.Spectrometer.entrance_slit_width == 0.256
     assert md.Acquisition_instrument.Spectrometer.bandpass == 0.9984
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.exposure_per_frame, 0.05)
+        md.Acquisition_instrument.Detector.exposure_per_frame, 0.05
+    )
     assert md.Acquisition_instrument.Detector.frames == 1
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.integration_time, 0.05)
+        md.Acquisition_instrument.Detector.integration_time, 0.05
+    )
     assert md.Acquisition_instrument.Detector.pixel_size == 20.0
-    #np.testing.assert_allclose(
+    # np.testing.assert_allclose(
     #    md.Acquisition_instrument.Spectrometer.central_wavelength, 869.9838)
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Detector.saturation_fraction[0], 0.004867628)
+        md.Acquisition_instrument.Detector.saturation_fraction[0], 0.004867628
+    )
     assert md.Acquisition_instrument.Detector.binning == (2, 400)
     assert md.Acquisition_instrument.Detector.processing == "Dark Subtracted"
     assert md.Acquisition_instrument.Detector.sensor_roi == (0, 0, 400, 1340)
-    #assert md.Acquisition_instrument.Spectrum_image.drift_correction_periodicity == 1
-    #assert md.Acquisition_instrument.Spectrum_image.drift_correction_units == "second(s)"
+    # assert md.Acquisition_instrument.Spectrum_image.drift_correction_periodicity == 1
+    # assert md.Acquisition_instrument.Spectrum_image.drift_correction_units == "second(s)"
     assert md.Acquisition_instrument.Spectrum_image.mode == "2D Array"
+
 
 def test_read_MonarcCL_image_metadata():
     fname = os.path.join(MY_PATH, "dm4_2D_data", "test-MonarcCL_mono-image.dm4")
@@ -437,17 +466,23 @@ def test_read_MonarcCL_image_metadata():
     assert md.Acquisition_instrument.SEM.acquisition_mode == "SEM"
     assert md.Acquisition_instrument.SEM.microscope == "Zeiss SEM COM"
     assert md.Acquisition_instrument.SEM.beam_energy == 3.0
-    assert md.Acquisition_instrument.SEM.magnification == 2500.
+    assert md.Acquisition_instrument.SEM.magnification == 2500.0
     assert md.Acquisition_instrument.SEM.dwell_time == 1e-5
     assert md.Acquisition_instrument.Spectrometer.Grating.groove_density == 300.0
     assert md.Acquisition_instrument.Spectrometer.entrance_slit_width == 0.961
     np.testing.assert_allclose(
-        md.Acquisition_instrument.Spectrometer.bandpass, 14.9915999)
+        md.Acquisition_instrument.Spectrometer.bandpass, 14.9915999
+    )
     assert md.Acquisition_instrument.Detector.pmt_voltage == 1000
 
+
 def test_location():
-    fname_list = ['Fei HAADF-DE_location.dm3', 'Fei HAADF-FR_location.dm3',
-                  'Fei HAADF-MX_location.dm3', 'Fei HAADF-UK_location.dm3']
+    fname_list = [
+        "Fei HAADF-DE_location.dm3",
+        "Fei HAADF-FR_location.dm3",
+        "Fei HAADF-MX_location.dm3",
+        "Fei HAADF-UK_location.dm3",
+    ]
     s = load(os.path.join(MY_PATH, "dm3_locale", fname_list[0]))
     assert s.metadata.General.date == "2016-08-27"
     assert s.metadata.General.time == "20:54:33"
@@ -456,10 +491,11 @@ def test_location():
     assert s.metadata.General.time == "20:55:20"
     s = load(os.path.join(MY_PATH, "dm3_locale", fname_list[2]))
     assert s.metadata.General.date == "2016-08-27"
-#    assert_equal(s.metadata.General.time, "20:55:20") # MX not working
+    #    assert_equal(s.metadata.General.time, "20:55:20") # MX not working
     s = load(os.path.join(MY_PATH, "dm3_locale", fname_list[3]))
     assert s.metadata.General.date == "2016-08-27"
     assert s.metadata.General.time == "20:52:30"
+
 
 def test_multi_signal():
     fname = os.path.join(MY_PATH, "dm3_2D_data", "multi_signal.dm3")
@@ -476,74 +512,82 @@ def test_multi_signal():
     assert isinstance(s2, Signal1D)
 
     s1_md_truth = {
-        '_HyperSpy': {
-            'Folding': {
-                'unfolded': False,
-                'signal_unfolded': False,
-                'original_shape': None,
-                'original_axes_manager': None}},
-        'General': {'title': 'HAADF',
-                    'original_filename': 'multi_signal.dm3',
-                    'date': '2019-12-10',
-                    'time': '15:32:41',
-                    'authors': 'JohnDoe',
-                    'FileIO': {
-                        '0': {
-                            'operation': 'load',
-                            'hyperspy_version': hs_version,
-                            'io_plugin':
-                                'rsciio.digital_micrograph.api'
-                        }
-                    }
+        "_HyperSpy": {
+            "Folding": {
+                "unfolded": False,
+                "signal_unfolded": False,
+                "original_shape": None,
+                "original_axes_manager": None,
+            }
         },
-        'Signal': {'signal_type': '',
-                   'quantity': 'Intensity',
-                   'Noise_properties': {
-                       'Variance_linear_model': {
-                           'gain_factor': 1.0,
-                           'gain_offset': 0.0}}},
-        'Acquisition_instrument': {
-            'TEM': {
-                'beam_energy': 300.0,
-                'Stage': {
-                    'tilt_alpha': 0.001951998453075299,
-                    'x': 0.07872150000000001,
-                    'y': 0.100896,
-                    'z': -0.0895279},
-                'acquisition_mode': 'STEM',
-                'beam_current': 0.0,
-                'camera_length': 77.0,
-                'magnification': 10000000.0,
-                'microscope': 'Example Microscope',
-                'dwell_time': 3.2400001525878905e-05}},
-        'Sample': {
-            'description': 'PrecipitateA'}
+        "General": {
+            "title": "HAADF",
+            "original_filename": "multi_signal.dm3",
+            "date": "2019-12-10",
+            "time": "15:32:41",
+            "authors": "JohnDoe",
+            "FileIO": {
+                "0": {
+                    "operation": "load",
+                    "hyperspy_version": hs_version,
+                    "io_plugin": "rsciio.digital_micrograph.api",
+                }
+            },
+        },
+        "Signal": {
+            "signal_type": "",
+            "quantity": "Intensity",
+            "Noise_properties": {
+                "Variance_linear_model": {"gain_factor": 1.0, "gain_offset": 0.0}
+            },
+        },
+        "Acquisition_instrument": {
+            "TEM": {
+                "beam_energy": 300.0,
+                "Stage": {
+                    "tilt_alpha": 0.001951998453075299,
+                    "x": 0.07872150000000001,
+                    "y": 0.100896,
+                    "z": -0.0895279,
+                },
+                "acquisition_mode": "STEM",
+                "beam_current": 0.0,
+                "camera_length": 77.0,
+                "magnification": 10000000.0,
+                "microscope": "Example Microscope",
+                "dwell_time": 3.2400001525878905e-05,
+            }
+        },
+        "Sample": {"description": "PrecipitateA"},
     }
 
     s2_md_truth = {
-        '_HyperSpy': {
-            'Folding': {
-                'unfolded': False,
-                'signal_unfolded': False,
-                'original_shape': None,
-                'original_axes_manager': None}},
-        'General': {
-            'title': 'Plot',
-            'original_filename': 'multi_signal.dm3',
-            'FileIO': {
-                '0': {
-                    'operation': 'load',
-                    'hyperspy_version': hs_version,
-                    'io_plugin': 'rsciio.digital_micrograph.api'
+        "_HyperSpy": {
+            "Folding": {
+                "unfolded": False,
+                "signal_unfolded": False,
+                "original_shape": None,
+                "original_axes_manager": None,
+            }
+        },
+        "General": {
+            "title": "Plot",
+            "original_filename": "multi_signal.dm3",
+            "FileIO": {
+                "0": {
+                    "operation": "load",
+                    "hyperspy_version": hs_version,
+                    "io_plugin": "rsciio.digital_micrograph.api",
                 }
-            }},
-        'Signal': {
-            'signal_type': '',
-            'quantity': 'Intensity',
-            'Noise_properties': {
-                'Variance_linear_model': {
-                    'gain_factor': 1.0,
-                    'gain_offset': 0.0}}}
+            },
+        },
+        "Signal": {
+            "signal_type": "",
+            "quantity": "Intensity",
+            "Noise_properties": {
+                "Variance_linear_model": {"gain_factor": 1.0, "gain_offset": 0.0}
+            },
+        },
     }
     # remove timestamps from metadata since these are runtime dependent
     del s1.metadata.General.FileIO.Number_0.timestamp
@@ -556,7 +600,7 @@ def test_multi_signal():
     # rather than testing all of original metadata (huge), use length as a proxy
     assert len(json.dumps(s1.original_metadata.as_dictionary())) == 17779
     assert len(json.dumps(s2.original_metadata.as_dictionary())) == 15024
-    
+
     # test axes
     assert s1.axes_manager[-1].is_binned == False
     assert s2.axes_manager[-1].is_binned == False
@@ -572,21 +616,27 @@ def generate_parameters():
     parameters = []
     for dim in range(1, 4):
         for key in dm3_data_types.keys():
-            subfolder = 'dm3_%iD_data' % dim
+            subfolder = "dm3_%iD_data" % dim
             fname = "test-%s.dm3" % key
             filename = os.path.join(MY_PATH, subfolder, fname)
-            parameters.append({
-                "filename": filename,
-                "subfolder": subfolder,
-                "key": key, })
+            parameters.append(
+                {
+                    "filename": filename,
+                    "subfolder": subfolder,
+                    "key": key,
+                }
+            )
         for key in dm4_data_types.keys():
-            subfolder = 'dm4_%iD_data' % dim
+            subfolder = "dm4_%iD_data" % dim
             fname = "test-%s.dm4" % key
             filename = os.path.join(MY_PATH, subfolder, fname)
-            parameters.append({
-                "filename": filename,
-                "subfolder": subfolder,
-                "key": key, })
+            parameters.append(
+                {
+                    "filename": filename,
+                    "subfolder": subfolder,
+                    "key": key,
+                }
+            )
     return parameters
 
 
@@ -600,23 +650,26 @@ def test_data(pdict, lazy):
     assert s.data.dtype == np.dtype(dm4_data_types[key])
     subfolder = pdict["subfolder"]
     print(pdict["subfolder"])
-    if subfolder in ('dm3_1D_data', 'dm4_1D_data'):
+    if subfolder in ("dm3_1D_data", "dm4_1D_data"):
         dat = np.arange(1, 3)
-    elif subfolder in ('dm3_2D_data', 'dm4_2D_data'):
+    elif subfolder in ("dm3_2D_data", "dm4_2D_data"):
         dat = np.arange(1, 5).reshape(2, 2)
-    elif subfolder in ('dm3_3D_data', 'dm4_3D_data'):
+    elif subfolder in ("dm3_3D_data", "dm4_3D_data"):
         dat = np.arange(1, 9).reshape(2, 2, 2)
     else:
         raise ValueError
     dat = dat.astype(dm4_data_types[key])
     if key in (8, 23):  # RGBA
         dat["A"][:] = 0
-    np.testing.assert_array_equal(s.data, dat,
-                                  err_msg='content %s type % i: '
-                                  '\n%s not equal to \n%s' %
-                                  (subfolder, key, str(s.data), str(dat)))
+    np.testing.assert_array_equal(
+        s.data,
+        dat,
+        err_msg="content %s type % i: "
+        "\n%s not equal to \n%s" % (subfolder, key, str(s.data), str(dat)),
+    )
+
 
 def test_axes_bug_for_image():
     fname = os.path.join(MY_PATH, "dm3_2D_data", "test_STEM_image.dm3")
     s = load(fname)
-    assert s.axes_manager[1].name == 'y'
+    assert s.axes_manager[1].name == "y"

--- a/rsciio/tests/test_dm_stackbuilder_plugin.py
+++ b/rsciio/tests/test_dm_stackbuilder_plugin.py
@@ -26,10 +26,12 @@ my_path = os.path.dirname(__file__)
 
 
 class TestStackBuilder:
-
     def test_load_stackbuilder_imagestack(self):
-        image_stack = load(os.path.join(my_path, "dm_stackbuilder_plugin",
-                                        "test_stackbuilder_imagestack.dm3"))
+        image_stack = load(
+            os.path.join(
+                my_path, "dm_stackbuilder_plugin", "test_stackbuilder_imagestack.dm3"
+            )
+        )
         data_dimensions = image_stack.data.ndim
         am = image_stack.axes_manager
         axes_dimensions = am.signal_dimension + am.navigation_dimension
@@ -40,8 +42,11 @@ class TestStackBuilder:
         np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
         np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 15.0)
         np.testing.assert_allclose(
-            md.Acquisition_instrument.TEM.dwell_time, 0.03000005078125)
-        np.testing.assert_allclose(md.Acquisition_instrument.TEM.magnification, 200000.0)
+            md.Acquisition_instrument.TEM.dwell_time, 0.03000005078125
+        )
+        np.testing.assert_allclose(
+            md.Acquisition_instrument.TEM.magnification, 200000.0
+        )
         assert md.Acquisition_instrument.TEM.microscope == "JEM-ARM200F"
         assert md.General.date == "2015-05-17"
         assert md.General.original_filename == "test_stackbuilder_imagestack.dm3"
@@ -51,7 +56,9 @@ class TestStackBuilder:
         assert md.Signal.quantity == "Electrons (Counts)"
         assert md.Signal.signal_type == ""
         assert am.signal_axes[0].is_binned == False
-        np.testing.assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_factor,
-                        0.15674974)
-        np.testing.assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_offset,
-                        2228741.5)
+        np.testing.assert_allclose(
+            md.Signal.Noise_properties.Variance_linear_model.gain_factor, 0.15674974
+        )
+        np.testing.assert_allclose(
+            md.Signal.Noise_properties.Variance_linear_model.gain_offset, 2228741.5
+        )

--- a/rsciio/tests/test_edax.py
+++ b/rsciio/tests/test_edax.py
@@ -27,27 +27,30 @@ SHA256SUM = "e217c71efbd208da4b52e9cf483443f9da2175f2924a96447ed393086fe32008"
 if not TEST_FILES_OK:
     try:
         r = requests.get(
-            "https://github.com/hyperspy/hyperspy/blob/e7a323a3bb9b237c24bd9267d2cc4fcb31bb99f3/hyperspy/tests/io/edax_files.zip?raw=true")
+            "https://github.com/hyperspy/hyperspy/blob/e7a323a3bb9b237c24bd9267d2cc4fcb31bb99f3/hyperspy/tests/io/edax_files.zip?raw=true"
+        )
 
         SHA256SUM_GOT = hashlib.sha256(r.content).hexdigest()
         if SHA256SUM_GOT == SHA256SUM:
-            with open(ZIPF, 'wb') as f:
+            with open(ZIPF, "wb") as f:
                 f.write(r.content)
             TEST_FILES_OK = True
         else:
-            REASON = "wrong sha256sum of downloaded file. Expected: %s, got: %s" % SHA256SUM, SHA256SUM_GOT
+            REASON = (
+                "wrong sha256sum of downloaded file. Expected: %s, got: %s" % SHA256SUM,
+                SHA256SUM_GOT,
+            )
     except BaseException as e:
         REASON = "download of EDAX test files failed: %s" % e
 
 
 def setup_module():
     if TEST_FILES_OK:
-        with zipfile.ZipFile(ZIPF, 'r') as zipped:
+        with zipfile.ZipFile(ZIPF, "r") as zipped:
             zipped.extractall(TMP_DIR.name)
 
 
-pytestmark = pytest.mark.skipif(not TEST_FILES_OK,
-                                reason=REASON)
+pytestmark = pytest.mark.skipif(not TEST_FILES_OK, reason=REASON)
 
 
 def teardown_module():
@@ -55,13 +58,12 @@ def teardown_module():
 
 
 class TestSpcSpectrum_v061_xrf:
-
     @classmethod
     def setup_class(cls):
         cls.spc = load(os.path.join(TMP_DIR.name, "spc0_61-ipr333_xrf.spc"))
-        cls.spc_loadAll = load(os.path.join(TMP_DIR.name,
-                                            "spc0_61-ipr333_xrf.spc"),
-                               load_all_spc=True)
+        cls.spc_loadAll = load(
+            os.path.join(TMP_DIR.name, "spc0_61-ipr333_xrf.spc"), load_all_spc=True
+        )
 
     @classmethod
     def teardown_class(cls):
@@ -74,75 +76,122 @@ class TestSpcSpectrum_v061_xrf:
         # test data shape
         assert (4000,) == TestSpcSpectrum_v061_xrf.spc.data.shape
         # test 40 datapoints
-        assert (
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 319, 504, 639, 924,
-             1081, 1326, 1470, 1727, 1983, 2123, 2278, 2509, 2586, 2639,
-             2681, 2833, 2696, 2704, 2812, 2745, 2709, 2647, 2608, 2620,
-             2571, 2669] == TestSpcSpectrum_v061_xrf.spc.data[:40].tolist())
+        assert [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            319,
+            504,
+            639,
+            924,
+            1081,
+            1326,
+            1470,
+            1727,
+            1983,
+            2123,
+            2278,
+            2509,
+            2586,
+            2639,
+            2681,
+            2833,
+            2696,
+            2704,
+            2812,
+            2745,
+            2709,
+            2647,
+            2608,
+            2620,
+            2571,
+            2669,
+        ] == TestSpcSpectrum_v061_xrf.spc.data[:40].tolist()
 
     def test_parameters(self):
-        elements = TestSpcSpectrum_v061_xrf.spc.metadata.as_dictionary()[
-            'Sample']['elements']
+        elements = TestSpcSpectrum_v061_xrf.spc.metadata.as_dictionary()["Sample"][
+            "elements"
+        ]
         sem_dict = TestSpcSpectrum_v061_xrf.spc.metadata.as_dictionary()[
-            'Acquisition_instrument']['SEM']  # this will eventually need to
+            "Acquisition_instrument"
+        ][
+            "SEM"
+        ]  # this will eventually need to
         #  be changed when XRF-specific
         #  features are added
-        eds_dict = sem_dict['Detector']['EDS']
-        signal_dict = TestSpcSpectrum_v061_xrf.spc.metadata.as_dictionary()[
-            'Signal']
+        eds_dict = sem_dict["Detector"]["EDS"]
+        signal_dict = TestSpcSpectrum_v061_xrf.spc.metadata.as_dictionary()["Signal"]
 
         # Testing SEM parameters
-        np.testing.assert_allclose(30, sem_dict['beam_energy'])
-        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(30, sem_dict["beam_energy"])
+        np.testing.assert_allclose(0, sem_dict["Stage"]["tilt_alpha"])
 
         # Testing EDS parameters
-        np.testing.assert_allclose(45, eds_dict['azimuth_angle'])
-        np.testing.assert_allclose(35, eds_dict['elevation_angle'])
-        np.testing.assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
-                        atol=1E-5)
-        np.testing.assert_allclose(2561.0, eds_dict['live_time'], atol=1E-6)
+        np.testing.assert_allclose(45, eds_dict["azimuth_angle"])
+        np.testing.assert_allclose(35, eds_dict["elevation_angle"])
+        np.testing.assert_allclose(
+            137.92946, eds_dict["energy_resolution_MnKa"], atol=1e-5
+        )
+        np.testing.assert_allclose(2561.0, eds_dict["live_time"], atol=1e-6)
 
         # Testing elements
-        assert ({'Al', 'Ca', 'Cl', 'Cr', 'Fe', 'K', 'Mg', 'Mn', 'Si', 'Y'} ==
-                set(elements))
+        assert {"Al", "Ca", "Cl", "Cr", "Fe", "K", "Mg", "Mn", "Si", "Y"} == set(
+            elements
+        )
 
         # Testing HyperSpy parameters
-        assert 'EDS_SEM' == signal_dict['signal_type']
+        assert "EDS_SEM" == signal_dict["signal_type"]
         assert isinstance(TestSpcSpectrum_v061_xrf.spc, signals.EDSSEMSpectrum)
 
     def test_axes(self):
-        spc_ax_manager = {'axis-0': {'_type': 'UniformDataAxis',
-                                     'name': 'Energy',
-                                     'navigate': False,
-                                     'is_binned': True,
-                                     'offset': 0.0,
-                                     'scale': 0.01,
-                                     'size': 4000,
-                                     'units': 'keV'}}
-        assert (spc_ax_manager ==
-                TestSpcSpectrum_v061_xrf.spc.axes_manager.as_dictionary())
+        spc_ax_manager = {
+            "axis-0": {
+                "_type": "UniformDataAxis",
+                "name": "Energy",
+                "navigate": False,
+                "is_binned": True,
+                "offset": 0.0,
+                "scale": 0.01,
+                "size": 4000,
+                "units": "keV",
+            }
+        }
+        assert (
+            spc_ax_manager == TestSpcSpectrum_v061_xrf.spc.axes_manager.as_dictionary()
+        )
 
     def test_load_all_spc(self):
         spc_header = TestSpcSpectrum_v061_xrf.spc_loadAll.original_metadata[
-            'spc_header']
+            "spc_header"
+        ]
 
-        np.testing.assert_allclose(4, spc_header['analysisType'])
-        np.testing.assert_allclose(4, spc_header['analyzerType'])
-        np.testing.assert_allclose(2013, spc_header['collectDateYear'])
-        np.testing.assert_allclose(9, spc_header['collectDateMon'])
-        np.testing.assert_allclose(26, spc_header['collectDateDay'])
-        np.testing.assert_equal(b'Garnet1.', spc_header['fileName'].view('|S8')[0])
-        np.testing.assert_allclose(45, spc_header['xRayTubeZ'])
+        np.testing.assert_allclose(4, spc_header["analysisType"])
+        np.testing.assert_allclose(4, spc_header["analyzerType"])
+        np.testing.assert_allclose(2013, spc_header["collectDateYear"])
+        np.testing.assert_allclose(9, spc_header["collectDateMon"])
+        np.testing.assert_allclose(26, spc_header["collectDateDay"])
+        np.testing.assert_equal(b"Garnet1.", spc_header["fileName"].view("|S8")[0])
+        np.testing.assert_allclose(45, spc_header["xRayTubeZ"])
 
 
 class TestSpcSpectrum_v070_eds:
-
     @classmethod
     def setup_class(cls):
         cls.spc = load(os.path.join(TMP_DIR.name, "single_spect.spc"))
-        cls.spc_loadAll = load(os.path.join(TMP_DIR.name,
-                                            "single_spect.spc"),
-                               load_all_spc=True)
+        cls.spc_loadAll = load(
+            os.path.join(TMP_DIR.name, "single_spect.spc"), load_all_spc=True
+        )
 
     @classmethod
     def teardown_class(cls):
@@ -155,71 +204,97 @@ class TestSpcSpectrum_v070_eds:
         # test data shape
         assert (4096,) == TestSpcSpectrum_v070_eds.spc.data.shape
         # test 1st 20 datapoints
-        assert (
-            [0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 10, 4, 10, 10, 45, 87, 146, 236,
-             312, 342] == TestSpcSpectrum_v070_eds.spc.data[:20].tolist())
+        assert [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            3,
+            3,
+            10,
+            4,
+            10,
+            10,
+            45,
+            87,
+            146,
+            236,
+            312,
+            342,
+        ] == TestSpcSpectrum_v070_eds.spc.data[:20].tolist()
 
     def test_parameters(self):
-        elements = TestSpcSpectrum_v070_eds.spc.metadata.as_dictionary()[
-            'Sample']['elements']
+        elements = TestSpcSpectrum_v070_eds.spc.metadata.as_dictionary()["Sample"][
+            "elements"
+        ]
         sem_dict = TestSpcSpectrum_v070_eds.spc.metadata.as_dictionary()[
-            'Acquisition_instrument']['SEM']
-        eds_dict = sem_dict['Detector']['EDS']
-        signal_dict = TestSpcSpectrum_v070_eds.spc.metadata.as_dictionary()[
-            'Signal']
+            "Acquisition_instrument"
+        ]["SEM"]
+        eds_dict = sem_dict["Detector"]["EDS"]
+        signal_dict = TestSpcSpectrum_v070_eds.spc.metadata.as_dictionary()["Signal"]
 
         # Testing SEM parameters
-        np.testing.assert_allclose(22, sem_dict['beam_energy'])
-        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(22, sem_dict["beam_energy"])
+        np.testing.assert_allclose(0, sem_dict["Stage"]["tilt_alpha"])
 
         # Testing EDS parameters
-        np.testing.assert_allclose(0, eds_dict['azimuth_angle'])
-        np.testing.assert_allclose(34, eds_dict['elevation_angle'])
-        np.testing.assert_allclose(129.31299, eds_dict['energy_resolution_MnKa'],
-                        atol=1E-5)
-        np.testing.assert_allclose(50.000004, eds_dict['live_time'], atol=1E-6)
+        np.testing.assert_allclose(0, eds_dict["azimuth_angle"])
+        np.testing.assert_allclose(34, eds_dict["elevation_angle"])
+        np.testing.assert_allclose(
+            129.31299, eds_dict["energy_resolution_MnKa"], atol=1e-5
+        )
+        np.testing.assert_allclose(50.000004, eds_dict["live_time"], atol=1e-6)
 
         # Testing elements
-        assert ({'Al', 'C', 'Ce', 'Cu', 'F', 'Ho', 'Mg', 'O'} ==
-                set(elements))
+        assert {"Al", "C", "Ce", "Cu", "F", "Ho", "Mg", "O"} == set(elements)
 
         # Testing HyperSpy parameters
-        assert 'EDS_SEM' == signal_dict['signal_type']
+        assert "EDS_SEM" == signal_dict["signal_type"]
         assert isinstance(TestSpcSpectrum_v070_eds.spc, signals.EDSSEMSpectrum)
 
     def test_axes(self):
-        spc_ax_manager = {'axis-0': {'_type': 'UniformDataAxis',
-                                     'name': 'Energy',
-                                     'navigate': False,
-                                     'is_binned': True,
-                                     'offset': 0.0,
-                                     'scale': 0.01,
-                                     'size': 4096,
-                                     'units': 'keV'}}
-        assert (spc_ax_manager ==
-                TestSpcSpectrum_v070_eds.spc.axes_manager.as_dictionary())
+        spc_ax_manager = {
+            "axis-0": {
+                "_type": "UniformDataAxis",
+                "name": "Energy",
+                "navigate": False,
+                "is_binned": True,
+                "offset": 0.0,
+                "scale": 0.01,
+                "size": 4096,
+                "units": "keV",
+            }
+        }
+        assert (
+            spc_ax_manager == TestSpcSpectrum_v070_eds.spc.axes_manager.as_dictionary()
+        )
 
     def test_load_all_spc(self):
         spc_header = TestSpcSpectrum_v070_eds.spc_loadAll.original_metadata[
-            'spc_header']
+            "spc_header"
+        ]
 
-        np.testing.assert_allclose(4, spc_header['analysisType'])
-        np.testing.assert_allclose(5, spc_header['analyzerType'])
-        np.testing.assert_allclose(2016, spc_header['collectDateYear'])
-        np.testing.assert_allclose(4, spc_header['collectDateMon'])
-        np.testing.assert_allclose(19, spc_header['collectDateDay'])
-        np.testing.assert_equal(b'C:\\ProgramData\\EDAX\\jtaillon\\Cole\\Mapping\\Lsm\\'
-                     b'GFdCr\\950\\Area 1\\spectrum20160419153851427_0.spc',
-                     spc_header['longFileName'].view('|S256')[0])
-        np.testing.assert_allclose(0, spc_header['xRayTubeZ'])
+        np.testing.assert_allclose(4, spc_header["analysisType"])
+        np.testing.assert_allclose(5, spc_header["analyzerType"])
+        np.testing.assert_allclose(2016, spc_header["collectDateYear"])
+        np.testing.assert_allclose(4, spc_header["collectDateMon"])
+        np.testing.assert_allclose(19, spc_header["collectDateDay"])
+        np.testing.assert_equal(
+            b"C:\\ProgramData\\EDAX\\jtaillon\\Cole\\Mapping\\Lsm\\"
+            b"GFdCr\\950\\Area 1\\spectrum20160419153851427_0.spc",
+            spc_header["longFileName"].view("|S256")[0],
+        )
+        np.testing.assert_allclose(0, spc_header["xRayTubeZ"])
 
 
 class TestSpdMap_070_eds:
-
     @classmethod
     def setup_class(cls):
-        cls.spd = load(os.path.join(TMP_DIR.name, "spd_map.spd"),
-                       convert_units=True)
+        cls.spd = load(os.path.join(TMP_DIR.name, "spd_map.spd"), convert_units=True)
 
     @classmethod
     def teardown_class(cls):
@@ -231,125 +306,140 @@ class TestSpdMap_070_eds:
         assert np.uint16 == TestSpdMap_070_eds.spd.data.dtype
         # test d_shape
         assert (200, 256, 2500) == TestSpdMap_070_eds.spd.data.shape
-        assert ([[[0, 0, 0, 0, 0],              # test random data
-                  [0, 0, 1, 0, 1],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0]],
-                 [[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 1, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0]],
-                 [[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1],
-                  [0, 1, 1, 0, 0],
-                  [0, 0, 0, 0, 0]],
-                 [[0, 1, 0, 0, 0],
-                  [0, 0, 0, 1, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 1, 0, 0],
-                  [0, 0, 0, 1, 0]],
-                 [[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 1, 0, 1],
-                  [0, 0, 0, 1, 0],
-                  [0, 0, 0, 0, 0]]] ==
-                TestSpdMap_070_eds.spd.data[15:20, 15:20, 15:20].tolist())
+        assert [
+            [
+                [0, 0, 0, 0, 0],  # test random data
+                [0, 0, 1, 0, 1],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ],
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ],
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1],
+                [0, 1, 1, 0, 0],
+                [0, 0, 0, 0, 0],
+            ],
+            [
+                [0, 1, 0, 0, 0],
+                [0, 0, 0, 1, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 0, 1, 0],
+            ],
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 1, 0, 1],
+                [0, 0, 0, 1, 0],
+                [0, 0, 0, 0, 0],
+            ],
+        ] == TestSpdMap_070_eds.spd.data[15:20, 15:20, 15:20].tolist()
 
     def test_parameters(self):
-        elements = TestSpdMap_070_eds.spd.metadata.as_dictionary()[
-            'Sample']['elements']
+        elements = TestSpdMap_070_eds.spd.metadata.as_dictionary()["Sample"]["elements"]
         sem_dict = TestSpdMap_070_eds.spd.metadata.as_dictionary()[
-            'Acquisition_instrument']['SEM']
-        eds_dict = sem_dict['Detector']['EDS']
-        signal_dict = TestSpdMap_070_eds.spd.metadata.as_dictionary()['Signal']
+            "Acquisition_instrument"
+        ]["SEM"]
+        eds_dict = sem_dict["Detector"]["EDS"]
+        signal_dict = TestSpdMap_070_eds.spd.metadata.as_dictionary()["Signal"]
 
         # Testing SEM parameters
-        np.testing.assert_allclose(22, sem_dict['beam_energy'])
-        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(22, sem_dict["beam_energy"])
+        np.testing.assert_allclose(0, sem_dict["Stage"]["tilt_alpha"])
 
         # Testing EDS parameters
-        np.testing.assert_allclose(0, eds_dict['azimuth_angle'])
-        np.testing.assert_allclose(34, eds_dict['elevation_angle'])
-        np.testing.assert_allclose(126.60252, eds_dict['energy_resolution_MnKa'],
-                        atol=1E-5)
-        np.testing.assert_allclose(2621.4399, eds_dict['live_time'], atol=1E-4)
+        np.testing.assert_allclose(0, eds_dict["azimuth_angle"])
+        np.testing.assert_allclose(34, eds_dict["elevation_angle"])
+        np.testing.assert_allclose(
+            126.60252, eds_dict["energy_resolution_MnKa"], atol=1e-5
+        )
+        np.testing.assert_allclose(2621.4399, eds_dict["live_time"], atol=1e-4)
 
         # Testing elements
-        assert {'Ce', 'Co', 'Cr', 'Fe', 'Gd', 'La', 'Mg', 'O',
-                'Sr'} == set(elements)
+        assert {"Ce", "Co", "Cr", "Fe", "Gd", "La", "Mg", "O", "Sr"} == set(elements)
 
         # Testing HyperSpy parameters
-        assert 'EDS_SEM' == signal_dict['signal_type']
+        assert "EDS_SEM" == signal_dict["signal_type"]
         assert isinstance(TestSpdMap_070_eds.spd, signals.EDSSEMSpectrum)
 
     def test_axes(self):
-        spd_ax_manager = {'axis-0': {'_type': 'UniformDataAxis',
-                                     'name': 'y',
-                                     'navigate': True,
-                                     'is_binned': False,
-                                     'offset': 0.0,
-                                     'scale': 14.227345585823057,
-                                     'size': 200,
-                                     'units': 'nm'},
-                          'axis-1': {'_type': 'UniformDataAxis',
-                                     'name': 'x',
-                                     'navigate': True,
-                                     'is_binned': False,
-                                     'offset': 0.0,
-                                     'scale': 14.235896058380602,
-                                     'size': 256,
-                                     'units': 'nm'},
-                          'axis-2': {'_type': 'UniformDataAxis',
-                                     'name': 'Energy',
-                                     'navigate': False,
-                                     'is_binned': True,
-                                     'offset': 0.0,
-                                     'scale': 0.0050000000000000001,
-                                     'size': 2500,
-                                     'units': 'keV'}}
-        assert (spd_ax_manager ==
-                TestSpdMap_070_eds.spd.axes_manager.as_dictionary())
+        spd_ax_manager = {
+            "axis-0": {
+                "_type": "UniformDataAxis",
+                "name": "y",
+                "navigate": True,
+                "is_binned": False,
+                "offset": 0.0,
+                "scale": 14.227345585823057,
+                "size": 200,
+                "units": "nm",
+            },
+            "axis-1": {
+                "_type": "UniformDataAxis",
+                "name": "x",
+                "navigate": True,
+                "is_binned": False,
+                "offset": 0.0,
+                "scale": 14.235896058380602,
+                "size": 256,
+                "units": "nm",
+            },
+            "axis-2": {
+                "_type": "UniformDataAxis",
+                "name": "Energy",
+                "navigate": False,
+                "is_binned": True,
+                "offset": 0.0,
+                "scale": 0.0050000000000000001,
+                "size": 2500,
+                "units": "keV",
+            },
+        }
+        assert spd_ax_manager == TestSpdMap_070_eds.spd.axes_manager.as_dictionary()
 
     def test_ipr_reading(self):
-        ipr_header = TestSpdMap_070_eds.spd.original_metadata['ipr_header']
-        np.testing.assert_allclose(0.014235896, ipr_header['mppX'])
-        np.testing.assert_allclose(0.014227346, ipr_header['mppY'])
+        ipr_header = TestSpdMap_070_eds.spd.original_metadata["ipr_header"]
+        np.testing.assert_allclose(0.014235896, ipr_header["mppX"])
+        np.testing.assert_allclose(0.014227346, ipr_header["mppY"])
 
     def test_spc_reading(self):
         # Test to make sure that spc metadata matches spd metadata
-        spc_header = TestSpdMap_070_eds.spd.original_metadata['spc_header']
+        spc_header = TestSpdMap_070_eds.spd.original_metadata["spc_header"]
 
-        elements = TestSpdMap_070_eds.spd.metadata.as_dictionary()[
-            'Sample']['elements']
+        elements = TestSpdMap_070_eds.spd.metadata.as_dictionary()["Sample"]["elements"]
         sem_dict = TestSpdMap_070_eds.spd.metadata.as_dictionary()[
-            'Acquisition_instrument']['SEM']
-        eds_dict = sem_dict['Detector']['EDS']
+            "Acquisition_instrument"
+        ]["SEM"]
+        eds_dict = sem_dict["Detector"]["EDS"]
 
-        np.testing.assert_allclose(spc_header.azimuth,
-                        eds_dict['azimuth_angle'])
-        np.testing.assert_allclose(spc_header.detReso,
-                        eds_dict['energy_resolution_MnKa'])
-        np.testing.assert_allclose(spc_header.elevation,
-                        eds_dict['elevation_angle'])
-        np.testing.assert_allclose(spc_header.liveTime,
-                        eds_dict['live_time'])
-        np.testing.assert_allclose(spc_header.evPerChan,
-                        TestSpdMap_070_eds.spd.axes_manager[2].scale * 1000)
-        np.testing.assert_allclose(spc_header.kV,
-                        sem_dict['beam_energy'])
-        np.testing.assert_allclose(spc_header.numElem,
-                        len(elements))
+        np.testing.assert_allclose(spc_header.azimuth, eds_dict["azimuth_angle"])
+        np.testing.assert_allclose(
+            spc_header.detReso, eds_dict["energy_resolution_MnKa"]
+        )
+        np.testing.assert_allclose(spc_header.elevation, eds_dict["elevation_angle"])
+        np.testing.assert_allclose(spc_header.liveTime, eds_dict["live_time"])
+        np.testing.assert_allclose(
+            spc_header.evPerChan, TestSpdMap_070_eds.spd.axes_manager[2].scale * 1000
+        )
+        np.testing.assert_allclose(spc_header.kV, sem_dict["beam_energy"])
+        np.testing.assert_allclose(spc_header.numElem, len(elements))
 
 
 class TestSpdMap_061_xrf:
-
     @classmethod
     def setup_class(cls):
-        cls.spd = load(os.path.join(TMP_DIR.name, "spc0_61-ipr333_xrf.spd"),
-                       convert_units=True)
+        cls.spd = load(
+            os.path.join(TMP_DIR.name, "spc0_61-ipr333_xrf.spd"), convert_units=True
+        )
 
     @classmethod
     def teardown_class(cls):
@@ -361,114 +451,131 @@ class TestSpdMap_061_xrf:
         assert np.uint16 == TestSpdMap_061_xrf.spd.data.dtype
         # test d_shape
         assert (200, 256, 2000) == TestSpdMap_061_xrf.spd.data.shape
-        assert ([[[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 1, 0]],
-                 [[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0]],
-                 [[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1]],
-                 [[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1]],
-                 [[0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0]]] ==
-                TestSpdMap_061_xrf.spd.data[15:20, 15:20, 15:20].tolist())
+        assert [
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0],
+            ],
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ],
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1],
+            ],
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1],
+            ],
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ],
+        ] == TestSpdMap_061_xrf.spd.data[15:20, 15:20, 15:20].tolist()
 
     def test_parameters(self):
-        elements = TestSpdMap_061_xrf.spd.metadata.as_dictionary()['Sample'][
-            'elements']
+        elements = TestSpdMap_061_xrf.spd.metadata.as_dictionary()["Sample"]["elements"]
         sem_dict = TestSpdMap_061_xrf.spd.metadata.as_dictionary()[
-            'Acquisition_instrument']['SEM']
-        eds_dict = sem_dict['Detector']['EDS']
-        signal_dict = TestSpdMap_061_xrf.spd.metadata.as_dictionary()['Signal']
+            "Acquisition_instrument"
+        ]["SEM"]
+        eds_dict = sem_dict["Detector"]["EDS"]
+        signal_dict = TestSpdMap_061_xrf.spd.metadata.as_dictionary()["Signal"]
 
         # Testing SEM parameters
-        np.testing.assert_allclose(30, sem_dict['beam_energy'])
-        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(30, sem_dict["beam_energy"])
+        np.testing.assert_allclose(0, sem_dict["Stage"]["tilt_alpha"])
 
         # Testing EDS parameters
-        np.testing.assert_allclose(45, eds_dict['azimuth_angle'])
-        np.testing.assert_allclose(35, eds_dict['elevation_angle'])
-        np.testing.assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
-                        atol=1E-5)
-        np.testing.assert_allclose(2561.0, eds_dict['live_time'], atol=1E-4)
+        np.testing.assert_allclose(45, eds_dict["azimuth_angle"])
+        np.testing.assert_allclose(35, eds_dict["elevation_angle"])
+        np.testing.assert_allclose(
+            137.92946, eds_dict["energy_resolution_MnKa"], atol=1e-5
+        )
+        np.testing.assert_allclose(2561.0, eds_dict["live_time"], atol=1e-4)
 
         # Testing elements
-        assert {'Al', 'Ca', 'Cl', 'Cr', 'Fe', 'K', 'Mg', 'Mn', 'Si',
-                'Y'} == set(elements)
+        assert {"Al", "Ca", "Cl", "Cr", "Fe", "K", "Mg", "Mn", "Si", "Y"} == set(
+            elements
+        )
 
         # Testing HyperSpy parameters
-        assert 'EDS_SEM' == signal_dict['signal_type']
+        assert "EDS_SEM" == signal_dict["signal_type"]
         assert isinstance(TestSpdMap_061_xrf.spd, signals.EDSSEMSpectrum)
 
     def test_axes(self):
-        spd_ax_manager = {'axis-0': {'_type': 'UniformDataAxis',
-                                     'name': 'y',
-                                     'navigate': True,
-                                     'is_binned': False,
-                                     'offset': 0.0,
-                                     'scale': 0.5651920166015625,
-                                     'size': 200,
-                                     'units': 'mm'},
-                          'axis-1': {'_type': 'UniformDataAxis',
-                                     'name': 'x',
-                                     'navigate': True,
-                                     'is_binned': False,
-                                     'offset': 0.0,
-                                     'scale': 0.5651920166015625,
-                                     'size': 256,
-                                     'units': 'mm'},
-                          'axis-2': {'_type': 'UniformDataAxis',
-                                     'name': 'Energy',
-                                     'navigate': False,
-                                     'is_binned': True,
-                                     'offset': 0.0,
-                                     'scale': 0.01,
-                                     'size': 2000,
-                                     'units': 'keV'}}
-        assert (spd_ax_manager ==
-                TestSpdMap_061_xrf.spd.axes_manager.as_dictionary())
+        spd_ax_manager = {
+            "axis-0": {
+                "_type": "UniformDataAxis",
+                "name": "y",
+                "navigate": True,
+                "is_binned": False,
+                "offset": 0.0,
+                "scale": 0.5651920166015625,
+                "size": 200,
+                "units": "mm",
+            },
+            "axis-1": {
+                "_type": "UniformDataAxis",
+                "name": "x",
+                "navigate": True,
+                "is_binned": False,
+                "offset": 0.0,
+                "scale": 0.5651920166015625,
+                "size": 256,
+                "units": "mm",
+            },
+            "axis-2": {
+                "_type": "UniformDataAxis",
+                "name": "Energy",
+                "navigate": False,
+                "is_binned": True,
+                "offset": 0.0,
+                "scale": 0.01,
+                "size": 2000,
+                "units": "keV",
+            },
+        }
+        assert spd_ax_manager == TestSpdMap_061_xrf.spd.axes_manager.as_dictionary()
 
     def test_ipr_reading(self):
-        ipr_header = TestSpdMap_061_xrf.spd.original_metadata['ipr_header']
-        np.testing.assert_allclose(565.1920166015625, ipr_header['mppX'])
-        np.testing.assert_allclose(565.1920166015625, ipr_header['mppY'])
+        ipr_header = TestSpdMap_061_xrf.spd.original_metadata["ipr_header"]
+        np.testing.assert_allclose(565.1920166015625, ipr_header["mppX"])
+        np.testing.assert_allclose(565.1920166015625, ipr_header["mppY"])
 
     def test_spc_reading(self):
         # Test to make sure that spc metadata matches spd_061_xrf metadata
-        spc_header = TestSpdMap_061_xrf.spd.original_metadata['spc_header']
+        spc_header = TestSpdMap_061_xrf.spd.original_metadata["spc_header"]
 
-        elements = TestSpdMap_061_xrf.spd.metadata.as_dictionary()['Sample'][
-            'elements']
+        elements = TestSpdMap_061_xrf.spd.metadata.as_dictionary()["Sample"]["elements"]
         sem_dict = TestSpdMap_061_xrf.spd.metadata.as_dictionary()[
-            'Acquisition_instrument']['SEM']
-        eds_dict = sem_dict['Detector']['EDS']
+            "Acquisition_instrument"
+        ]["SEM"]
+        eds_dict = sem_dict["Detector"]["EDS"]
 
-        np.testing.assert_allclose(spc_header.azimuth,
-                        eds_dict['azimuth_angle'])
-        np.testing.assert_allclose(spc_header.detReso,
-                        eds_dict['energy_resolution_MnKa'])
-        np.testing.assert_allclose(spc_header.elevation,
-                        eds_dict['elevation_angle'])
-        np.testing.assert_allclose(spc_header.liveTime,
-                        eds_dict['live_time'])
-        np.testing.assert_allclose(spc_header.evPerChan,
-                        TestSpdMap_061_xrf.spd.axes_manager[2].scale * 1000)
-        np.testing.assert_allclose(spc_header.kV,
-                        sem_dict['beam_energy'])
-        np.testing.assert_allclose(spc_header.numElem,
-                        len(elements))
+        np.testing.assert_allclose(spc_header.azimuth, eds_dict["azimuth_angle"])
+        np.testing.assert_allclose(
+            spc_header.detReso, eds_dict["energy_resolution_MnKa"]
+        )
+        np.testing.assert_allclose(spc_header.elevation, eds_dict["elevation_angle"])
+        np.testing.assert_allclose(spc_header.liveTime, eds_dict["live_time"])
+        np.testing.assert_allclose(
+            spc_header.evPerChan, TestSpdMap_061_xrf.spd.axes_manager[2].scale * 1000
+        )
+        np.testing.assert_allclose(spc_header.kV, sem_dict["beam_energy"])
+        np.testing.assert_allclose(spc_header.numElem, len(elements))

--- a/rsciio/tests/test_emd.py
+++ b/rsciio/tests/test_emd.py
@@ -35,8 +35,13 @@ import shutil
 from hyperspy import __version__ as hs_version
 from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
-from hyperspy.signals import (BaseSignal, EDSTEMSpectrum, Signal1D, Signal2D,
-                              ComplexSignal2D)
+from hyperspy.signals import (
+    BaseSignal,
+    EDSTEMSpectrum,
+    Signal1D,
+    Signal2D,
+    ComplexSignal2D,
+)
 
 my_path = os.path.dirname(__file__)
 
@@ -45,19 +50,22 @@ data_signal = np.arange(27).reshape((3, 3, 3)).T
 data_image = np.arange(9).reshape((3, 3)).T
 data_spectrum = np.arange(3).T
 data_save = np.arange(24).reshape((2, 3, 4))
-sig_metadata = {'a': 1, 'b': 2}
-user = {'name': 'John Doe', 'institution': 'TestUniversity',
-        'department': 'Microscopy', 'email': 'johndoe@web.de'}
-microscope = {'name': 'Titan', 'voltage': '300kV'}
-sample = {'material': 'TiO2', 'preparation': 'FIB'}
-comments = {'comment': 'Test'}
-test_title = 'This is a test!'
+sig_metadata = {"a": 1, "b": 2}
+user = {
+    "name": "John Doe",
+    "institution": "TestUniversity",
+    "department": "Microscopy",
+    "email": "johndoe@web.de",
+}
+microscope = {"name": "Titan", "voltage": "300kV"}
+sample = {"material": "TiO2", "preparation": "FIB"}
+comments = {"comment": "Test"}
+test_title = "This is a test!"
 
 
 @pytest.mark.parametrize("lazy", (True, False))
 def test_signal_3d_loading(lazy):
-    signal = load(os.path.join(my_path, 'emd_files', 'example_signal.emd'),
-                  lazy=lazy)
+    signal = load(os.path.join(my_path, "emd_files", "example_signal.emd"), lazy=lazy)
     if lazy:
         signal.compute(close_file=True)
     np.testing.assert_equal(signal.data, data_signal)
@@ -65,19 +73,19 @@ def test_signal_3d_loading(lazy):
 
 
 def test_image_2d_loading():
-    signal = load(os.path.join(my_path, 'emd_files', 'example_image.emd'))
+    signal = load(os.path.join(my_path, "emd_files", "example_image.emd"))
     np.testing.assert_equal(signal.data, data_image)
     assert isinstance(signal, Signal2D)
 
 
 def test_spectrum_1d_loading():
-    signal = load(os.path.join(my_path, 'emd_files', 'example_spectrum.emd'))
+    signal = load(os.path.join(my_path, "emd_files", "example_spectrum.emd"))
     np.testing.assert_equal(signal.data, data_spectrum)
     assert isinstance(signal, Signal1D)
 
 
 def test_metadata():
-    signal = load(os.path.join(my_path, 'emd_files', 'example_metadata.emd'))
+    signal = load(os.path.join(my_path, "emd_files", "example_metadata.emd"))
     om = signal.original_metadata
     np.testing.assert_equal(signal.data, data_image)
     np.testing.assert_equal(signal.metadata.General.title, test_title)
@@ -90,54 +98,50 @@ def test_metadata():
 
 def test_metadata_with_bytes_string():
     pytest.importorskip("natsort", minversion="5.1.0")
-    filename = os.path.join(
-        my_path, 'emd_files', 'example_bytes_string_metadata.emd')
-    f = h5py.File(filename, 'r')
-    dim1 = f['test_group']['data_group']['dim1']
-    dim1_name = dim1.attrs['name']
-    dim1_units = dim1.attrs['units']
+    filename = os.path.join(my_path, "emd_files", "example_bytes_string_metadata.emd")
+    f = h5py.File(filename, "r")
+    dim1 = f["test_group"]["data_group"]["dim1"]
+    dim1_name = dim1.attrs["name"]
+    dim1_units = dim1.attrs["units"]
     f.close()
     assert isinstance(dim1_name, np.bytes_)
     assert isinstance(dim1_units, np.bytes_)
-    _ = load(os.path.join(my_path, 'emd_files', filename))
+    _ = load(os.path.join(my_path, "emd_files", filename))
 
 
 def test_data_numpy_object_dtype():
-    filename = os.path.join(
-        my_path, 'emd_files', 'example_object_dtype_data.emd')
+    filename = os.path.join(my_path, "emd_files", "example_object_dtype_data.emd")
     signal = load(filename)
-    np.testing.assert_equal(signal.data,
-                            np.array([['a, 2, test1', 'a, 2, test1']]))
+    np.testing.assert_equal(signal.data, np.array([["a, 2, test1", "a, 2, test1"]]))
 
 
 def test_data_axis_length_1():
-    filename = os.path.join(
-        my_path, 'emd_files', 'example_axis_len_1.emd')
+    filename = os.path.join(my_path, "emd_files", "example_axis_len_1.emd")
     signal = load(filename)
     assert signal.data.shape == (5, 1, 5)
 
 
 class TestDatasetName:
-
     def setup_method(self):
         tmpdir = tempfile.TemporaryDirectory()
         hdf5_dataset_path = os.path.join(tmpdir.name, "test_dataset.emd")
         f = h5py.File(hdf5_dataset_path, mode="w")
-        f.attrs.create('version_major', 0)
-        f.attrs.create('version_minor', 2)
+        f.attrs.create("version_major", 0)
+        f.attrs.create("version_minor", 2)
 
         dataset_path_list = [
-            '/experimental/science_data_0/data',
-            '/experimental/science_data_1/data',
-            '/processed/science_data_0/data']
+            "/experimental/science_data_0/data",
+            "/experimental/science_data_1/data",
+            "/processed/science_data_0/data",
+        ]
         data_size_list = [(50, 50), (20, 10), (16, 32)]
 
         for dataset_path, data_size in zip(dataset_path_list, data_size_list):
             group = f.create_group(os.path.dirname(dataset_path))
-            group.attrs.create('emd_group_type', 1)
-            group.create_dataset(name='data', data=np.random.random(data_size))
-            group.create_dataset(name='dim1', data=range(data_size[0]))
-            group.create_dataset(name='dim2', data=range(data_size[1]))
+            group.attrs.create("emd_group_type", 1)
+            group.create_dataset(name="data", data=np.random.random(data_size))
+            group.create_dataset(name="dim1", data=range(data_size[0]))
+            group.create_dataset(name="dim2", data=range(data_size[1]))
 
         f.close()
 
@@ -152,8 +156,7 @@ class TestDatasetName:
     def test_load_with_dataset_path(self):
         s = load(self.hdf5_dataset_path)
         assert len(s) == len(self.dataset_path_list)
-        for dataset_path, data_size in zip(
-                self.dataset_path_list, self.data_size_list):
+        for dataset_path, data_size in zip(self.dataset_path_list, self.data_size_list):
             s = load(self.hdf5_dataset_path, dataset_path=dataset_path)
             title = os.path.basename(os.path.dirname(dataset_path))
             assert s.metadata.General.title == title
@@ -168,10 +171,12 @@ class TestDatasetName:
 
     def test_wrong_dataset_path(self):
         with pytest.raises(IOError):
-            load(self.hdf5_dataset_path, dataset_path='a_wrong_name')
+            load(self.hdf5_dataset_path, dataset_path="a_wrong_name")
         with pytest.raises(IOError):
-            load(self.hdf5_dataset_path,
-                 dataset_path=[self.dataset_path_list[0], 'a_wrong_name'])
+            load(
+                self.hdf5_dataset_path,
+                dataset_path=[self.dataset_path_list[0], "a_wrong_name"],
+            )
 
     def test_deprecated_dataset_name(self):
         with pytest.warns(UserWarning):
@@ -182,29 +187,26 @@ class TestDatasetName:
 def test_minimal_save():
     signal = Signal1D([0, 1])
     with tempfile.TemporaryDirectory() as tmp:
-        signal.save(os.path.join(tmp, 'testfile.emd'))
+        signal.save(os.path.join(tmp, "testfile.emd"))
 
 
 class TestReadSeveralDatasets:
-
     def setup_method(self):
         tmpdir = tempfile.TemporaryDirectory()
         hdf5_dataset_path = os.path.join(tmpdir.name, "test_dataset.emd")
         f = h5py.File(hdf5_dataset_path, mode="w")
-        f.attrs.create('version_major', 0)
-        f.attrs.create('version_minor', 2)
+        f.attrs.create("version_major", 0)
+        f.attrs.create("version_minor", 2)
 
-        group_path_list = ['/exp/data_0/data',
-                           '/exp/data_1/data',
-                           '/calc/data_0/data']
+        group_path_list = ["/exp/data_0/data", "/exp/data_1/data", "/calc/data_0/data"]
 
         for group_path in group_path_list:
             group = f.create_group(group_path)
-            group.attrs.create('emd_group_type', 1)
+            group.attrs.create("emd_group_type", 1)
             data = np.random.random((128, 128))
-            group.create_dataset(name='data', data=data)
-            group.create_dataset(name='dim1', data=range(128))
-            group.create_dataset(name='dim2', data=range(128))
+            group.create_dataset(name="data", data=data)
+            group.create_dataset(name="dim1", data=range(128))
+            group.create_dataset(name="dim2", data=range(128))
 
         f.close()
 
@@ -222,49 +224,48 @@ class TestReadSeveralDatasets:
             assert _s.metadata.General.title in path
 
 
-class TestCaseSaveAndRead():
-
+class TestCaseSaveAndRead:
     @pytest.mark.parametrize("lazy", (True, False))
     def test_save_and_read(self, lazy):
         signal_ref = BaseSignal(data_save)
         signal_ref.metadata.General.title = test_title
-        signal_ref.axes_manager[0].name = 'x'
-        signal_ref.axes_manager[1].name = 'y'
-        signal_ref.axes_manager[2].name = 'z'
+        signal_ref.axes_manager[0].name = "x"
+        signal_ref.axes_manager[1].name = "y"
+        signal_ref.axes_manager[2].name = "z"
         signal_ref.axes_manager[0].scale = 2
         signal_ref.axes_manager[1].scale = 3
         signal_ref.axes_manager[2].scale = 4
         signal_ref.axes_manager[0].offset = 10
         signal_ref.axes_manager[1].offset = 20
         signal_ref.axes_manager[2].offset = 30
-        signal_ref.axes_manager[0].units = 'nm'
-        signal_ref.axes_manager[1].units = 'µm'
-        signal_ref.axes_manager[2].units = 'mm'
-        signal_ref.original_metadata.add_dictionary({'user':user})
-        signal_ref.original_metadata.add_dictionary({'microscope':microscope})
-        signal_ref.original_metadata.add_dictionary({'sample':sample})
-        signal_ref.original_metadata.add_dictionary({'comments':comments})
+        signal_ref.axes_manager[0].units = "nm"
+        signal_ref.axes_manager[1].units = "µm"
+        signal_ref.axes_manager[2].units = "mm"
+        signal_ref.original_metadata.add_dictionary({"user": user})
+        signal_ref.original_metadata.add_dictionary({"microscope": microscope})
+        signal_ref.original_metadata.add_dictionary({"sample": sample})
+        signal_ref.original_metadata.add_dictionary({"comments": comments})
 
-        signal_ref.save(os.path.join(my_path, 'emd_files', 'example_temp.emd'),
-                        overwrite=True)
-        signal = load(os.path.join(my_path, 'emd_files', 'example_temp.emd'),
-                      lazy=lazy)
+        signal_ref.save(
+            os.path.join(my_path, "emd_files", "example_temp.emd"), overwrite=True
+        )
+        signal = load(os.path.join(my_path, "emd_files", "example_temp.emd"), lazy=lazy)
         if lazy:
             signal.compute(close_file=True)
         om = signal.original_metadata
         np.testing.assert_equal(signal.data, signal_ref.data)
-        np.testing.assert_equal(signal.axes_manager[0].name, 'x')
-        np.testing.assert_equal(signal.axes_manager[1].name, 'y')
-        np.testing.assert_equal(signal.axes_manager[2].name, 'z')
+        np.testing.assert_equal(signal.axes_manager[0].name, "x")
+        np.testing.assert_equal(signal.axes_manager[1].name, "y")
+        np.testing.assert_equal(signal.axes_manager[2].name, "z")
         np.testing.assert_equal(signal.axes_manager[0].scale, 2)
         np.testing.assert_almost_equal(signal.axes_manager[1].scale, 3.0)
         np.testing.assert_almost_equal(signal.axes_manager[2].scale, 4.0)
         np.testing.assert_equal(signal.axes_manager[0].offset, 10)
         np.testing.assert_almost_equal(signal.axes_manager[1].offset, 20.0)
         np.testing.assert_almost_equal(signal.axes_manager[2].offset, 30.0)
-        np.testing.assert_equal(signal.axes_manager[0].units, 'nm')
-        np.testing.assert_equal(signal.axes_manager[1].units, 'µm')
-        np.testing.assert_equal(signal.axes_manager[2].units, 'mm')
+        np.testing.assert_equal(signal.axes_manager[0].units, "nm")
+        np.testing.assert_equal(signal.axes_manager[1].units, "µm")
+        np.testing.assert_equal(signal.axes_manager[2].units, "mm")
         np.testing.assert_equal(signal.metadata.General.title, test_title)
         np.testing.assert_equal(om.user.as_dictionary(), user)
         np.testing.assert_equal(om.microscope.as_dictionary(), microscope)
@@ -274,16 +275,16 @@ class TestCaseSaveAndRead():
         assert isinstance(signal, BaseSignal)
 
     def teardown_method(self, method):
-        os.remove(os.path.join(my_path, 'emd_files', 'example_temp.emd'))
+        os.remove(os.path.join(my_path, "emd_files", "example_temp.emd"))
 
 
 def test_chunking_saving_lazy():
     s = Signal2D(da.zeros((50, 100, 100))).as_lazy()
     s.data = s.data.rechunk([50, 25, 25])
     with tempfile.TemporaryDirectory() as tmp:
-        filename = os.path.join(tmp, 'test_chunking_saving_lazy.emd')
-        filename2 = os.path.join(tmp, 'test_chunking_saving_lazy_chunks_True.emd')
-        filename3 = os.path.join(tmp, 'test_chunking_saving_lazy_chunks_specify.emd')
+        filename = os.path.join(tmp, "test_chunking_saving_lazy.emd")
+        filename2 = os.path.join(tmp, "test_chunking_saving_lazy_chunks_True.emd")
+        filename3 = os.path.join(tmp, "test_chunking_saving_lazy_chunks_specify.emd")
     s.save(filename)
     s1 = load(filename, lazy=True)
     assert s.data.chunks == s1.data.chunks
@@ -310,15 +311,16 @@ def _generate_parameters():
     return parameters
 
 
-class TestFeiEMD():
+class TestFeiEMD:
 
     fei_files_path = os.path.join(my_path, "emd_files", "fei_emd_files")
 
     @classmethod
     def setup_class(cls):
         import zipfile
+
         zipf = os.path.join(my_path, "emd_files", "fei_emd_files.zip")
-        with zipfile.ZipFile(zipf, 'r') as zipped:
+        with zipfile.ZipFile(zipf, "r") as zipped:
             zipped.extractall(cls.fei_files_path)
 
     @classmethod
@@ -328,315 +330,336 @@ class TestFeiEMD():
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_image(self, lazy):
-        stage = {'tilt_alpha': 0.006,
-                 'tilt_beta': 0.000,
-                 'x': -0.000009,
-                 'y': 0.000144,
-                 'z': 0.000029}
-        md = {'Acquisition_instrument': {'TEM': {'beam_energy': 200.0,
-                                                 'camera_length': 98.0,
-                                                 'magnification': 40000.0,
-                                                 'microscope': 'Talos',
-                                                 'Stage': stage}},
-              'General': {'original_filename': 'fei_emd_image.emd',
-                          'date': '2017-03-06',
-                          'time': '09:56:41',
-                          'time_zone': 'BST',
-                          'title': 'HAADF',
-                          'FileIO': {
-                              '0': {
-                                  'operation': 'load',
-                                  'hyperspy_version': hs_version,
-                                  'io_plugin': 'rsciio.emd.api'
-                              }
-                          }
-              },
-              'Signal': {'signal_type': ''},
-              '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                        'original_shape': None,
-                                        'signal_unfolded': False,
-                                        'unfolded': False}}}
+        stage = {
+            "tilt_alpha": 0.006,
+            "tilt_beta": 0.000,
+            "x": -0.000009,
+            "y": 0.000144,
+            "z": 0.000029,
+        }
+        md = {
+            "Acquisition_instrument": {
+                "TEM": {
+                    "beam_energy": 200.0,
+                    "camera_length": 98.0,
+                    "magnification": 40000.0,
+                    "microscope": "Talos",
+                    "Stage": stage,
+                }
+            },
+            "General": {
+                "original_filename": "fei_emd_image.emd",
+                "date": "2017-03-06",
+                "time": "09:56:41",
+                "time_zone": "BST",
+                "title": "HAADF",
+                "FileIO": {
+                    "0": {
+                        "operation": "load",
+                        "hyperspy_version": hs_version,
+                        "io_plugin": "rsciio.emd.api",
+                    }
+                },
+            },
+            "Signal": {"signal_type": ""},
+            "_HyperSpy": {
+                "Folding": {
+                    "original_axes_manager": None,
+                    "original_shape": None,
+                    "signal_unfolded": False,
+                    "unfolded": False,
+                }
+            },
+        }
 
         # Update time and time_zone to local ones
-        md['General']['time_zone'] = tz.tzlocal().tzname(datetime.today())
+        md["General"]["time_zone"] = tz.tzlocal().tzname(datetime.today())
         dt = datetime.fromtimestamp(1488794201, tz=tz.tzutc())
-        date, time = dt.astimezone(
-            tz.tzlocal()).isoformat().split('+')[0].split('T')
-        md['General']['date'] = date
-        md['General']['time'] = time
+        date, time = dt.astimezone(tz.tzlocal()).isoformat().split("+")[0].split("T")
+        md["General"]["date"] = date
+        md["General"]["time"] = time
 
-        signal = load(os.path.join(self.fei_files_path, 'fei_emd_image.emd'),
-                      lazy=lazy)
+        signal = load(os.path.join(self.fei_files_path, "fei_emd_image.emd"), lazy=lazy)
         # delete timestamp from metadata since it's runtime dependent
         del signal.metadata.General.FileIO.Number_0.timestamp
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        fei_image = np.load(os.path.join(self.fei_files_path,
-                                         'fei_emd_image.npy'))
-        assert signal.axes_manager[0].name == 'x'
-        assert signal.axes_manager[0].units == 'µm'
+        fei_image = np.load(os.path.join(self.fei_files_path, "fei_emd_image.npy"))
+        assert signal.axes_manager[0].name == "x"
+        assert signal.axes_manager[0].units == "µm"
         assert signal.axes_manager[0].is_binned == False
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 0.00530241, rtol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
-        assert signal.axes_manager[1].units == 'µm'
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 0.00530241, rtol=1e-5)
+        assert signal.axes_manager[1].name == "y"
+        assert signal.axes_manager[1].units == "µm"
         assert signal.axes_manager[1].is_binned == False
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 0.00530241, rtol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 0.00530241, rtol=1e-5)
         np.testing.assert_allclose(signal.data, fei_image)
         assert_deep_almost_equal(signal.metadata.as_dictionary(), md)
         assert isinstance(signal, Signal2D)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_spectrum(self, lazy):
-        signal = load(os.path.join(
-            self.fei_files_path, 'fei_emd_spectrum.emd'), lazy=lazy)
+        signal = load(
+            os.path.join(self.fei_files_path, "fei_emd_spectrum.emd"), lazy=lazy
+        )
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        fei_spectrum = np.load(os.path.join(self.fei_files_path,
-                                            'fei_emd_spectrum.npy'))
+        fei_spectrum = np.load(
+            os.path.join(self.fei_files_path, "fei_emd_spectrum.npy")
+        )
         np.testing.assert_equal(signal.data, fei_spectrum)
         assert isinstance(signal, Signal1D)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si(self, lazy):
-        signal = load(os.path.join(self.fei_files_path, 'fei_emd_si.emd'),
-                      lazy=lazy)
+        signal = load(os.path.join(self.fei_files_path, "fei_emd_si.emd"), lazy=lazy)
         if lazy:
             assert signal[1]._lazy
             signal[1].compute(close_file=True)
-        fei_si = np.load(os.path.join(self.fei_files_path, 'fei_emd_si.npy'))
+        fei_si = np.load(os.path.join(self.fei_files_path, "fei_emd_si.npy"))
         np.testing.assert_equal(signal[1].data, fei_si)
         assert isinstance(signal[1], Signal1D)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_10frames(self, lazy):
-        s = load(os.path.join(
-            self.fei_files_path, 'fei_SI_SuperX-HAADF_10frames_10x50.emd'),
-            lazy=lazy)
-        signal = s[1]
-        if lazy:
-            assert signal._lazy
-            signal.compute(close_file=True)
-        assert isinstance(signal, EDSTEMSpectrum)
-        assert signal.axes_manager[0].name == 'x'
-        assert signal.axes_manager[0].size == 10
-        assert signal.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
-        assert signal.axes_manager[1].size == 50
-        assert signal.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[2].name == 'X-ray energy'
-        assert signal.axes_manager[2].size == 4096
-        assert signal.axes_manager[2].units == 'keV'
-        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1E-5)
-
-        signal0 = s[0]
-        if lazy:
-            assert signal0._lazy
-            signal0.compute(close_file=True)
-        assert isinstance(signal0, Signal2D)
-        assert signal0.axes_manager[0].name == 'x'
-        assert signal0.axes_manager[0].size == 10
-        assert signal0.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal0.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal0.axes_manager[1].name == 'y'
-        assert signal0.axes_manager[1].size == 50
-        assert signal0.axes_manager[1].units == 'nm'
-
-        s = load(os.path.join(
-            self.fei_files_path, 'fei_SI_SuperX-HAADF_10frames_10x50.emd'),
+        s = load(
+            os.path.join(self.fei_files_path, "fei_SI_SuperX-HAADF_10frames_10x50.emd"),
             lazy=lazy,
-            load_SI_image_stack=True)
+        )
         signal = s[1]
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
         assert isinstance(signal, EDSTEMSpectrum)
-        assert signal.axes_manager[0].name == 'x'
+        assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
-        assert signal.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
+        assert signal.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[1].name == "y"
         assert signal.axes_manager[1].size == 50
-        assert signal.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[2].name == 'X-ray energy'
+        assert signal.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[2].name == "X-ray energy"
         assert signal.axes_manager[2].size == 4096
-        assert signal.axes_manager[2].units == 'keV'
-        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1E-5)
+        assert signal.axes_manager[2].units == "keV"
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1e-5)
 
         signal0 = s[0]
         if lazy:
             assert signal0._lazy
             signal0.compute(close_file=True)
         assert isinstance(signal0, Signal2D)
-        assert signal0.axes_manager[0].name == 'Time'
+        assert signal0.axes_manager[0].name == "x"
         assert signal0.axes_manager[0].size == 10
-        assert signal0.axes_manager[0].units == 's'
-        assert signal0.axes_manager[1].name == 'x'
-        assert signal0.axes_manager[1].size == 10
-        assert signal0.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal0.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal0.axes_manager[2].name == 'y'
-        assert signal0.axes_manager[2].size == 50
-        assert signal0.axes_manager[2].units == 'nm'
+        assert signal0.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal0.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal0.axes_manager[1].name == "y"
+        assert signal0.axes_manager[1].size == 50
+        assert signal0.axes_manager[1].units == "nm"
 
-        s = load(os.path.join(self.fei_files_path,
-                              'fei_SI_SuperX-HAADF_10frames_10x50.emd'),
-                 sum_frames=False,
-                 SI_dtype=np.uint8,
-                 rebin_energy=256,
-                 lazy=lazy)
+        s = load(
+            os.path.join(self.fei_files_path, "fei_SI_SuperX-HAADF_10frames_10x50.emd"),
+            lazy=lazy,
+            load_SI_image_stack=True,
+        )
+        signal = s[1]
+        if lazy:
+            assert signal._lazy
+            signal.compute(close_file=True)
+        assert isinstance(signal, EDSTEMSpectrum)
+        assert signal.axes_manager[0].name == "x"
+        assert signal.axes_manager[0].size == 10
+        assert signal.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[1].name == "y"
+        assert signal.axes_manager[1].size == 50
+        assert signal.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[2].name == "X-ray energy"
+        assert signal.axes_manager[2].size == 4096
+        assert signal.axes_manager[2].units == "keV"
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1e-5)
+
+        signal0 = s[0]
+        if lazy:
+            assert signal0._lazy
+            signal0.compute(close_file=True)
+        assert isinstance(signal0, Signal2D)
+        assert signal0.axes_manager[0].name == "Time"
+        assert signal0.axes_manager[0].size == 10
+        assert signal0.axes_manager[0].units == "s"
+        assert signal0.axes_manager[1].name == "x"
+        assert signal0.axes_manager[1].size == 10
+        assert signal0.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal0.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal0.axes_manager[2].name == "y"
+        assert signal0.axes_manager[2].size == 50
+        assert signal0.axes_manager[2].units == "nm"
+
+        s = load(
+            os.path.join(self.fei_files_path, "fei_SI_SuperX-HAADF_10frames_10x50.emd"),
+            sum_frames=False,
+            SI_dtype=np.uint8,
+            rebin_energy=256,
+            lazy=lazy,
+        )
         signal = s[1]
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
         assert isinstance(signal, EDSTEMSpectrum)
         assert signal.axes_manager.navigation_shape == (10, 50, 10)
-        assert signal.axes_manager[0].name == 'x'
+        assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
-        assert signal.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
+        assert signal.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[1].name == "y"
         assert signal.axes_manager[1].size == 50
-        assert signal.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[2].name == 'Time'
+        assert signal.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[2].name == "Time"
         assert signal.axes_manager[2].size == 10
-        assert signal.axes_manager[2].units == 's'
-        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
-        assert signal.axes_manager[3].name == 'X-ray energy'
+        assert signal.axes_manager[2].units == "s"
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1e-5)
+        assert signal.axes_manager[3].name == "X-ray energy"
         assert signal.axes_manager[3].size == 16
-        assert signal.axes_manager[3].units == 'keV'
-        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
+        assert signal.axes_manager[3].units == "keV"
+        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1e-5)
 
-        s = load(os.path.join(self.fei_files_path,
-                              'fei_SI_SuperX-HAADF_10frames_10x50.emd'),
-                 sum_frames=False,
-                 last_frame=5,
-                 SI_dtype=np.uint8,
-                 rebin_energy=256,
-                 lazy=lazy)
+        s = load(
+            os.path.join(self.fei_files_path, "fei_SI_SuperX-HAADF_10frames_10x50.emd"),
+            sum_frames=False,
+            last_frame=5,
+            SI_dtype=np.uint8,
+            rebin_energy=256,
+            lazy=lazy,
+        )
         signal = s[1]
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
         assert isinstance(signal, EDSTEMSpectrum)
         assert signal.axes_manager.navigation_shape == (10, 50, 5)
-        assert signal.axes_manager[0].name == 'x'
+        assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
-        assert signal.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
+        assert signal.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[1].name == "y"
         assert signal.axes_manager[1].size == 50
-        assert signal.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[2].name == 'Time'
+        assert signal.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[2].name == "Time"
         assert signal.axes_manager[2].size == 5
-        assert signal.axes_manager[2].units == 's'
-        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
-        assert signal.axes_manager[3].name == 'X-ray energy'
+        assert signal.axes_manager[2].units == "s"
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1e-5)
+        assert signal.axes_manager[3].name == "X-ray energy"
         assert signal.axes_manager[3].size == 16
-        assert signal.axes_manager[3].units == 'keV'
-        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
+        assert signal.axes_manager[3].units == "keV"
+        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1e-5)
 
-        s = load(os.path.join(self.fei_files_path,
-                              'fei_SI_SuperX-HAADF_10frames_10x50.emd'),
-                 sum_frames=False,
-                 first_frame=4,
-                 SI_dtype=np.uint8,
-                 rebin_energy=256,
-                 lazy=lazy)
+        s = load(
+            os.path.join(self.fei_files_path, "fei_SI_SuperX-HAADF_10frames_10x50.emd"),
+            sum_frames=False,
+            first_frame=4,
+            SI_dtype=np.uint8,
+            rebin_energy=256,
+            lazy=lazy,
+        )
         signal = s[1]
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
         assert isinstance(signal, EDSTEMSpectrum)
         assert signal.axes_manager.navigation_shape == (10, 50, 6)
-        assert signal.axes_manager[0].name == 'x'
+        assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
-        assert signal.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
+        assert signal.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[1].name == "y"
         assert signal.axes_manager[1].size == 50
-        assert signal.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[2].name == 'Time'
+        assert signal.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[2].name == "Time"
         assert signal.axes_manager[2].size == 6
-        assert signal.axes_manager[2].units == 's'
-        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
-        assert signal.axes_manager[3].name == 'X-ray energy'
+        assert signal.axes_manager[2].units == "s"
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1e-5)
+        assert signal.axes_manager[3].name == "X-ray energy"
         assert signal.axes_manager[3].size == 16
-        assert signal.axes_manager[3].units == 'keV'
-        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
+        assert signal.axes_manager[3].units == "keV"
+        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1e-5)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_20frames(self, lazy):
-        s = load(os.path.join(
-            self.fei_files_path,
-            'fei_SI_SuperX-HAADF_20frames_10x50.emd'),
-            lazy=lazy)
+        s = load(
+            os.path.join(self.fei_files_path, "fei_SI_SuperX-HAADF_20frames_10x50.emd"),
+            lazy=lazy,
+        )
         signal = s[1]
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
         assert isinstance(signal, EDSTEMSpectrum)
-        assert signal.axes_manager[0].name == 'x'
+        assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
-        assert signal.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
+        assert signal.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[1].name == "y"
         assert signal.axes_manager[1].size == 50
-        assert signal.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[2].name == 'X-ray energy'
+        assert signal.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[2].name == "X-ray energy"
         assert signal.axes_manager[2].size == 4096
-        assert signal.axes_manager[2].units == 'keV'
-        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1E-5)
+        assert signal.axes_manager[2].units == "keV"
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1e-5)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_20frames_2eV(self, lazy):
-        s = load(os.path.join(
-            self.fei_files_path,
-            'fei_SI_SuperX-HAADF_20frames_10x50_2ev.emd'),
-            lazy=lazy)
+        s = load(
+            os.path.join(
+                self.fei_files_path, "fei_SI_SuperX-HAADF_20frames_10x50_2ev.emd"
+            ),
+            lazy=lazy,
+        )
         signal = s[1]
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
         assert isinstance(signal, EDSTEMSpectrum)
-        assert signal.axes_manager[0].name == 'x'
+        assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
-        assert signal.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[1].name == 'y'
+        assert signal.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[1].name == "y"
         assert signal.axes_manager[1].size == 50
-        assert signal.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
-        assert signal.axes_manager[2].name == 'X-ray energy'
+        assert signal.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1e-5)
+        assert signal.axes_manager[2].name == "X-ray energy"
         assert signal.axes_manager[2].size == 4096
-        assert signal.axes_manager[2].units == 'keV'
-        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.002, atol=1E-5)
+        assert signal.axes_manager[2].units == "keV"
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.002, atol=1e-5)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_frame_range(self, lazy):
-        signal = load(os.path.join(self.fei_files_path, 'fei_emd_si.emd'),
-                      first_frame=2, last_frame=4, lazy=lazy)
-        fei_si = np.load(os.path.join(self.fei_files_path,
-                                      'fei_emd_si_frame.npy'))
+        signal = load(
+            os.path.join(self.fei_files_path, "fei_emd_si.emd"),
+            first_frame=2,
+            last_frame=4,
+            lazy=lazy,
+        )
+        fei_si = np.load(os.path.join(self.fei_files_path, "fei_emd_si_frame.npy"))
         if lazy:
             assert signal[1]._lazy
             signal[1].compute(close_file=True)
         np.testing.assert_equal(signal[1].data, fei_si)
         assert isinstance(signal[1], Signal1D)
 
-    @pytest.mark.parametrize(["lazy", "sum_EDS_detectors"],
-                             _generate_parameters())
+    @pytest.mark.parametrize(["lazy", "sum_EDS_detectors"], _generate_parameters())
     def test_fei_si_4detectors(self, lazy, sum_EDS_detectors):
-        fname = os.path.join(self.fei_files_path,
-                             'fei_SI_EDS-HAADF-4detectors_2frames.emd')
+        fname = os.path.join(
+            self.fei_files_path, "fei_SI_EDS-HAADF-4detectors_2frames.emd"
+        )
         signal = load(fname, sum_EDS_detectors=sum_EDS_detectors, lazy=lazy)
         if lazy:
             assert signal[1]._lazy
@@ -648,21 +671,15 @@ class TestFeiEMD():
         # TODO: add parsing azimuth_angle
 
     def test_fei_emd_ceta_camera(self):
-        signal = load(
-            os.path.join(
-                self.fei_files_path,
-                '1532 Camera Ceta.emd'))
+        signal = load(os.path.join(self.fei_files_path, "1532 Camera Ceta.emd"))
         np.testing.assert_allclose(signal.data, np.zeros((64, 64)))
         assert isinstance(signal, Signal2D)
-        date, time = self._convert_datetime(1512055942.914275).split('T')
+        date, time = self._convert_datetime(1512055942.914275).split("T")
         assert signal.metadata.General.date == date
         assert signal.metadata.General.time == time
         assert signal.metadata.General.time_zone == self._get_local_time_zone()
 
-        signal = load(
-            os.path.join(
-                self.fei_files_path,
-                '1854 Camera Ceta.emd'))
+        signal = load(os.path.join(self.fei_files_path, "1854 Camera Ceta.emd"))
         np.testing.assert_allclose(signal.data, np.zeros((64, 64)))
         assert isinstance(signal, Signal2D)
 
@@ -670,7 +687,7 @@ class TestFeiEMD():
         # Since we don't know the actual time zone of where the data have been
         # acquired, we convert the datetime to the local time for convenience
         dt = datetime.fromtimestamp(float(unix_time), tz=tz.tzutc())
-        return dt.astimezone(tz.tzlocal()).isoformat().split('+')[0]
+        return dt.astimezone(tz.tzlocal()).isoformat().split("+")[0]
 
     def _get_local_time_zone(self):
         return tz.tzlocal().tzname(datetime.today())
@@ -678,42 +695,50 @@ class TestFeiEMD():
     def time_loading_frame(self):
         # Run this function to check the loading time when loading EDS data
         import time
+
         frame_number = 100
         point_measurement = 15
-        frame_offsets = np.arange(0, point_measurement * frame_number,
-                                  frame_number)
+        frame_offsets = np.arange(0, point_measurement * frame_number, frame_number)
         time_data = np.zeros_like(frame_offsets)
-        path = 'path to large dataset'
+        path = "path to large dataset"
         for i, frame_offset in enumerate(frame_offsets):
             print(frame_offset + frame_number)
             t0 = time.time()
-            load(os.path.join(path, 'large dataset.emd'),
-                 first_frame=frame_offset, last_frame=frame_offset + frame_number)
+            load(
+                os.path.join(path, "large dataset.emd"),
+                first_frame=frame_offset,
+                last_frame=frame_offset + frame_number,
+            )
             t1 = time.time()
             time_data[i] = t1 - t0
         import matplotlib.pyplot as plt
+
         plt.plot(frame_offsets, time_data)
-        plt.xlabel('Frame offset')
-        plt.xlabel('Loading time (s)')
+        plt.xlabel("Frame offset")
+        plt.xlabel("Loading time (s)")
 
 
 def test_fei_complex_loading():
-    signal = load(os.path.join(my_path, 'emd_files', 'fei_example_complex_fft.emd'))
+    signal = load(os.path.join(my_path, "emd_files", "fei_example_complex_fft.emd"))
     assert isinstance(signal, ComplexSignal2D)
+
 
 def test_fei_complex_loading_lazy():
-    signal = load(os.path.join(my_path, 'emd_files', 'fei_example_complex_fft.emd'), lazy=True)
+    signal = load(
+        os.path.join(my_path, "emd_files", "fei_example_complex_fft.emd"), lazy=True
+    )
     assert isinstance(signal, ComplexSignal2D)
 
+
 def test_fei_no_frametime():
-    signal = load(os.path.join(my_path, 'emd_files', 'fei_example_tem_stack.emd'))
+    signal = load(os.path.join(my_path, "emd_files", "fei_example_tem_stack.emd"))
     assert isinstance(signal, Signal2D)
     assert signal.data.shape == (2, 3, 3)
     assert signal.axes_manager["Time"].scale == 0.8
 
 
 def test_fei_dpc_loading():
-    signals = load(os.path.join(my_path, 'emd_files', 'fei_example_dpc_titles.emd'))
+    signals = load(os.path.join(my_path, "emd_files", "fei_example_dpc_titles.emd"))
     assert signals[0].metadata.General.title == "B-D"
     assert signals[1].metadata.General.title == "DPC"
     assert signals[2].metadata.General.title == "iDPC"

--- a/rsciio/tests/test_emd_prismatic.py
+++ b/rsciio/tests/test_emd_prismatic.py
@@ -24,11 +24,11 @@ import traits.api as t
 
 import hyperspy.api as hs
 
-FILES_PATH = os.path.join(os.path.dirname(__file__), 'emd_files')
+FILES_PATH = os.path.join(os.path.dirname(__file__), "emd_files")
 
 
 def test_all_but_4D():
-    filename = os.path.join(FILES_PATH, 'Si100_2D_3D_DPC_potential_2slices.emd')
+    filename = os.path.join(FILES_PATH, "Si100_2D_3D_DPC_potential_2slices.emd")
     s = hs.load(filename)
 
     assert len(s) == 4
@@ -49,8 +49,8 @@ def test_all_but_4D():
         np.testing.assert_allclose(axis.size, 2)
 
     def check_signal_axes(signal_axes):
-        assert signal_axes[0].name == 'R_x'
-        assert signal_axes[1].name == 'R_y'
+        assert signal_axes[0].name == "R_x"
+        assert signal_axes[1].name == "R_y"
         for axis in signal_axes:
             assert axis.units == "nm"
             np.testing.assert_allclose(axis.scale, 0.25)
@@ -80,8 +80,8 @@ def test_all_but_4D():
 
     # signal axes
     signal_axes = s[2].axes_manager.signal_axes
-    assert signal_axes[0].name == 'R_x'
-    assert signal_axes[1].name == 'R_y'
+    assert signal_axes[0].name == "R_x"
+    assert signal_axes[1].name == "R_y"
     for axis in signal_axes:
         assert axis.units == "nm"
         np.testing.assert_allclose(axis.scale, 0.339375)
@@ -89,9 +89,8 @@ def test_all_but_4D():
         np.testing.assert_allclose(axis.size, 16)
 
 
-
 def test_depth_axis_zStart():
-    filename = os.path.join(FILES_PATH, 'Si100_1x1x3-zStart5.43.emd')
+    filename = os.path.join(FILES_PATH, "Si100_1x1x3-zStart5.43.emd")
     s = hs.load(filename)
     axis = s.axes_manager[1]
 
@@ -103,7 +102,7 @@ def test_depth_axis_zStart():
 
     # non-uniform depth axis, not supported yet
     # only the depth of the last image differ from others
-    filename = os.path.join(FILES_PATH, 'Si100_1x1x3-zStart6.7875.emd')
+    filename = os.path.join(FILES_PATH, "Si100_1x1x3-zStart6.7875.emd")
     s = hs.load(filename)
     axis = s.axes_manager[1]
 
@@ -115,7 +114,7 @@ def test_depth_axis_zStart():
 
 
 def test_all_but_4D_no_stack():
-    filename = os.path.join(FILES_PATH, 'Si100_2D_3D_DPC_potential_2slices.emd')
+    filename = os.path.join(FILES_PATH, "Si100_2D_3D_DPC_potential_2slices.emd")
     s = hs.load(filename, stack_group=False)
     assert len(s) == 7
 
@@ -123,22 +122,28 @@ def test_all_but_4D_no_stack():
     np.testing.assert_allclose(np.stack([s[0].data, s[1].data]), s2[0].data)
 
 
-@pytest.mark.parametrize("dataset_path",
-                         ['4DSTEM_simulation/data/realslices/annular_detector_depth0000/realslice',
-                          '4DSTEM_simulation/data/realslices/virtual_detector_depth0000/realslice',
-                          '4DSTEM_simulation/data/realslices/DPC_CoM_depth0000/realslice',
-                          '4DSTEM_simulation/data/realslices/ppotential/realslice'])
+@pytest.mark.parametrize(
+    "dataset_path",
+    [
+        "4DSTEM_simulation/data/realslices/annular_detector_depth0000/realslice",
+        "4DSTEM_simulation/data/realslices/virtual_detector_depth0000/realslice",
+        "4DSTEM_simulation/data/realslices/DPC_CoM_depth0000/realslice",
+        "4DSTEM_simulation/data/realslices/ppotential/realslice",
+    ],
+)
 def test_load_single_dataset(dataset_path):
-    filename = os.path.join(FILES_PATH, 'Si100_2D_3D_DPC_potential_2slices.emd')
+    filename = os.path.join(FILES_PATH, "Si100_2D_3D_DPC_potential_2slices.emd")
     s = hs.load(filename, dataset_path=dataset_path)
 
     assert isinstance(s, hs.signals.Signal2D)
 
 
 def test_load_specific_datasets():
-    filename = os.path.join(FILES_PATH, 'Si100_2D_3D_DPC_potential_2slices.emd')
-    dataset_path = ['4DSTEM_simulation/data/realslices/annular_detector_depth0000/realslice',
-                    '4DSTEM_simulation/data/realslices/virtual_detector_depth0000/realslice']
+    filename = os.path.join(FILES_PATH, "Si100_2D_3D_DPC_potential_2slices.emd")
+    dataset_path = [
+        "4DSTEM_simulation/data/realslices/annular_detector_depth0000/realslice",
+        "4DSTEM_simulation/data/realslices/virtual_detector_depth0000/realslice",
+    ]
     s = hs.load(filename, dataset_path=dataset_path)
 
     assert len(s) == 2
@@ -146,7 +151,7 @@ def test_load_specific_datasets():
 
 @pytest.mark.parametrize("lazy", (True, False))
 def test_3D_only(lazy):
-    filename = os.path.join(FILES_PATH, 'Si100_3D.emd')
+    filename = os.path.join(FILES_PATH, "Si100_3D.emd")
     s = hs.load(filename, lazy=lazy)
     if lazy:
         s.compute(close_file=True)
@@ -157,14 +162,14 @@ def test_3D_only(lazy):
     axis = s.axes_manager[0]
     assert axis.name == "bin_outer_angle"
     assert axis.units == "mrad"
-    np.testing.assert_allclose(axis.scale, 0.001, rtol=1E-6)
+    np.testing.assert_allclose(axis.scale, 0.001, rtol=1e-6)
     np.testing.assert_allclose(axis.offset, 0.0005)
     np.testing.assert_allclose(axis.size, 37)
 
     # signal axes
     signal_axes = s.axes_manager.signal_axes
-    assert signal_axes[0].name == 'R_x'
-    assert signal_axes[1].name == 'R_y'
+    assert signal_axes[0].name == "R_x"
+    assert signal_axes[1].name == "R_y"
     for axis in signal_axes:
         assert axis.units == "nm"
         np.testing.assert_allclose(axis.scale, 0.25)
@@ -173,15 +178,15 @@ def test_3D_only(lazy):
 
 
 def test_non_square_3D():
-    filename = os.path.join(FILES_PATH, 'Si100_2x1x1_3D.emd')
+    filename = os.path.join(FILES_PATH, "Si100_2x1x1_3D.emd")
     s = hs.load(filename)
 
     assert s.data.shape == (22, 44)
 
     # signal axes
     signal_axes = s.axes_manager.signal_axes
-    assert signal_axes[0].name == 'R_x'
-    assert signal_axes[1].name == 'R_y'
+    assert signal_axes[0].name == "R_x"
+    assert signal_axes[1].name == "R_y"
     assert signal_axes[0].size == 44
     assert signal_axes[1].size == 22
     for axis in signal_axes:
@@ -192,7 +197,7 @@ def test_non_square_3D():
 
 @pytest.mark.parametrize("lazy", (True, False))
 def test_4D(lazy):
-    filename = os.path.join(FILES_PATH, 'Si100_4D.emd')
+    filename = os.path.join(FILES_PATH, "Si100_4D.emd")
     s = hs.load(filename, lazy=lazy)
     if lazy:
         s.compute(close_file=True)
@@ -200,8 +205,8 @@ def test_4D(lazy):
 
     # navigation x, y axes
     navigation_axes = s.axes_manager.navigation_axes
-    assert navigation_axes[0].name == 'R_y'
-    assert navigation_axes[1].name == 'R_x'
+    assert navigation_axes[0].name == "R_y"
+    assert navigation_axes[1].name == "R_x"
     for axis in navigation_axes[:2]:
         assert axis.units == "nm"
         np.testing.assert_allclose(axis.scale, 0.5)
@@ -218,8 +223,8 @@ def test_4D(lazy):
 
     # signal axes
     signal_axes = s.axes_manager.signal_axes
-    assert signal_axes[0].name == 'Q_y'
-    assert signal_axes[1].name == 'Q_x'
+    assert signal_axes[0].name == "Q_y"
+    assert signal_axes[1].name == "Q_x"
     assert signal_axes[0].size == 8
     assert signal_axes[1].size == 8
     for axis in signal_axes:

--- a/rsciio/tests/test_empad.py
+++ b/rsciio/tests/test_empad.py
@@ -108,6 +108,6 @@ def test_parse_xml_1_2_0():
     # xml file version 1.2.0 (2020-10-29)
     filename = os.path.join(DATA_DIR, "map128x128_version1.2.0.xml")
     om, info = _parse_xml(filename)
-    assert info['scan_x'] == 128
-    assert info['scan_y'] == 128
-    assert info['raw_filename'] == 'scan_x128_y128.raw'
+    assert info["scan_x"] == 128
+    assert info["scan_y"] == 128
+    assert info["raw_filename"] == "scan_x128_y128.raw"

--- a/rsciio/tests/test_fei.py
+++ b/rsciio/tests/test_fei.py
@@ -29,515 +29,494 @@ from rsciio.fei.api import load_ser_file
 MY_PATH = os.path.dirname(__file__)
 
 
-class TestFEIReader():
-
+class TestFEIReader:
     def setup_method(self, method):
-        self.dirpathold = os.path.join(MY_PATH, 'FEI_old')
-        self.dirpathnew = os.path.join(MY_PATH, 'FEI_new')
+        self.dirpathold = os.path.join(MY_PATH, "FEI_old")
+        self.dirpathnew = os.path.join(MY_PATH, "FEI_new")
 
     def test_load_emi_old_new_format(self):
         # TIA old format
-        fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
         load(fname0)
         # TIA new format
-        fname1 = os.path.join(self.dirpathnew, '128x128_TEM_acquire-sum1.emi')
+        fname1 = os.path.join(self.dirpathnew, "128x128_TEM_acquire-sum1.emi")
         load(fname1)
 
     def test_load_image_content(self):
         # TEM image of the beam stop
-        fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
         s0 = load(fname0)
-        data = np.load(fname0.replace('emi', 'npy'))
+        data = np.load(fname0.replace("emi", "npy"))
         np.testing.assert_array_equal(s0.data, data)
 
     def test_load_ser_reader_old_new_format(self):
         # test TIA old format
-        fname0 = os.path.join(
-            self.dirpathold, '64x64_TEM_images_acquire_1.ser')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire_1.ser")
         header0, data0 = load_ser_file(fname0)
-        assert header0['SeriesVersion'] == 528
+        assert header0["SeriesVersion"] == 528
         # test TIA new format
-        fname1 = os.path.join(
-            self.dirpathnew, '128x128_TEM_acquire-sum1_1.ser')
+        fname1 = os.path.join(self.dirpathnew, "128x128_TEM_acquire-sum1_1.ser")
         header1, data1 = load_ser_file(fname1)
-        assert header1['SeriesVersion'] == 544
+        assert header1["SeriesVersion"] == 544
 
     def test_load_no_acquire_date(self, caplog):
-        fname = os.path.join(
-            self.dirpathold, 'no_AcquireDate.emi')
+        fname = os.path.join(self.dirpathold, "no_AcquireDate.emi")
         s = load(fname)
-        assert not hasattr(s.metadata.General, 'date')
-        assert not hasattr(s.metadata.General, 'time')
-        assert 'AcquireDate not found in metadata' in caplog.text
+        assert not hasattr(s.metadata.General, "date")
+        assert not hasattr(s.metadata.General, "time")
+        assert "AcquireDate not found in metadata" in caplog.text
 
     def test_load_more_ser_than_metadata(self, caplog):
-        fname = os.path.join(
-            self.dirpathold, 'more_ser_then_emi_metadata.emi')
+        fname = os.path.join(self.dirpathold, "more_ser_then_emi_metadata.emi")
         s0, s1 = load(fname, only_valid_data=True)
-        assert hasattr(s0.original_metadata, 'ObjectInfo')
-        assert not hasattr(s1.original_metadata, 'ObjectInfo')
-        assert 'more_ser_then_emi_metadata.emi did not contain any metadata' \
-               in caplog.text
+        assert hasattr(s0.original_metadata, "ObjectInfo")
+        assert not hasattr(s1.original_metadata, "ObjectInfo")
+        assert (
+            "more_ser_then_emi_metadata.emi did not contain any metadata" in caplog.text
+        )
 
     @pytest.fixture(scope="function")
     def prepare_non_zero_float(self):
         import tarfile
-        tgz_fname = os.path.join(
-            self.dirpathold, 'non_float_meta_value_zeroed.tar.gz')
-        with tarfile.open(tgz_fname, 'r:gz') as tar:
+
+        tgz_fname = os.path.join(self.dirpathold, "non_float_meta_value_zeroed.tar.gz")
+        with tarfile.open(tgz_fname, "r:gz") as tar:
             tar.extractall(path=os.path.dirname(tgz_fname))
 
         yield True
 
         # teardown code
-        os.remove(os.path.join(
-            self.dirpathold, 'non_float_meta_value_zeroed.emi'))
-        os.remove(os.path.join(
-            self.dirpathold, 'non_float_meta_value_zeroed_1.ser'))
+        os.remove(os.path.join(self.dirpathold, "non_float_meta_value_zeroed.emi"))
+        os.remove(os.path.join(self.dirpathold, "non_float_meta_value_zeroed_1.ser"))
 
     def test_load_non_zero_float(self, prepare_non_zero_float, caplog):
-        fname = os.path.join(self.dirpathold, 'non_float_meta_value_zeroed.emi')
+        fname = os.path.join(self.dirpathold, "non_float_meta_value_zeroed.emi")
         s = load(fname)
-        assert s.original_metadata.ObjectInfo.ExperimentalDescription\
-            .as_dictionary()['OBJ Aperture_um'] == 'V'
-        assert 'Expected decimal value for OBJ Aperture' in caplog.text
+        assert (
+            s.original_metadata.ObjectInfo.ExperimentalDescription.as_dictionary()[
+                "OBJ Aperture_um"
+            ]
+            == "V"
+        )
+        assert "Expected decimal value for OBJ Aperture" in caplog.text
 
     def test_load_diffraction_point(self):
-        fname0 = os.path.join(self.dirpathold, '64x64_diffraction_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_diffraction_acquire.emi")
         s0 = load(fname0)
         assert s0.data.shape == (64, 64)
         assert s0.axes_manager.signal_dimension == 2
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'TEM')
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.101571, rtol=1E-5)
-        assert s0.axes_manager[0].units == '1 / nm'
-        assert (s0.axes_manager[0].name == 'x')
-        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.101571, rtol=1E-5)
-        assert s0.axes_manager[1].units == '1 / nm'
-        assert (s0.axes_manager[1].name == 'y')
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "TEM"
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.101571, rtol=1e-5)
+        assert s0.axes_manager[0].units == "1 / nm"
+        assert s0.axes_manager[0].name == "x"
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.101571, rtol=1e-5)
+        assert s0.axes_manager[1].units == "1 / nm"
+        assert s0.axes_manager[1].name == "y"
 
     def test_load_diffraction_line_scan(self):
         fname0 = os.path.join(
-            self.dirpathnew, '16x16-line_profile_horizontal_5x128x128_EDS.emi')
+            self.dirpathnew, "16x16-line_profile_horizontal_5x128x128_EDS.emi"
+        )
         s0 = load(fname0)
         # s0[0] contains EDS
         assert s0[0].data.shape == (5, 4000)
         assert s0[0].axes_manager.signal_dimension == 1
-        assert (
-            s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0[0].axes_manager[0].scale, 3.68864, rtol=1E-5)
-        assert s0[0].axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0[0].axes_manager[1].scale, 5.0, rtol=1E-5)
-        assert s0[0].axes_manager[1].units == 'eV'
-        assert (s0[0].axes_manager[0].name == 'x')
-        assert (s0[0].axes_manager[1].name == 'Energy')
+        assert s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0[0].axes_manager[0].scale, 3.68864, rtol=1e-5)
+        assert s0[0].axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0[0].axes_manager[1].scale, 5.0, rtol=1e-5)
+        assert s0[0].axes_manager[1].units == "eV"
+        assert s0[0].axes_manager[0].name == "x"
+        assert s0[0].axes_manager[1].name == "Energy"
         # s0[1] contains diffraction patterns
         assert s0[1].data.shape == (5, 128, 128)
         assert s0[1].axes_manager.signal_dimension == 2
-        assert (
-            s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 3.68864, rtol=1E-5)
-        assert s0[1].axes_manager[0].units == 'nm'
-        assert s0[1].axes_manager[1].units == '1 / nm'
-        assert (s0[1].axes_manager[0].name == 'x')
-        np.testing.assert_allclose(s0[1].axes_manager[1].scale, 0.174353, rtol=1E-5)
-        np.testing.assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1E-5)
-        assert s0[1].axes_manager[2].units == '1 / nm'
-        assert (s0[1].axes_manager[1].units == '1 / nm')
-        assert (s0[1].axes_manager[1].name == 'x')
-        assert (s0[1].axes_manager[2].name == 'y')
+        assert s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 3.68864, rtol=1e-5)
+        assert s0[1].axes_manager[0].units == "nm"
+        assert s0[1].axes_manager[1].units == "1 / nm"
+        assert s0[1].axes_manager[0].name == "x"
+        np.testing.assert_allclose(s0[1].axes_manager[1].scale, 0.174353, rtol=1e-5)
+        np.testing.assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1e-5)
+        assert s0[1].axes_manager[2].units == "1 / nm"
+        assert s0[1].axes_manager[1].units == "1 / nm"
+        assert s0[1].axes_manager[1].name == "x"
+        assert s0[1].axes_manager[2].name == "y"
 
     def test_load_diffraction_area_scan(self):
         fname0 = os.path.join(
-            self.dirpathnew, '16x16-diffraction_imagel_5x5x256x256_EDS.emi')
+            self.dirpathnew, "16x16-diffraction_imagel_5x5x256x256_EDS.emi"
+        )
         s0 = load(fname0)
         # s0[0] contains EDS
         assert s0[0].data.shape == (5, 5, 4000)
         assert s0[0].axes_manager.signal_dimension == 1
-        assert (
-            s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0[0].axes_manager[0].scale, 1.87390, rtol=1E-5)
-        assert s0[0].axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0[0].axes_manager[1].scale, -1.87390, rtol=1E-5)
-        assert s0[0].axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(s0[0].axes_manager[2].scale, 5.0, rtol=1E-5)
-        assert s0[0].axes_manager[2].units == 'eV'
+        assert s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0[0].axes_manager[0].scale, 1.87390, rtol=1e-5)
+        assert s0[0].axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0[0].axes_manager[1].scale, -1.87390, rtol=1e-5)
+        assert s0[0].axes_manager[1].units == "nm"
+        np.testing.assert_allclose(s0[0].axes_manager[2].scale, 5.0, rtol=1e-5)
+        assert s0[0].axes_manager[2].units == "eV"
         # s0[1] contains diffraction patterns
         assert s0[1].data.shape == (5, 5, 256, 256)
         assert s0[1].axes_manager.signal_dimension == 2
-        assert (
-            s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1E-5)
-        assert s0[1].axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1E-5)
-        assert s0[1].axes_manager[2].units == '1 / nm'
-        assert (s0[0].axes_manager[0].name == 'x')
-        assert (s0[0].axes_manager[1].name == 'y')
-        assert (s0[0].axes_manager[2].name == 'Energy')
-        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1E-5)
-        assert (s0[1].axes_manager[0].name == 'x')
-        np.testing.assert_allclose(s0[1].axes_manager[1].scale, -1.87390, rtol=1E-5)
-        assert (s0[1].axes_manager[1].units == 'nm')
-        assert (s0[1].axes_manager[1].name == 'y')
-        assert (s0[1].axes_manager[2].name == 'x')
-        np.testing.assert_allclose(s0[1].axes_manager[3].scale, 0.174353, rtol=1E-5)
-        assert (s0[1].axes_manager[3].units == '1 / nm')
-        assert (s0[1].axes_manager[3].name == 'y')
+        assert s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1e-5)
+        assert s0[1].axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1e-5)
+        assert s0[1].axes_manager[2].units == "1 / nm"
+        assert s0[0].axes_manager[0].name == "x"
+        assert s0[0].axes_manager[1].name == "y"
+        assert s0[0].axes_manager[2].name == "Energy"
+        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1e-5)
+        assert s0[1].axes_manager[0].name == "x"
+        np.testing.assert_allclose(s0[1].axes_manager[1].scale, -1.87390, rtol=1e-5)
+        assert s0[1].axes_manager[1].units == "nm"
+        assert s0[1].axes_manager[1].name == "y"
+        assert s0[1].axes_manager[2].name == "x"
+        np.testing.assert_allclose(s0[1].axes_manager[3].scale, 0.174353, rtol=1e-5)
+        assert s0[1].axes_manager[3].units == "1 / nm"
+        assert s0[1].axes_manager[3].name == "y"
 
     def test_load_spectrum_point(self):
-        fname0 = os.path.join(
-            self.dirpathold, '16x16-point_spectrum-1x1024.emi')
+        fname0 = os.path.join(self.dirpathold, "16x16-point_spectrum-1x1024.emi")
         s0 = load(fname0)
         assert s0.data.shape == (1, 1024)
         assert s0.axes_manager.signal_dimension == 1
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
         # single spectrum should be imported as 1D data, not 2D
         # TODO: the following calibration is wrong because it parse the
         # 'Dim-1_CalibrationDelta' from the ser header, which is not correct in
         # case of point spectra. However, the position seems to be saved in
         # 'PositionX' and 'PositionY' arrays of the ser header, so it should
         # be possible to workaround using the position arrays.
-#        np.testing.assert_almost_equal(
-#            s0.axes_manager[0].scale, 1.0, places=5)
-#        np.testing.assert_equal(s0.axes_manager[0].units, '')
-#        np.testing.assert_is(s0.axes_manager[0].name, 'Position index')
-        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'eV'
-        assert (s0.axes_manager[1].name == 'Energy')
+        #        np.testing.assert_almost_equal(
+        #            s0.axes_manager[0].scale, 1.0, places=5)
+        #        np.testing.assert_equal(s0.axes_manager[0].units, '')
+        #        np.testing.assert_is(s0.axes_manager[0].name, 'Position index')
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1e-5)
+        assert s0.axes_manager[1].units == "eV"
+        assert s0.axes_manager[1].name == "Energy"
 
-        fname1 = os.path.join(
-            self.dirpathold, '16x16-2_point-spectra-2x1024.emi')
+        fname1 = os.path.join(self.dirpathold, "16x16-2_point-spectra-2x1024.emi")
         s1 = load(fname1)
         assert s1.data.shape == (2, 1024)
         assert s1.axes_manager.signal_dimension == 1
-        assert (
-            s1.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'eV'
-        assert (s0.axes_manager[1].name == 'Energy')
+        assert s1.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1e-5)
+        assert s0.axes_manager[1].units == "eV"
+        assert s0.axes_manager[1].name == "Energy"
 
     def test_load_spectrum_line_scan(self):
         fname0 = os.path.join(
-            self.dirpathold, '16x16-line_profile_horizontal_10x1024.emi')
+            self.dirpathold, "16x16-line_profile_horizontal_10x1024.emi"
+        )
         s0 = load(fname0)
         assert s0.data.shape == (10, 1024)
         assert s0.axes_manager.signal_dimension == 1
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.123034, rtol=1E-5)
-        assert s0.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'eV'
-        assert (s0.axes_manager[0].name == 'x')
-        assert (s0.axes_manager[1].name == 'Energy')
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.123034, rtol=1e-5)
+        assert s0.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1e-5)
+        assert s0.axes_manager[1].units == "eV"
+        assert s0.axes_manager[0].name == "x"
+        assert s0.axes_manager[1].name == "Energy"
 
         fname1 = os.path.join(
-            self.dirpathold, '16x16-line_profile_diagonal_10x1024.emi')
+            self.dirpathold, "16x16-line_profile_diagonal_10x1024.emi"
+        )
         s1 = load(fname1)
         assert s1.data.shape == (10, 1024)
         assert s1.axes_manager.signal_dimension == 1
-        assert (
-            s1.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s1.axes_manager[0].scale, 0.166318, rtol=1E-5)
-        assert s1.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s1.axes_manager[1].scale, 0.2, rtol=1E-5)
-        assert s1.axes_manager[1].units == 'eV'
-        assert (s0.axes_manager[0].name == 'x')
+        assert s1.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s1.axes_manager[0].scale, 0.166318, rtol=1e-5)
+        assert s1.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s1.axes_manager[1].scale, 0.2, rtol=1e-5)
+        assert s1.axes_manager[1].units == "eV"
+        assert s0.axes_manager[0].name == "x"
 
     def test_load_spectrum_area_scan(self):
-        fname0 = os.path.join(
-            self.dirpathold, '16x16-spectrum_image-5x5x1024.emi')
+        fname0 = os.path.join(self.dirpathold, "16x16-spectrum_image-5x5x1024.emi")
         s0 = load(fname0)
         assert s0.data.shape == (5, 5, 1024)
         assert s0.axes_manager.signal_dimension == 1
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.120539, rtol=1E-5)
-        assert s0.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[1].scale, -0.120539, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[2].scale, 0.2, rtol=1E-5)
-        assert s0.axes_manager[2].units == 'eV'
-        assert (s0.axes_manager[2].name == 'Energy')
-        assert (s0.axes_manager[1].name == 'y')
-        assert (s0.axes_manager[2].name == 'Energy')
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.120539, rtol=1e-5)
+        assert s0.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[1].scale, -0.120539, rtol=1e-5)
+        assert s0.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[2].scale, 0.2, rtol=1e-5)
+        assert s0.axes_manager[2].units == "eV"
+        assert s0.axes_manager[2].name == "Energy"
+        assert s0.axes_manager[1].name == "y"
+        assert s0.axes_manager[2].name == "Energy"
 
     def test_load_spectrum_area_scan_not_square(self):
         fname0 = os.path.join(
-            self.dirpathnew, '16x16-spectrum_image_5x5x4000-not_square.emi')
+            self.dirpathnew, "16x16-spectrum_image_5x5x4000-not_square.emi"
+        )
         s0 = load(fname0)
         assert s0.data.shape == (5, 5, 4000)
         assert s0.axes_manager.signal_dimension == 1
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 1.98591, rtol=1E-5)
-        assert s0.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[1].scale, -4.25819, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[2].scale, 5.0, rtol=1E-5)
-        assert s0.axes_manager[2].units == 'eV'
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 1.98591, rtol=1e-5)
+        assert s0.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[1].scale, -4.25819, rtol=1e-5)
+        assert s0.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[2].scale, 5.0, rtol=1e-5)
+        assert s0.axes_manager[2].units == "eV"
 
     def test_load_search(self):
-        fname0 = os.path.join(self.dirpathnew, '128x128-TEM_search.emi')
+        fname0 = os.path.join(self.dirpathnew, "128x128-TEM_search.emi")
         s0 = load(fname0)
         assert s0.data.shape == (128, 128)
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 5.26121, rtol=1E-5)
-        assert s0.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[1].scale, 5.26121, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'nm'
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 5.26121, rtol=1e-5)
+        assert s0.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 5.26121, rtol=1e-5)
+        assert s0.axes_manager[1].units == "nm"
 
-        fname1 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_search.emi')
+        fname1 = os.path.join(self.dirpathold, "16x16_STEM_BF_DF_search.emi")
         s1 = load(fname1)
         assert len(s1) == 2
         for s in s1:
             assert s.data.shape == (16, 16)
-            assert (
-                s.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-            np.testing.assert_allclose(
-                s.axes_manager[0].scale, 22.026285, rtol=1E-5)
-            assert s.axes_manager[0].units == 'nm'
-            np.testing.assert_allclose(
-                s.axes_manager[1].scale, 22.026285, rtol=1E-5)
-            assert s.axes_manager[1].units == 'nm'
+            assert s.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+            np.testing.assert_allclose(s.axes_manager[0].scale, 22.026285, rtol=1e-5)
+            assert s.axes_manager[0].units == "nm"
+            np.testing.assert_allclose(s.axes_manager[1].scale, 22.026285, rtol=1e-5)
+            assert s.axes_manager[1].units == "nm"
 
     def test_load_stack_image_preview(self):
-        fname0 = os.path.join(self.dirpathold, '64x64x5_TEM_preview.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64x5_TEM_preview.emi")
         s0 = load(fname0)
         assert s0.data.shape == (5, 64, 64)
         assert s0.axes_manager.signal_dimension == 2
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'TEM')
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 1.0, rtol=1E-5)
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "TEM"
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 1.0, rtol=1e-5)
         assert s0.axes_manager[0].units is t.Undefined
-        np.testing.assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[2].scale, 6.281833, rtol=1E-5)
-        assert s0.axes_manager[2].units == 'nm'
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1e-5)
+        assert s0.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[2].scale, 6.281833, rtol=1e-5)
+        assert s0.axes_manager[2].units == "nm"
         assert s0.axes_manager[0].units is t.Undefined
-        assert (s0.axes_manager[0].scale == 1.0)
-        assert (s0.axes_manager[0].name is t.Undefined)
-        assert (s0.axes_manager[1].name == 'x')
-        assert (s0.axes_manager[2].name == 'y')
+        assert s0.axes_manager[0].scale == 1.0
+        assert s0.axes_manager[0].name is t.Undefined
+        assert s0.axes_manager[1].name == "x"
+        assert s0.axes_manager[2].name == "y"
 
-        fname2 = os.path.join(
-            self.dirpathnew, '128x128x5-diffraction_preview.emi')
+        fname2 = os.path.join(self.dirpathnew, "128x128x5-diffraction_preview.emi")
         s2 = load(fname2)
         assert s2.data.shape == (5, 128, 128)
-        np.testing.assert_allclose(s2.axes_manager[1].scale, 0.042464, rtol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[1].scale, 0.042464, rtol=1e-5)
         assert s0.axes_manager[0].units is t.Undefined
-        assert s2.axes_manager[1].units == '1 / nm'
-        np.testing.assert_allclose(s2.axes_manager[2].scale, 0.042464, rtol=1E-5)
-        assert s2.axes_manager[2].units == '1 / nm'
+        assert s2.axes_manager[1].units == "1 / nm"
+        np.testing.assert_allclose(s2.axes_manager[2].scale, 0.042464, rtol=1e-5)
+        assert s2.axes_manager[2].units == "1 / nm"
 
-        fname1 = os.path.join(
-            self.dirpathold, '16x16x5_STEM_BF_DF_preview.emi')
+        fname1 = os.path.join(self.dirpathold, "16x16x5_STEM_BF_DF_preview.emi")
         s1 = load(fname1)
         assert len(s1) == 2
         for s in s1:
             assert s.data.shape == (5, 16, 16)
-            assert (
-                s.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-            np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
-            assert s.axes_manager[1].units == 'nm'
-            np.testing.assert_allclose(
-                s.axes_manager[1].scale, 21.510044, rtol=1E-5)
+            assert s.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+            np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1e-5)
+            assert s.axes_manager[1].units == "nm"
+            np.testing.assert_allclose(s.axes_manager[1].scale, 21.510044, rtol=1e-5)
 
     def test_load_acquire(self):
-        fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
         s0 = load(fname0)
         assert s0.axes_manager.signal_dimension == 2
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'TEM')
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 6.281833, rtol=1E-5)
-        assert s0.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1E-5)
-        assert s0.axes_manager[1].units == 'nm'
-        assert (s0.axes_manager[0].name == 'x')
-        assert (s0.axes_manager[1].name == 'y')
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "TEM"
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 6.281833, rtol=1e-5)
+        assert s0.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1e-5)
+        assert s0.axes_manager[1].units == "nm"
+        assert s0.axes_manager[0].name == "x"
+        assert s0.axes_manager[1].name == "y"
 
-        fname1 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_acquire.emi')
+        fname1 = os.path.join(self.dirpathold, "16x16_STEM_BF_DF_acquire.emi")
         s1 = load(fname1)
         assert len(s1) == 2
         for s in s1:
             assert s.data.shape == (16, 16)
-            assert (
-                s.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-            np.testing.assert_allclose(
-                s.axes_manager[0].scale, 21.510044, rtol=1E-5)
-            assert s.axes_manager[0].units == 'nm'
-            np.testing.assert_allclose(
-                s.axes_manager[1].scale, 21.510044, rtol=1E-5)
-            assert s.axes_manager[1].units == 'nm'
-            assert (s.axes_manager[0].name == 'x')
-            assert (s.axes_manager[1].name == 'y')
+            assert s.metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+            np.testing.assert_allclose(s.axes_manager[0].scale, 21.510044, rtol=1e-5)
+            assert s.axes_manager[0].units == "nm"
+            np.testing.assert_allclose(s.axes_manager[1].scale, 21.510044, rtol=1e-5)
+            assert s.axes_manager[1].units == "nm"
+            assert s.axes_manager[0].name == "x"
+            assert s.axes_manager[1].name == "y"
 
     @pytest.mark.parametrize("only_valid_data", (True, False))
-    def test_load_TotalNumberElements_ne_ValidNumberElements(self,
-                                                             only_valid_data):
-        fname0 = os.path.join(self.dirpathold, 'X - Au NP EELS_2.ser')
+    def test_load_TotalNumberElements_ne_ValidNumberElements(self, only_valid_data):
+        fname0 = os.path.join(self.dirpathold, "X - Au NP EELS_2.ser")
         s0 = load(fname0, only_valid_data=only_valid_data)
-        nav_shape = () if only_valid_data else (2, )
-        assert s0.data.shape == nav_shape + (2048, )
+        nav_shape = () if only_valid_data else (2,)
+        assert s0.data.shape == nav_shape + (2048,)
         assert len(s0.axes_manager.navigation_axes) == len(nav_shape)
-        np.testing.assert_allclose(s0.axes_manager[-1].offset, 2160, rtol=1E-5)
-        np.testing.assert_allclose(s0.axes_manager[-1].scale, 0.2, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[-1].offset, 2160, rtol=1e-5)
+        np.testing.assert_allclose(s0.axes_manager[-1].scale, 0.2, rtol=1e-5)
 
-        fname1 = os.path.join(self.dirpathold, '03_Scanning Preview.emi')
+        fname1 = os.path.join(self.dirpathold, "03_Scanning Preview.emi")
         s1 = load(fname1, only_valid_data=only_valid_data)
-        nav_shape = (5, ) if only_valid_data else (200, )
+        nav_shape = (5,) if only_valid_data else (200,)
         assert s1.data.shape == nav_shape + (128, 128)
         nav_axes = s1.axes_manager.navigation_axes
         sig_axes = s1.axes_manager.signal_axes
         assert len(nav_axes) == len(nav_shape)
         assert sig_axes[-1].size == sig_axes[1].size == 128
-        np.testing.assert_allclose(sig_axes[0].scale, 0.38435, rtol=1E-5)
-        np.testing.assert_allclose(sig_axes[1].scale, 0.38435, rtol=1E-5)
+        np.testing.assert_allclose(sig_axes[0].scale, 0.38435, rtol=1e-5)
+        np.testing.assert_allclose(sig_axes[1].scale, 0.38435, rtol=1e-5)
 
     def test_read_STEM_TEM_mode(self):
         # TEM image
-        fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
         s0 = load(fname0)
-        assert (
-            s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "TEM")
+        assert s0.metadata.Acquisition_instrument.TEM.acquisition_mode == "TEM"
         # TEM diffraction
-        fname1 = os.path.join(self.dirpathold, '64x64_diffraction_acquire.emi')
+        fname1 = os.path.join(self.dirpathold, "64x64_diffraction_acquire.emi")
         s1 = load(fname1)
-        assert (
-            s1.metadata.Acquisition_instrument.TEM.acquisition_mode == "TEM")
-        fname2 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_acquire.emi')
+        assert s1.metadata.Acquisition_instrument.TEM.acquisition_mode == "TEM"
+        fname2 = os.path.join(self.dirpathold, "16x16_STEM_BF_DF_acquire.emi")
         # STEM diffraction
         s2 = load(fname2)
-        assert (
-            s2[0].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM")
-        assert (
-            s2[1].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM")
+        assert s2[0].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        assert s2[1].metadata.Acquisition_instrument.TEM.acquisition_mode == "STEM"
 
     def test_load_units_scale(self):
         # TEM image
-        fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
         s0 = load(fname0)
-        np.testing.assert_allclose(s0.axes_manager[0].scale, 6.28183, rtol=1E-5)
-        assert s0.axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s0.metadata.Acquisition_instrument.TEM.magnification,
-                        19500.0, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 6.28183, rtol=1e-5)
+        assert s0.axes_manager[0].units == "nm"
+        np.testing.assert_allclose(
+            s0.metadata.Acquisition_instrument.TEM.magnification, 19500.0, rtol=1e-5
+        )
         # TEM diffraction
-        fname1 = os.path.join(self.dirpathold, '64x64_diffraction_acquire.emi')
+        fname1 = os.path.join(self.dirpathold, "64x64_diffraction_acquire.emi")
         s1 = load(fname1)
-        np.testing.assert_allclose(s1.axes_manager[0].scale, 0.101571, rtol=1E-5)
-        assert s1.axes_manager[0].units == '1 / nm'
-        np.testing.assert_allclose(s1.metadata.Acquisition_instrument.TEM.camera_length,
-                        490.0, rtol=1E-5)
+        np.testing.assert_allclose(s1.axes_manager[0].scale, 0.101571, rtol=1e-5)
+        assert s1.axes_manager[0].units == "1 / nm"
+        np.testing.assert_allclose(
+            s1.metadata.Acquisition_instrument.TEM.camera_length, 490.0, rtol=1e-5
+        )
         # STEM diffraction
-        fname2 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_acquire.emi')
+        fname2 = os.path.join(self.dirpathold, "16x16_STEM_BF_DF_acquire.emi")
         s2 = load(fname2)
-        assert s2[0].axes_manager[0].units == 'nm'
-        np.testing.assert_allclose(s2[0].axes_manager[0].scale, 21.5100, rtol=1E-5)
-        np.testing.assert_allclose(s2[0].metadata.Acquisition_instrument.TEM.magnification,
-                        10000.0, rtol=1E-5)
+        assert s2[0].axes_manager[0].units == "nm"
+        np.testing.assert_allclose(s2[0].axes_manager[0].scale, 21.5100, rtol=1e-5)
+        np.testing.assert_allclose(
+            s2[0].metadata.Acquisition_instrument.TEM.magnification, 10000.0, rtol=1e-5
+        )
 
     def test_guess_units_from_mode(self):
-        from rsciio.fei.api import _guess_units_from_mode, \
-            convert_xml_to_dict, get_xml_info_from_emi
-        fname0_emi = os.path.join(
-            self.dirpathold, '64x64_TEM_images_acquire.emi')
-        fname0_ser = os.path.join(
-            self.dirpathold, '64x64_TEM_images_acquire_1.ser')
+        from rsciio.fei.api import (
+            _guess_units_from_mode,
+            convert_xml_to_dict,
+            get_xml_info_from_emi,
+        )
+
+        fname0_emi = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
+        fname0_ser = os.path.join(self.dirpathold, "64x64_TEM_images_acquire_1.ser")
         objects = get_xml_info_from_emi(fname0_emi)
         header0, data0 = load_ser_file(fname0_ser)
         objects_dict = convert_xml_to_dict(objects[0])
 
         unit = _guess_units_from_mode(objects_dict, header0)
-        assert unit == 'meters'
+        assert unit == "meters"
 
         # objects is empty dictionary
         with pytest.warns(
-                UserWarning,
-                match="The navigation axes units could not be determined."):
+            UserWarning, match="The navigation axes units could not be determined."
+        ):
             unit = _guess_units_from_mode({}, header0)
-        assert unit == 'meters'
+        assert unit == "meters"
 
-    @pytest.mark.parametrize('stack_metadata', [True, False, 0])
+    @pytest.mark.parametrize("stack_metadata", [True, False, 0])
     def test_load_multisignal_stack(self, stack_metadata):
         fname0 = os.path.join(
-            self.dirpathnew, '16x16-line_profile_horizontal_5x128x128_EDS.emi')
+            self.dirpathnew, "16x16-line_profile_horizontal_5x128x128_EDS.emi"
+        )
         s = load([fname0, fname0], stack=True, stack_metadata=stack_metadata)
         assert s[0].axes_manager.navigation_shape == (5, 2)
-        assert s[0].axes_manager.signal_shape == (4000, )
+        assert s[0].axes_manager.signal_shape == (4000,)
         assert s[1].axes_manager.navigation_shape == (5, 2)
         assert s[1].axes_manager.signal_shape == (128, 128)
 
         om = s[0].original_metadata
-        assert om.has_item('stack_elements') is (stack_metadata is True)
+        assert om.has_item("stack_elements") is (stack_metadata is True)
 
     def test_load_multisignal_stack_mismatch(self):
         fname0 = os.path.join(
-            self.dirpathnew, '16x16-diffraction_imagel_5x5x256x256_EDS.emi')
+            self.dirpathnew, "16x16-diffraction_imagel_5x5x256x256_EDS.emi"
+        )
         fname1 = os.path.join(
-            self.dirpathnew,
-            '16x16-diffraction_imagel_5x5x256x256_EDS_copy.emi')
+            self.dirpathnew, "16x16-diffraction_imagel_5x5x256x256_EDS_copy.emi"
+        )
         with pytest.raises(ValueError) as cm:
             load([fname0, fname1], stack=True)
             cm.match("The number of sub-signals per file does not match*")
         load([fname0, fname1])
 
     def test_date_time(self):
-        fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
         s = load(fname0)
         assert s.metadata.General.date == "2016-02-21"
         assert s.metadata.General.time == "17:50:18"
-        fname1 = os.path.join(self.dirpathold,
-                              '16x16-line_profile_horizontal_10x1024.emi')
+        fname1 = os.path.join(
+            self.dirpathold, "16x16-line_profile_horizontal_10x1024.emi"
+        )
         s = load(fname1)
-        assert (s.metadata.General.date == "2016-02-22")
-        assert (s.metadata.General.time == "11:50:36")
+        assert s.metadata.General.date == "2016-02-22"
+        assert s.metadata.General.time == "11:50:36"
 
     def test_metadata_TEM(self):
-        fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_TEM_images_acquire.emi")
         s = load(fname0)
+        assert s.metadata.Acquisition_instrument.TEM.beam_energy == 200.0
+        assert s.metadata.Acquisition_instrument.TEM.magnification == 19500.0
         assert (
-            s.metadata.Acquisition_instrument.TEM.beam_energy == 200.0)
-        assert (
-            s.metadata.Acquisition_instrument.TEM.magnification ==
-            19500.0)
-        assert (
-            s.metadata.Acquisition_instrument.TEM.microscope ==
-            "Tecnai 200 kV D2267 SuperTwin")
-        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha,
-                        0.0, rtol=1E-5)
+            s.metadata.Acquisition_instrument.TEM.microscope
+            == "Tecnai 200 kV D2267 SuperTwin"
+        )
+        np.testing.assert_allclose(
+            s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha, 0.0, rtol=1e-5
+        )
 
     def test_metadata_STEM(self):
-        fname0 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "16x16_STEM_BF_DF_acquire.emi")
         s = load(fname0)[0]
+        assert s.metadata.Acquisition_instrument.TEM.beam_energy == 200.0
+        assert s.metadata.Acquisition_instrument.TEM.camera_length == 40.0
+        assert s.metadata.Acquisition_instrument.TEM.magnification == 10000.0
         assert (
-            s.metadata.Acquisition_instrument.TEM.beam_energy == 200.0)
-        assert (
-            s.metadata.Acquisition_instrument.TEM.camera_length == 40.0)
-        assert (
-            s.metadata.Acquisition_instrument.TEM.magnification ==
-            10000.0)
-        assert (
-            s.metadata.Acquisition_instrument.TEM.microscope ==
-            "Tecnai 200 kV D2267 SuperTwin")
-        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha,
-                        0.0, rtol=1E-6)
-        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_beta,
-                        0.0, rtol=1E-6)
-        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.x,
-                        -0.000158, rtol=1E-6)
-        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.y,
-                        1.9e-05, rtol=1E-6)
-        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.z,
-                        0.0, rtol=1E-6)
+            s.metadata.Acquisition_instrument.TEM.microscope
+            == "Tecnai 200 kV D2267 SuperTwin"
+        )
+        np.testing.assert_allclose(
+            s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha, 0.0, rtol=1e-6
+        )
+        np.testing.assert_allclose(
+            s.metadata.Acquisition_instrument.TEM.Stage.tilt_beta, 0.0, rtol=1e-6
+        )
+        np.testing.assert_allclose(
+            s.metadata.Acquisition_instrument.TEM.Stage.x, -0.000158, rtol=1e-6
+        )
+        np.testing.assert_allclose(
+            s.metadata.Acquisition_instrument.TEM.Stage.y, 1.9e-05, rtol=1e-6
+        )
+        np.testing.assert_allclose(
+            s.metadata.Acquisition_instrument.TEM.Stage.z, 0.0, rtol=1e-6
+        )
 
     def test_metadata_diffraction(self):
-        fname0 = os.path.join(self.dirpathold, '64x64_diffraction_acquire.emi')
+        fname0 = os.path.join(self.dirpathold, "64x64_diffraction_acquire.emi")
         s = load(fname0)
+        assert s.metadata.Acquisition_instrument.TEM.beam_energy == 200.0
+        assert s.metadata.Acquisition_instrument.TEM.camera_length == 490.0
         assert (
-            s.metadata.Acquisition_instrument.TEM.beam_energy == 200.0)
-        assert (
-            s.metadata.Acquisition_instrument.TEM.camera_length ==
-            490.0)
-        assert (
-            s.metadata.Acquisition_instrument.TEM.microscope ==
-            "Tecnai 200 kV D2267 SuperTwin")
+            s.metadata.Acquisition_instrument.TEM.microscope
+            == "Tecnai 200 kV D2267 SuperTwin"
+        )

--- a/rsciio/tests/test_fei_stream_readers.py
+++ b/rsciio/tests/test_fei_stream_readers.py
@@ -27,9 +27,11 @@ in order to mimic the usage in the FEI EMD reader.
 import numpy as np
 import pytest
 
-from rsciio.utils.fei_stream_readers import (array_to_stream,
-                                                 stream_to_array,
-                                                 stream_to_sparse_COO_array)
+from rsciio.utils.fei_stream_readers import (
+    array_to_stream,
+    stream_to_array,
+    stream_to_sparse_COO_array,
+)
 
 
 @pytest.mark.parametrize("lazy", (True, False))
@@ -38,14 +40,14 @@ def test_dense_stream(lazy):
     stream = array_to_stream(arr)
     if lazy:
         arrs = stream_to_sparse_COO_array(
-            stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2)
+            stream, spatial_shape=(3, 4), sum_frames=False, channels=5, last_frame=2
+        )
         arrs = arrs.compute()
         assert (arrs == arr).all()
     else:
         arrs = stream_to_array(
-            stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2)
+            stream, spatial_shape=(3, 4), sum_frames=False, channels=5, last_frame=2
+        )
         assert (arrs == arr).all()
 
 
@@ -55,14 +57,14 @@ def test_empty_stream(lazy):
     stream = array_to_stream(arr)
     if lazy:
         arrs = stream_to_sparse_COO_array(
-            stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2)
+            stream, spatial_shape=(3, 4), sum_frames=False, channels=5, last_frame=2
+        )
         arrs = arrs.compute()
         assert not arrs.any()
     else:
         arrs = stream_to_array(
-            stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2)
+            stream, spatial_shape=(3, 4), sum_frames=False, channels=5, last_frame=2
+        )
         assert not arrs.any()
 
 
@@ -75,12 +77,12 @@ def test_sparse_stream(lazy):
     stream = array_to_stream(arr)
     if lazy:
         arrs = stream_to_sparse_COO_array(
-            stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2)
+            stream, spatial_shape=(3, 4), sum_frames=False, channels=5, last_frame=2
+        )
         arrs = arrs.compute()
         assert (arrs == arr).all()
     else:
         arrs = stream_to_array(
-            stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2)
+            stream, spatial_shape=(3, 4), sum_frames=False, channels=5, last_frame=2
+        )
         assert (arrs == arr).all()

--- a/rsciio/tests/test_hdf5.py
+++ b/rsciio/tests/test_hdf5.py
@@ -48,111 +48,129 @@ my_path = Path(__file__).parent
 try:
     # zarr (because of numcodecs) is only supported on x86_64 machines
     import zarr
+
     zspy_marker = pytest.mark.parametrize("file", ["test.hspy", "test.zspy"])
 except ImportError:
     zspy_marker = pytest.mark.parametrize("file", ["test.hspy"])
 
 
-data = np.array([4066., 3996., 3932., 3923., 5602., 5288., 7234., 7809.,
-                 4710., 5015., 4366., 4524., 4832., 5474., 5718., 5034.,
-                 4651., 4613., 4637., 4429., 4217.])
+data = np.array(
+    [
+        4066.0,
+        3996.0,
+        3932.0,
+        3923.0,
+        5602.0,
+        5288.0,
+        7234.0,
+        7809.0,
+        4710.0,
+        5015.0,
+        4366.0,
+        4524.0,
+        4832.0,
+        5474.0,
+        5718.0,
+        5034.0,
+        4651.0,
+        4613.0,
+        4637.0,
+        4429.0,
+        4217.0,
+    ]
+)
 example1_original_metadata = {
-    'BEAMDIAM -nm': 100.0,
-    'BEAMKV   -kV': 120.0,
-    'CHOFFSET': -168.0,
-    'COLLANGLE-mR': 3.4,
-    'CONVANGLE-mR': 1.5,
-    'DATATYPE': 'XY',
-    'DATE': '01-OCT-1991',
-    'DWELLTIME-ms': 100.0,
-    'ELSDET': 'SERIAL',
-    'EMISSION -uA': 5.5,
-    'FORMAT': 'EMSA/MAS Spectral Data File',
-    'MAGCAM': 100.0,
-    'NCOLUMNS': 1.0,
-    'NPOINTS': 20.0,
-    'OFFSET': 520.13,
-    'OPERMODE': 'IMAG',
-    'OWNER': 'EMSA/MAS TASK FORCE',
-    'PROBECUR -nA': 12.345,
-    'SIGNALTYPE': 'ELS',
-    'THICKNESS-nm': 50.0,
-    'TIME': '12:00',
-    'TITLE': 'NIO EELS OK SHELL',
-    'VERSION': '1.0',
-    'XLABEL': 'Energy',
-    'XPERCHAN': 3.1,
-    'XUNITS': 'eV',
-    'YLABEL': 'Counts',
-    'YUNITS': 'Intensity'}
+    "BEAMDIAM -nm": 100.0,
+    "BEAMKV   -kV": 120.0,
+    "CHOFFSET": -168.0,
+    "COLLANGLE-mR": 3.4,
+    "CONVANGLE-mR": 1.5,
+    "DATATYPE": "XY",
+    "DATE": "01-OCT-1991",
+    "DWELLTIME-ms": 100.0,
+    "ELSDET": "SERIAL",
+    "EMISSION -uA": 5.5,
+    "FORMAT": "EMSA/MAS Spectral Data File",
+    "MAGCAM": 100.0,
+    "NCOLUMNS": 1.0,
+    "NPOINTS": 20.0,
+    "OFFSET": 520.13,
+    "OPERMODE": "IMAG",
+    "OWNER": "EMSA/MAS TASK FORCE",
+    "PROBECUR -nA": 12.345,
+    "SIGNALTYPE": "ELS",
+    "THICKNESS-nm": 50.0,
+    "TIME": "12:00",
+    "TITLE": "NIO EELS OK SHELL",
+    "VERSION": "1.0",
+    "XLABEL": "Energy",
+    "XPERCHAN": 3.1,
+    "XUNITS": "eV",
+    "YLABEL": "Counts",
+    "YUNITS": "Intensity",
+}
 
 
 class Example1:
     "Used as a base class for the TestExample classes below"
+
     def test_data(self):
-        assert (
-            [4066.0,
-             3996.0,
-             3932.0,
-             3923.0,
-             5602.0,
-             5288.0,
-             7234.0,
-             7809.0,
-             4710.0,
-             5015.0,
-             4366.0,
-             4524.0,
-             4832.0,
-             5474.0,
-             5718.0,
-             5034.0,
-             4651.0,
-             4613.0,
-             4637.0,
-             4429.0,
-             4217.0] == self.s.data.tolist())
+        assert [
+            4066.0,
+            3996.0,
+            3932.0,
+            3923.0,
+            5602.0,
+            5288.0,
+            7234.0,
+            7809.0,
+            4710.0,
+            5015.0,
+            4366.0,
+            4524.0,
+            4832.0,
+            5474.0,
+            5718.0,
+            5034.0,
+            4651.0,
+            4613.0,
+            4637.0,
+            4429.0,
+            4217.0,
+        ] == self.s.data.tolist()
 
     def test_original_metadata(self):
-        assert (
-            example1_original_metadata ==
-            self.s.original_metadata.as_dictionary())
+        assert example1_original_metadata == self.s.original_metadata.as_dictionary()
 
 
 class TestExample1_12(Example1):
-
     def setup_method(self, method):
         self.s = load(my_path / "hdf5_files" / "example1_v1.2.hdf5", reader="HSPY")
 
     def test_date(self):
-        assert (
-            self.s.metadata.General.date == "1991-10-01")
+        assert self.s.metadata.General.date == "1991-10-01"
 
     def test_time(self):
         assert self.s.metadata.General.time == "12:00:00"
 
 
 class TestExample1_10(Example1):
-
     def setup_method(self, method):
         self.s = load(my_path / "hdf5_files" / "example1_v1.0.hdf5", reader="HSPY")
 
 
 class TestExample1_11(Example1):
-
     def setup_method(self, method):
         self.s = load(my_path / "hdf5_files" / "example1_v1.1.hdf5", reader="HSPY")
 
 
 class TestLoadingNewSavedMetadata:
-
     def setup_method(self, method):
         self.s = load(my_path / "hdf5_files" / "with_lists_etc.hdf5", reader="HSPY")
 
     def test_signal_inside(self):
         np.testing.assert_array_almost_equal(
-            self.s.data,
-            self.s.metadata.Signal.Noise_properties.variance.data
+            self.s.data, self.s.metadata.Signal.Noise_properties.variance.data
         )
 
     def test_empty_things(self):
@@ -164,50 +182,42 @@ class TestLoadingNewSavedMetadata:
         assert self.s.metadata.test.tuple == (1, 2)
 
     def test_inside_things(self):
-        assert (
-            self.s.metadata.test.list_inside_list == [
-                42, 137, [
-                    0, 1]])
+        assert self.s.metadata.test.list_inside_list == [42, 137, [0, 1]]
         assert self.s.metadata.test.list_inside_tuple == (137, [42, 0])
-        assert (
-            self.s.metadata.test.tuple_inside_tuple == (137, (123, 44)))
-        assert (
-            self.s.metadata.test.tuple_inside_list == [
-                137, (123, 44)])
+        assert self.s.metadata.test.tuple_inside_tuple == (137, (123, 44))
+        assert self.s.metadata.test.tuple_inside_list == [137, (123, 44)]
 
-    @pytest.mark.xfail(
-        reason="dill is not guaranteed to load across Python versions")
+    @pytest.mark.xfail(reason="dill is not guaranteed to load across Python versions")
     def test_binary_string(self):
         import dill
+
         # apparently pickle is not "full" and marshal is not
         # backwards-compatible
         f = dill.loads(self.s.metadata.test.binary_string)
         assert f(3.5) == 4.5
 
 
-
 class TestSavingMetadataContainers:
-
     def setup_method(self, method):
         self.s = BaseSignal([0.1])
 
     @zspy_marker
     def test_save_unicode(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', ['a', 'b', '\u6f22\u5b57'])
+        s.metadata.set_item("test", ["a", "b", "\u6f22\u5b57"])
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
         assert isinstance(l.metadata.test[0], str)
         assert isinstance(l.metadata.test[1], str)
         assert isinstance(l.metadata.test[2], str)
-        assert l.metadata.test[2] == '\u6f22\u5b57'
+        assert l.metadata.test[2] == "\u6f22\u5b57"
 
     @pytest.mark.xfail(reason="osx is slow occasionally")
     @zspy_marker
     def test_save_long_list(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('long_list', list(range(10000)))
+        s.metadata.set_item("long_list", list(range(10000)))
         start = time.time()
         fname = tmp_path / file
         s.save(fname)
@@ -218,7 +228,7 @@ class TestSavingMetadataContainers:
     @zspy_marker
     def test_numpy_only_inner_lists(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', [[1., 2], ('3', 4)])
+        s.metadata.set_item("test", [[1.0, 2], ("3", 4)])
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
@@ -226,23 +236,21 @@ class TestSavingMetadataContainers:
         assert isinstance(l.metadata.test[0], list)
         assert isinstance(l.metadata.test[1], tuple)
 
-    @pytest.mark.xfail(sys.platform == 'win32',
-                       reason="randomly fails in win32")
+    @pytest.mark.xfail(sys.platform == "win32", reason="randomly fails in win32")
     @zspy_marker
     def test_numpy_general_type(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', np.array([[1., 2], ['3', 4]]))
+        s.metadata.set_item("test", np.array([[1.0, 2], ["3", 4]]))
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
         np.testing.assert_array_equal(l.metadata.test, s.metadata.test)
 
-    @pytest.mark.xfail(sys.platform == 'win32',
-                       reason="randomly fails in win32")
+    @pytest.mark.xfail(sys.platform == "win32", reason="randomly fails in win32")
     @zspy_marker
     def test_list_general_type(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', [[1., 2], ['3', 4]])
+        s.metadata.set_item("test", [[1.0, 2], ["3", 4]])
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
@@ -251,12 +259,11 @@ class TestSavingMetadataContainers:
         assert isinstance(l.metadata.test[1][0], str)
         assert isinstance(l.metadata.test[1][1], str)
 
-    @pytest.mark.xfail(sys.platform == 'win32',
-                       reason="randomly fails in win32")
+    @pytest.mark.xfail(sys.platform == "win32", reason="randomly fails in win32")
     @zspy_marker
     def test_general_type_not_working(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', (BaseSignal([1]), 0.1, 'test_string'))
+        s.metadata.set_item("test", (BaseSignal([1]), 0.1, "test_string"))
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
@@ -268,11 +275,11 @@ class TestSavingMetadataContainers:
     @zspy_marker
     def test_unsupported_type(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', Point2DROI(1, 2))
+        s.metadata.set_item("test", Point2DROI(1, 2))
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
-        assert 'test' not in l.metadata
+        assert "test" not in l.metadata
 
     @zspy_marker
     def test_date_time(self, tmp_path, file):
@@ -315,18 +322,18 @@ class TestSavingMetadataContainers:
     @zspy_marker
     def test_save_axes_manager(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', s.axes_manager)
-        fname = tmp_path /  file
+        s.metadata.set_item("test", s.axes_manager)
+        fname = tmp_path / file
         s.save(fname)
         l = load(fname)
-        #strange becuase you need the encoding...
+        # strange becuase you need the encoding...
         assert isinstance(l.metadata.test, AxesManager)
 
     @zspy_marker
     def test_title(self, tmp_path, file):
         s = self.s
         fname = tmp_path / file
-        s.metadata.General.title = '__unnamed__'
+        s.metadata.General.title = "__unnamed__"
         s.save(fname)
         l = load(fname)
         assert l.metadata.General.title == ""
@@ -334,18 +341,18 @@ class TestSavingMetadataContainers:
     @zspy_marker
     def test_save_empty_tuple(self, tmp_path, file):
         s = self.s
-        s.metadata.set_item('test', ())
+        s.metadata.set_item("test", ())
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
-        #strange becuase you need the encoding...
+        # strange becuase you need the encoding...
         assert l.metadata.test == s.metadata.test
 
     @zspy_marker
-    def test_save_bytes(self, tmp_path,file):
+    def test_save_bytes(self, tmp_path, file):
         s = self.s
-        byte_message = bytes("testing", 'utf-8')
-        s.metadata.set_item('test', byte_message)
+        byte_message = bytes("testing", "utf-8")
+        s.metadata.set_item("test", byte_message)
         fname = tmp_path / file
         s.save(fname)
         l = load(fname)
@@ -353,41 +360,54 @@ class TestSavingMetadataContainers:
 
     def test_metadata_binned_deprecate(self):
         with pytest.warns(UserWarning, match="Loading old file"):
-            s = load(my_path / "hdf5_files" / 'example2_v2.2.hspy')
-        assert s.metadata.has_item('Signal.binned') == False
+            s = load(my_path / "hdf5_files" / "example2_v2.2.hspy")
+        assert s.metadata.has_item("Signal.binned") == False
         assert s.axes_manager[-1].is_binned == False
 
-
     def test_metadata_update_to_v3_1(self):
-        md = {'Acquisition_instrument': {'SEM': {'Stage': {'tilt_alpha': 5.0}},
-                                         'TEM': {'Detector': {'Camera': {'exposure': 0.20000000000000001}},
-                                                 'Stage': {'tilt_alpha': 10.0},
-                                                 'acquisition_mode': 'TEM',
-                                                 'beam_current': 0.0,
-                                                 'beam_energy': 200.0,
-                                                 'camera_length': 320.00000000000006,
-                                                 'microscope': 'FEI Tecnai'}},
-              'General': {'date': '2014-07-09',
-                          'original_filename': 'test_diffraction_pattern.dm3',
-                          'time': '18:56:37',
-                          'title': 'test_diffraction_pattern',
-                          'FileIO': {
-                              '0': {
-                                  'operation': 'load',
-                                  'hyperspy_version': hs_version,
-                                  'io_plugin': 'rsciio.hspy.api'
-                              }
-                          }
-              },
-              'Signal': {'Noise_properties': {'Variance_linear_model': {'gain_factor': 1.0,
-                                                                        'gain_offset': 0.0}},
-                         'quantity': 'Intensity',
-                         'signal_type': ''},
-              '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                        'original_shape': None,
-                                        'signal_unfolded': False,
-                                        'unfolded': False}}}
-        s = load(my_path / "hdf5_files" / 'example2_v3.1.hspy')
+        md = {
+            "Acquisition_instrument": {
+                "SEM": {"Stage": {"tilt_alpha": 5.0}},
+                "TEM": {
+                    "Detector": {"Camera": {"exposure": 0.20000000000000001}},
+                    "Stage": {"tilt_alpha": 10.0},
+                    "acquisition_mode": "TEM",
+                    "beam_current": 0.0,
+                    "beam_energy": 200.0,
+                    "camera_length": 320.00000000000006,
+                    "microscope": "FEI Tecnai",
+                },
+            },
+            "General": {
+                "date": "2014-07-09",
+                "original_filename": "test_diffraction_pattern.dm3",
+                "time": "18:56:37",
+                "title": "test_diffraction_pattern",
+                "FileIO": {
+                    "0": {
+                        "operation": "load",
+                        "hyperspy_version": hs_version,
+                        "io_plugin": "rsciio.hspy.api",
+                    }
+                },
+            },
+            "Signal": {
+                "Noise_properties": {
+                    "Variance_linear_model": {"gain_factor": 1.0, "gain_offset": 0.0}
+                },
+                "quantity": "Intensity",
+                "signal_type": "",
+            },
+            "_HyperSpy": {
+                "Folding": {
+                    "original_axes_manager": None,
+                    "original_shape": None,
+                    "signal_unfolded": False,
+                    "unfolded": False,
+                }
+            },
+        }
+        s = load(my_path / "hdf5_files" / "example2_v3.1.hspy")
         # delete timestamp from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
@@ -401,16 +421,16 @@ def test_none_metadata():
 def test_rgba16():
     print(my_path)
     s = load(my_path / "hdf5_files" / "test_rgba16.hdf5", reader="HSPY")
-    data = np.load(my_path / "npz_files" / "test_rgba16.npz")['a']
+    data = np.load(my_path / "npz_files" / "test_rgba16.npz")["a"]
     assert (s.data == data).all()
 
 
 def test_non_valid_hspy(tmp_path, caplog):
-    filename = tmp_path / 'testfile.hspy'
+    filename = tmp_path / "testfile.hspy"
     data = np.arange(10)
 
-    with h5py.File(filename, mode='w') as f:
-        f.create_dataset('dataset', data=data)
+    with h5py.File(filename, mode="w") as f:
+        f.create_dataset("dataset", data=data)
 
     with pytest.raises(IOError):
         with caplog.at_level(logging.ERROR):
@@ -418,57 +438,55 @@ def test_non_valid_hspy(tmp_path, caplog):
 
 
 @zspy_marker
-@pytest.mark.parametrize('lazy', [True, False])
+@pytest.mark.parametrize("lazy", [True, False])
 def test_nonuniformaxis(tmp_path, file, lazy):
     fname = tmp_path / file
     data = np.arange(10)
-    axis = DataAxis(axis =1/np.arange(1, data.size+1), navigate=False)
-    s = Signal1D(data, axes=(axis.get_axis_dictionary(), ))
+    axis = DataAxis(axis=1 / np.arange(1, data.size + 1), navigate=False)
+    s = Signal1D(data, axes=(axis.get_axis_dictionary(),))
     if lazy:
         s = s.as_lazy()
     s.save(fname, overwrite=True)
     s2 = load(fname)
-    np.testing.assert_array_almost_equal(s.axes_manager[0].axis,
-                                         s2.axes_manager[0].axis)
-    assert(s2.axes_manager[0].is_uniform == False)
-    assert(s2.axes_manager[0].navigate == False)
-    assert(s2.axes_manager[0].size == data.size)
+    np.testing.assert_array_almost_equal(
+        s.axes_manager[0].axis, s2.axes_manager[0].axis
+    )
+    assert s2.axes_manager[0].is_uniform == False
+    assert s2.axes_manager[0].navigate == False
+    assert s2.axes_manager[0].size == data.size
 
 
 @zspy_marker
-@pytest.mark.parametrize('lazy', [True, False])
+@pytest.mark.parametrize("lazy", [True, False])
 def test_nonuniformFDA(tmp_path, file, lazy):
     fname = tmp_path / file
     data = np.arange(10)
     x0 = UniformDataAxis(size=data.size, offset=1)
-    axis = FunctionalDataAxis(expression='1/x', x=x0, navigate=False)
-    s = Signal1D(data, axes = (axis.get_axis_dictionary(), ))
+    axis = FunctionalDataAxis(expression="1/x", x=x0, navigate=False)
+    s = Signal1D(data, axes=(axis.get_axis_dictionary(),))
     if lazy:
         s = s.as_lazy()
     print(axis.get_axis_dictionary())
     s.save(fname, overwrite=True)
     s2 = load(fname)
-    np.testing.assert_array_almost_equal(s.axes_manager[0].axis,
-                                         s2.axes_manager[0].axis)
-    assert(s2.axes_manager[0].is_uniform == False)
-    assert(s2.axes_manager[0].navigate == False)
-    assert(s2.axes_manager[0].size == data.size)
+    np.testing.assert_array_almost_equal(
+        s.axes_manager[0].axis, s2.axes_manager[0].axis
+    )
+    assert s2.axes_manager[0].is_uniform == False
+    assert s2.axes_manager[0].navigate == False
+    assert s2.axes_manager[0].size == data.size
 
 
 def test_lazy_loading(tmp_path):
     s = BaseSignal(np.empty((5, 5, 5)))
-    fname = tmp_path / 'tmp.hdf5'
+    fname = tmp_path / "tmp.hdf5"
     s.save(fname, overwrite=True, file_format="HSPY")
     shape = (10000, 10000, 100)
     del s
-    f = h5py.File(fname, mode='r+')
-    s = f['Experiments/__unnamed__']
-    del s['data']
-    s.create_dataset(
-        'data',
-        shape=shape,
-        dtype='float64',
-        chunks=True)
+    f = h5py.File(fname, mode="r+")
+    s = f["Experiments/__unnamed__"]
+    del s["data"]
+    s.create_dataset("data", shape=shape, dtype="float64", chunks=True)
     f.close()
 
     s = load(fname, lazy=True, reader="HSPY")
@@ -479,13 +497,13 @@ def test_lazy_loading(tmp_path):
 
 
 def test_passing_compression_opts_saving(tmp_path):
-    filename = tmp_path / 'testfile.hdf5'
+    filename = tmp_path / "testfile.hdf5"
     BaseSignal([1, 2, 3]).save(filename, compression_opts=8, file_format="HSPY")
 
-    f = h5py.File(filename, mode='r+')
-    d = f['Experiments/__unnamed__/data']
+    f = h5py.File(filename, mode="r+")
+    d = f["Experiments/__unnamed__/data"]
     assert d.compression_opts == 8
-    assert d.compression == 'gzip'
+    assert d.compression == "gzip"
     f.close()
 
 
@@ -516,7 +534,6 @@ def test_axes_configuration_binning(tmp_path, file):
 
 @lazifyTestClass
 class Test_permanent_markers_io:
-
     def setup_method(self, method):
         s = Signal2D(np.arange(100).reshape(10, 10))
         self.s = s
@@ -546,9 +563,9 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x, y = 5, 2
-        color = 'red'
+        color = "red"
         size = 10
-        name = 'testname'
+        name = "testname"
         m = markers.point(x=x, y=y, color=color, size=size)
         m.name = name
         s.add_marker(m, permanent=True)
@@ -556,10 +573,10 @@ class Test_permanent_markers_io:
         s1 = load(filename)
         assert s1.metadata.Markers.has_item(name)
         m1 = s1.metadata.Markers.get_item(name)
-        assert m1.get_data_position('x1') == x
-        assert m1.get_data_position('y1') == y
-        assert m1.get_data_position('size') == size
-        assert m1.marker_properties['color'] == color
+        assert m1.get_data_position("x1") == x
+        assert m1.get_data_position("y1") == y
+        assert m1.get_data_position("size") == size
+        assert m1.marker_properties["color"] == color
         assert m1.name == name
 
     @zspy_marker
@@ -587,17 +604,18 @@ class Test_permanent_markers_io:
         for m in m0_list:
             m0_dict_list.append(san_dict(m._to_dictionary()))
             m1_dict_list.append(
-                san_dict(markers_dict.get_item(m.name)._to_dictionary()))
+                san_dict(markers_dict.get_item(m.name)._to_dictionary())
+            )
         assert len(list(s1.metadata.Markers)) == 8
         for m0_dict, m1_dict in zip(m0_dict_list, m1_dict_list):
             assert m0_dict == m1_dict
 
     @zspy_marker
-    def test_save_load_horizontal_line_marker(self,tmp_path,file):
+    def test_save_load_horizontal_line_marker(self, tmp_path, file):
         filename = tmp_path / file
         s = self.s
         y = 8
-        color = 'blue'
+        color = "blue"
         linewidth = 2.5
         name = "horizontal_line_test"
         m = markers.horizontal_line(y=y, color=color, linewidth=linewidth)
@@ -613,11 +631,12 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x1, x2, y = 1, 5, 8
-        color = 'red'
+        color = "red"
         linewidth = 1.2
         name = "horizontal_line_segment_test"
         m = markers.horizontal_line_segment(
-            x1=x1, x2=x2, y=y, color=color, linewidth=linewidth)
+            x1=x1, x2=x2, y=y, color=color, linewidth=linewidth
+        )
         m.name = name
         s.add_marker(m, permanent=True)
         s.save(filename)
@@ -630,7 +649,7 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x = 9
-        color = 'black'
+        color = "black"
         linewidth = 3.5
         name = "vertical_line_test"
         m = markers.vertical_line(x=x, color=color, linewidth=linewidth)
@@ -646,11 +665,12 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x, y1, y2 = 2, 1, 3
-        color = 'white'
+        color = "white"
         linewidth = 4.2
         name = "vertical_line_segment_test"
         m = markers.vertical_line_segment(
-            x=x, y1=y1, y2=y2, color=color, linewidth=linewidth)
+            x=x, y1=y1, y2=y2, color=color, linewidth=linewidth
+        )
         m.name = name
         s.add_marker(m, permanent=True)
         s.save(filename)
@@ -663,11 +683,12 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x1, x2, y1, y2 = 1, 9, 4, 7
-        color = 'cyan'
+        color = "cyan"
         linewidth = 0.7
         name = "line_segment_test"
         m = markers.line_segment(
-            x1=x1, x2=x2, y1=y1, y2=y2, color=color, linewidth=linewidth)
+            x1=x1, x2=x2, y1=y1, y2=y2, color=color, linewidth=linewidth
+        )
         m.name = name
         s.add_marker(m, permanent=True)
         s.save(filename)
@@ -680,10 +701,9 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x, y = 9, 8
-        color = 'purple'
+        color = "purple"
         name = "point test"
-        m = markers.point(
-            x=x, y=y, color=color)
+        m = markers.point(x=x, y=y, color=color)
         m.name = name
         s.add_marker(m, permanent=True)
         s.save(filename)
@@ -696,11 +716,12 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x1, x2, y1, y2 = 2, 4, 1, 3
-        color = 'yellow'
+        color = "yellow"
         linewidth = 5
         name = "rectangle_test"
         m = markers.rectangle(
-            x1=x1, x2=x2, y1=y1, y2=y2, color=color, linewidth=linewidth)
+            x1=x1, x2=x2, y1=y1, y2=y2, color=color, linewidth=linewidth
+        )
         m.name = name
         s.add_marker(m, permanent=True)
         s.save(filename)
@@ -713,11 +734,10 @@ class Test_permanent_markers_io:
         filename = tmp_path / file
         s = self.s
         x, y = 3, 9.5
-        color = 'brown'
+        color = "brown"
         name = "text_test"
         text = "a text"
-        m = markers.text(
-            x=x, y=y, text=text, color=color)
+        m = markers.text(x=x, y=y, text=text, color=color)
         m.name = name
         s.add_marker(m, permanent=True)
         s.save(filename)
@@ -726,11 +746,11 @@ class Test_permanent_markers_io:
         assert san_dict(m1._to_dictionary()) == san_dict(m._to_dictionary())
 
     @zspy_marker
-    @pytest.mark.parametrize('lazy', [True, False])
+    @pytest.mark.parametrize("lazy", [True, False])
     def test_save_load_multidim_navigation_marker(self, tmp_path, file, lazy):
         filename = tmp_path / file
         x, y = (1, 2, 3), (5, 6, 7)
-        name = 'test point'
+        name = "test point"
         s = Signal2D(np.arange(300).reshape(3, 10, 10))
         if lazy:
             s = s.as_lazy()
@@ -741,14 +761,14 @@ class Test_permanent_markers_io:
         s1 = load(filename)
         m1 = s1.metadata.Markers.get_item(name)
         assert san_dict(m1._to_dictionary()) == san_dict(m._to_dictionary())
-        assert m1.get_data_position('x1') == x[0]
-        assert m1.get_data_position('y1') == y[0]
+        assert m1.get_data_position("x1") == x[0]
+        assert m1.get_data_position("y1") == y[0]
         s1.axes_manager.navigation_axes[0].index = 1
-        assert m1.get_data_position('x1') == x[1]
-        assert m1.get_data_position('y1') == y[1]
+        assert m1.get_data_position("x1") == x[1]
+        assert m1.get_data_position("y1") == y[1]
         s1.axes_manager.navigation_axes[0].index = 2
-        assert m1.get_data_position('x1') == x[2]
-        assert m1.get_data_position('y1') == y[2]
+        assert m1.get_data_position("x1") == x[2]
+        assert m1.get_data_position("y1") == y[2]
 
     def test_load_unknown_marker_type(self):
         # test_marker_bad_marker_type.hdf5 has 5 markers,
@@ -768,9 +788,10 @@ class Test_permanent_markers_io:
 
 
 @zspy_marker
-@pytest.mark.parametrize('lazy', [True, False])
+@pytest.mark.parametrize("lazy", [True, False])
 def test_save_load_model(tmp_path, file, lazy):
     from hyperspy._components.gaussian import Gaussian
+
     filename = tmp_path / file
     s = Signal1D(np.ones((10, 10, 10, 10)))
     if lazy:
@@ -786,10 +807,9 @@ def test_save_load_model(tmp_path, file, lazy):
 
 @pytest.mark.parametrize("compression", (None, "gzip", "lzf"))
 def test_compression(compression, tmp_path):
-    s = Signal1D(np.ones((3,3)))
-    s.save(tmp_path / 'test_compression.hspy', overwrite=True,
-           compression=compression)
-    load(tmp_path / 'test_compression.hspy')
+    s = Signal1D(np.ones((3, 3)))
+    s.save(tmp_path / "test_compression.hspy", overwrite=True, compression=compression)
+    load(tmp_path / "test_compression.hspy")
 
 
 def test_strings_from_py2():
@@ -822,8 +842,8 @@ def test_save_ragged_dim2(tmp_path, file):
     s.save(filename)
     s2 = load(filename)
 
-    for i, j in zip(s.data,s2.data):
-        np.testing.assert_array_equal(i,j)
+    for i, j in zip(s.data, s2.data):
+        np.testing.assert_array_equal(i, j)
 
 
 def test_load_missing_extension(caplog):
@@ -832,16 +852,16 @@ def test_load_missing_extension(caplog):
         s = load(path)
     assert "This file contains a signal provided by the hspy_ext_missing" in caplog.text
     with pytest.raises(ImportError):
-       _ = s.models.restore("a")
+        _ = s.models.restore("a")
 
 
 @zspy_marker
 def test_save_chunks_signal_metadata(tmp_path, file):
     N = 10
     dim = 3
-    s = Signal1D(np.arange(N**dim).reshape([N]*dim))
+    s = Signal1D(np.arange(N**dim).reshape([N] * dim))
     s.navigator = s.sum(-1)
-    s.change_dtype('float')
+    s.change_dtype("float")
     s.decomposition()
 
     filename = tmp_path / file
@@ -856,9 +876,9 @@ def test_chunking_saving_lazy(tmp_path, file):
     s = Signal2D(da.zeros((50, 100, 100))).as_lazy()
     s.data = s.data.rechunk([50, 25, 25])
 
-    filename = tmp_path / 'test_chunking_saving_lazy.hspy'
-    filename2 = tmp_path / 'test_chunking_saving_lazy_chunks_True.hspy'
-    filename3 = tmp_path / 'test_chunking_saving_lazy_chunks_specified.hspy'
+    filename = tmp_path / "test_chunking_saving_lazy.hspy"
+    filename2 = tmp_path / "test_chunking_saving_lazy_chunks_True.hspy"
+    filename3 = tmp_path / "test_chunking_saving_lazy_chunks_specified.hspy"
     s.save(filename)
     s1 = load(filename, lazy=True)
     assert s.data.chunks == s1.data.chunks
@@ -878,15 +898,15 @@ def test_chunking_saving_lazy(tmp_path, file):
 def test_saving_close_file(tmp_path):
     # Setup that we will reopen
     s = Signal1D(da.zeros((10, 100))).as_lazy()
-    fname = tmp_path / 'test.hspy'
+    fname = tmp_path / "test.hspy"
     s.save(fname, close_file=True)
 
-    s2 = load(fname, lazy=True, mode='a')
+    s2 = load(fname, lazy=True, mode="a")
     assert get_file_handle(s2.data) is not None
     s2.save(fname, close_file=True, overwrite=True)
     assert get_file_handle(s2.data) is None
 
-    s3 = load(fname, lazy=True, mode='a')
+    s3 = load(fname, lazy=True, mode="a")
     assert get_file_handle(s3.data) is not None
     s3.save(fname, close_file=False, overwrite=True)
     assert get_file_handle(s3.data) is not None
@@ -902,27 +922,27 @@ def test_saving_close_file(tmp_path):
 @zspy_marker
 def test_saving_overwrite_data(tmp_path, file):
     s = Signal1D(da.zeros((10, 100))).as_lazy()
-    kwds = dict(close_file=True) if file == 'test.hspy' else {}
+    kwds = dict(close_file=True) if file == "test.hspy" else {}
     fname = tmp_path / file
     s.save(fname, **kwds)
 
-    s2 = load(fname, lazy=True, mode='a')
-    s2.axes_manager[0].units = 'nm'
+    s2 = load(fname, lazy=True, mode="a")
+    s2.axes_manager[0].units = "nm"
     s2.data = da.ones((10, 100))
     s2.save(fname, overwrite=True, write_dataset=False)
 
     s3 = load(fname)
-    assert s3.axes_manager[0].units == 'nm'
+    assert s3.axes_manager[0].units == "nm"
     # Still old data
     np.testing.assert_allclose(s3.data, np.zeros((10, 100)))
 
     s4 = load(fname)
     s4.data = da.ones((10, 100))
-    if file == 'test.hspy':
+    if file == "test.hspy":
         # try with opening non-lazily to check opening mode
         # only relevant for hdf5 file
         with pytest.raises(ValueError):
-            s4.save(fname, overwrite=True, write_dataset=False, mode='w')
+            s4.save(fname, overwrite=True, write_dataset=False, mode="w")
 
     s4.save(fname, overwrite=True, write_dataset=True)
     # make sure we can open it after, file haven't been corrupted
@@ -940,14 +960,13 @@ def test_saving_overwrite_data(tmp_path, file):
         assert tuple([c[0] for c in s1.data.chunks]) == chunks
 
 
-@pytest.mark.parametrize("target_size", (1e6,1e7))
+@pytest.mark.parametrize("target_size", (1e6, 1e7))
 def test_get_signal_chunks(target_size):
     shape = (2, 150, 3, 200, 1, 600, 1)
-    chunks = get_signal_chunks(shape=shape,
-                               dtype=np.int64,
-                               signal_axes=(2, 3),
-                               target_size=target_size)
-    assert (np.prod(chunks)*8 < target_size)
+    chunks = get_signal_chunks(
+        shape=shape, dtype=np.int64, signal_axes=(2, 3), target_size=target_size
+    )
+    assert np.prod(chunks) * 8 < target_size
     # The chunks must be smaller or equal that the corresponding sizes
     assert (np.array(chunks) <= np.array(shape)).all()
 
@@ -955,22 +974,22 @@ def test_get_signal_chunks(target_size):
 def test_get_signal_chunks_big_signal():
     # One signal exceeds the target size
     shape = (10, 1000, 5, 1000)
-    chunks = get_signal_chunks(shape=shape,
-                               dtype=np.int32,
-                               signal_axes=(1, 3),
-                               target_size=1e6)
+    chunks = get_signal_chunks(
+        shape=shape, dtype=np.int32, signal_axes=(1, 3), target_size=1e6
+    )
     # The chunks must be smaller or equal that the corresponding sizes
     assert chunks == (1, 1000, 1, 1000)
+
 
 def test_get_signal_chunks_small_dataset():
     # Whole dataset fits in one chunk
     shape = (10, 10, 2, 2)
-    chunks = get_signal_chunks(shape=shape,
-                               dtype=np.int32,
-                               signal_axes=(2, 3),
-                               target_size=1e6)
+    chunks = get_signal_chunks(
+        shape=shape, dtype=np.int32, signal_axes=(2, 3), target_size=1e6
+    )
     # The chunks must be smaller or equal that the corresponding sizes
     assert chunks == shape
+
 
 @zspy_marker
 def test_error_saving(tmp_path, file):
@@ -978,17 +997,17 @@ def test_error_saving(tmp_path, file):
     s = Signal1D(np.arange(10))
 
     with pytest.raises(ValueError):
-        s.save(filename, write_dataset='unsupported_type')
-        assert not s.metadata.Signal.has_item('record_by')
+        s.save(filename, write_dataset="unsupported_type")
+        assert not s.metadata.Signal.has_item("record_by")
 
 
 def test_more_recent_version_warning(tmp_path):
-    filename = tmp_path / 'test.hspy'
+    filename = tmp_path / "test.hspy"
     s = Signal1D(np.arange(10))
     s.save(filename)
 
-    with h5py.File(filename, mode='a') as f:
-        f.attrs["file_format_version"] = '99999999'
+    with h5py.File(filename, mode="a") as f:
+        f.attrs["file_format_version"] = "99999999"
 
     with pytest.warns(UserWarning):
         s2 = load(filename)

--- a/rsciio/tests/test_image.py
+++ b/rsciio/tests/test_image.py
@@ -24,71 +24,74 @@ import hyperspy.api as hs
 
 try:
     from matplotlib_scalebar.scalebar import ScaleBar
+
     matplotlib_scalebar_installed = True
 except ImportError:  # pragma: no cover
     matplotlib_scalebar_installed = False
 
 
-@pytest.mark.parametrize(("dtype"), ['uint8', 'uint32'])
-@pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpg'])
+@pytest.mark.parametrize(("dtype"), ["uint8", "uint32"])
+@pytest.mark.parametrize(("ext"), ["png", "bmp", "gif", "jpg"])
 def test_save_load_cycle_grayscale(dtype, ext, tmp_path):
-    s = hs.signals.Signal2D(np.arange(128*128).reshape(128, 128).astype(dtype))
+    s = hs.signals.Signal2D(np.arange(128 * 128).reshape(128, 128).astype(dtype))
 
-    print('Saving-loading cycle for the extension:', ext)
-    filename = tmp_path / f'test_image.{ext}'
+    print("Saving-loading cycle for the extension:", ext)
+    filename = tmp_path / f"test_image.{ext}"
     s.save(filename)
     hs.load(filename)
 
 
-@pytest.mark.parametrize(("color"), ['rgb8', 'rgba8', 'rgb16', 'rgba16'])
-@pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpeg'])
+@pytest.mark.parametrize(("color"), ["rgb8", "rgba8", "rgb16", "rgba16"])
+@pytest.mark.parametrize(("ext"), ["png", "bmp", "gif", "jpeg"])
 def test_save_load_cycle_color(color, ext, tmp_path):
     dim = 4 if "rgba" in color else 3
-    dtype = 'uint8' if "8" in color else 'uint16'
-    if dim == 4 and ext == 'jpeg':
+    dtype = "uint8" if "8" in color else "uint16"
+    if dim == 4 and ext == "jpeg":
         # JPEG does not support alpha channel.
         return
-    print('color:', color, '; dim:', dim, '; dtype:', dtype)
-    s = hs.signals.Signal1D(np.arange(128*128*dim).reshape(128, 128, dim).astype(dtype))
+    print("color:", color, "; dim:", dim, "; dtype:", dtype)
+    s = hs.signals.Signal1D(
+        np.arange(128 * 128 * dim).reshape(128, 128, dim).astype(dtype)
+    )
     s.change_dtype(color)
 
-    print('Saving-loading cycle for the extension:', ext)
-    filename = tmp_path / f'test_image.{ext}'
+    print("Saving-loading cycle for the extension:", ext)
+    filename = tmp_path / f"test_image.{ext}"
     s.save(filename)
     hs.load(filename)
 
 
-@pytest.mark.parametrize(("dtype"), ['uint8', 'uint32'])
-@pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpg'])
+@pytest.mark.parametrize(("dtype"), ["uint8", "uint32"])
+@pytest.mark.parametrize(("ext"), ["png", "bmp", "gif", "jpg"])
 def test_save_load_cycle_kwds(dtype, ext, tmp_path):
-    s = hs.signals.Signal2D(np.arange(128*128).reshape(128, 128).astype(dtype))
+    s = hs.signals.Signal2D(np.arange(128 * 128).reshape(128, 128).astype(dtype))
 
-    print('Saving-loading cycle for the extension:', ext)
-    filename = tmp_path / f'test_image.{ext}'
-    if ext == 'png':
-        if dtype == 'uint32':
-            kwds = {'bits': 32}
+    print("Saving-loading cycle for the extension:", ext)
+    filename = tmp_path / f"test_image.{ext}"
+    if ext == "png":
+        if dtype == "uint32":
+            kwds = {"bits": 32}
         else:
-            kwds = {'optimize': True}
-    elif ext == 'jpg':
-        kwds = {'quality': 100, 'optimize': True}
-    elif ext == 'gif':
-        kwds = {'subrectangles': 'True', 'palettesize': 128}
+            kwds = {"optimize": True}
+    elif ext == "jpg":
+        kwds = {"quality": 100, "optimize": True}
+    elif ext == "gif":
+        kwds = {"subrectangles": "True", "palettesize": 128}
     else:
         kwds = {}
     s.save(filename, **kwds)
-    hs.load(filename, pilmode='L', as_grey=True)
+    hs.load(filename, pilmode="L", as_grey=True)
 
 
-@pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpg'])
+@pytest.mark.parametrize(("ext"), ["png", "bmp", "gif", "jpg"])
 def test_export_scalebar(ext, tmp_path):
-    data = np.arange(1E6).reshape((1000, 1000))
+    data = np.arange(1e6).reshape((1000, 1000))
     s = hs.signals.Signal2D(data)
-    s.axes_manager[0].units = 'nm'
-    s.axes_manager[1].units = 'nm'
+    s.axes_manager[0].units = "nm"
+    s.axes_manager[1].units = "nm"
 
-    filename = tmp_path / f'test_scalebar_export.{ext}'
-    if ext in ['bmp', 'gif'] and matplotlib_scalebar_installed:
+    filename = tmp_path / f"test_scalebar_export.{ext}"
+    if ext in ["bmp", "gif"] and matplotlib_scalebar_installed:
         with pytest.raises(ValueError):
             s.save(filename, scalebar=True)
         with pytest.raises(ValueError):
@@ -104,11 +107,11 @@ def test_export_scalebar_reciprocal(tmp_path):
     pixels = 512
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     for axis in s.axes_manager.signal_axes:
-        axis.units = '1/nm'
+        axis.units = "1/nm"
         axis.scale = 0.1
 
-    filename = tmp_path / 'test_scalebar_export.jpg'
-    s.save(filename, scalebar=True, scalebar_kwds={'location':'lower right'})
+    filename = tmp_path / "test_scalebar_export.jpg"
+    s.save(filename, scalebar=True, scalebar_kwds={"location": "lower right"})
     s_reload = hs.load(filename)
     assert s.data.shape == s_reload.data.shape
 
@@ -117,8 +120,8 @@ def test_export_scalebar_undefined_units(tmp_path):
     pixels = 512
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
 
-    filename = tmp_path / 'test_scalebar_export.jpg'
-    s.save(filename, scalebar=True, scalebar_kwds={'location':'lower right'})
+    filename = tmp_path / "test_scalebar_export.jpg"
+    s.save(filename, scalebar=True, scalebar_kwds={"location": "lower right"})
     s_reload = hs.load(filename)
     assert s.data.shape == s_reload.data.shape
 
@@ -128,64 +131,67 @@ def test_non_uniform(tmp_path):
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     s.axes_manager[0].convert_to_non_uniform_axis()
 
-    filename = tmp_path / 'test_export_size.jpg'
+    filename = tmp_path / "test_export_size.jpg"
     with pytest.raises(TypeError):
         s.save(filename)
 
 
-@pytest.mark.skipif(not matplotlib_scalebar_installed,
-                    reason='matplotlib_scalebar is not installed')
+@pytest.mark.skipif(
+    not matplotlib_scalebar_installed, reason="matplotlib_scalebar is not installed"
+)
 def test_export_scalebar_different_scale_units(tmp_path):
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     s.axes_manager[0].scale = 2
 
-    filename = tmp_path / 'test_export_size.jpg'
+    filename = tmp_path / "test_export_size.jpg"
     with pytest.raises(ValueError):
         s.save(filename, scalebar=True)
 
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
-    s.axes_manager[0].units = 'nm'
+    s.axes_manager[0].units = "nm"
 
-    filename = tmp_path / 'test_export_size.jpg'
+    filename = tmp_path / "test_export_size.jpg"
     with pytest.raises(ValueError):
         s.save(filename, scalebar=True)
 
 
-@pytest.mark.parametrize('output_size', (512, [512, 512]))
+@pytest.mark.parametrize("output_size", (512, [512, 512]))
 def test_export_output_size(output_size, tmp_path):
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
 
-    fname = tmp_path / 'test_export_size.jpg'
+    fname = tmp_path / "test_export_size.jpg"
     s.save(fname, scalebar=True, output_size=output_size)
     s_reload = hs.load(fname)
     assert s_reload.data.shape == (512, 512)
 
 
-@pytest.mark.parametrize('output_size', (512, (512, 512)))
+@pytest.mark.parametrize("output_size", (512, (512, 512)))
 def test_export_output_size_non_square(output_size, tmp_path):
     pixels = (8, 16)
     s = hs.signals.Signal2D(np.arange(np.multiply(*pixels)).reshape(pixels))
 
-    fname = tmp_path / 'test_export_size_non_square.jpg'
+    fname = tmp_path / "test_export_size_non_square.jpg"
     s.save(fname, output_size=output_size)
     s_reload = hs.load(fname)
 
     if isinstance(output_size, int):
-       output_size = (output_size * np.divide(*pixels), output_size)
+        output_size = (output_size * np.divide(*pixels), output_size)
 
     assert s_reload.data.shape == output_size
 
 
-@pytest.mark.parametrize('output_size', (None, 512))
-@pytest.mark.parametrize('aspect', (1, 0.5))
+@pytest.mark.parametrize("output_size", (None, 512))
+@pytest.mark.parametrize("aspect", (1, 0.5))
 def test_export_output_size_aspect(aspect, output_size, tmp_path):
     pixels = (256, 256)
     s = hs.signals.Signal2D(np.arange(np.multiply(*pixels)).reshape(pixels))
 
-    fname = tmp_path / 'test_export_size_non_square_aspect.jpg'
-    s.save(fname, scalebar=True, output_size=output_size, imshow_kwds=dict(aspect=aspect))
+    fname = tmp_path / "test_export_size_non_square_aspect.jpg"
+    s.save(
+        fname, scalebar=True, output_size=output_size, imshow_kwds=dict(aspect=aspect)
+    )
     s_reload = hs.load(fname)
 
     if output_size is None:
@@ -197,5 +203,5 @@ def test_save_image_navigation(tmp_path):
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
 
-    fname = tmp_path / 'test_save_image_navigation.jpg'
+    fname = tmp_path / "test_save_image_navigation.jpg"
     s.T.save(fname, scalebar=True)

--- a/rsciio/tests/test_impulse.py
+++ b/rsciio/tests/test_impulse.py
@@ -22,11 +22,7 @@ import numpy as np
 import pytest
 
 import hyperspy.api as hs
-from rsciio.impulse.api import (
-    ImpulseCSV,
-    invalid_file_error,
-    invalid_filenaming_error
-)
+from rsciio.impulse.api import ImpulseCSV, invalid_file_error, invalid_filenaming_error
 
 testdirpath = os.path.dirname(__file__)
 dirpath = os.path.join(testdirpath, "impulse_data")
@@ -34,38 +30,38 @@ dirpath = os.path.join(testdirpath, "impulse_data")
 
 # Load a synchronized data log file
 
+
 def test_read_sync_file():
-    filename = os.path.join(dirpath, 'StubExperiment_Synchronized data.csv')
-    s = hs.load(filename, reader='impulse')
+    filename = os.path.join(dirpath, "StubExperiment_Synchronized data.csv")
+    s = hs.load(filename, reader="impulse")
     assert len(s) == 13
-    assert (s[0].metadata.General.title ==
-            'Temperature Measured (degC)')
-    assert s[0].metadata.Signal.quantity == 'degC'
-    assert s[1].metadata.General.title == 'MixValve'
-    assert s[1].metadata.Signal.quantity == ''
-    assert s[2].metadata.General.title == 'Pin Measured'
-    assert s[2].metadata.Signal.quantity == ''
-    assert s[3].metadata.General.title == 'Pout Measured'
-    assert s[3].metadata.Signal.quantity == ''
-    assert s[4].metadata.General.title == 'Pnr Measured'
-    assert s[4].metadata.Signal.quantity == ''
-    assert s[5].metadata.General.title == 'Fnr'
-    assert s[5].metadata.Signal.quantity == ''
-    assert s[6].metadata.General.title == '% Gas1 Measured'
-    assert s[6].metadata.Signal.quantity == ''
-    assert s[7].metadata.General.title == '% Gas2 Measured'
-    assert s[7].metadata.Signal.quantity == ''
-    assert s[8].metadata.General.title == '% Gas3 Measured'
-    assert s[8].metadata.Signal.quantity == ''
-    assert s[9].metadata.General.title == 'Channel#1'
-    assert s[9].metadata.Signal.quantity == ''
-    assert s[10].metadata.General.title == 'Channel#2'
-    assert s[10].metadata.Signal.quantity == ''
-    assert s[11].metadata.General.title == 'Channel#3'
-    assert s[11].metadata.Signal.quantity == ''
-    assert s[12].metadata.General.title == 'Channel#4'
-    assert s[12].metadata.Signal.quantity == ''
-    
+    assert s[0].metadata.General.title == "Temperature Measured (degC)"
+    assert s[0].metadata.Signal.quantity == "degC"
+    assert s[1].metadata.General.title == "MixValve"
+    assert s[1].metadata.Signal.quantity == ""
+    assert s[2].metadata.General.title == "Pin Measured"
+    assert s[2].metadata.Signal.quantity == ""
+    assert s[3].metadata.General.title == "Pout Measured"
+    assert s[3].metadata.Signal.quantity == ""
+    assert s[4].metadata.General.title == "Pnr Measured"
+    assert s[4].metadata.Signal.quantity == ""
+    assert s[5].metadata.General.title == "Fnr"
+    assert s[5].metadata.Signal.quantity == ""
+    assert s[6].metadata.General.title == "% Gas1 Measured"
+    assert s[6].metadata.Signal.quantity == ""
+    assert s[7].metadata.General.title == "% Gas2 Measured"
+    assert s[7].metadata.Signal.quantity == ""
+    assert s[8].metadata.General.title == "% Gas3 Measured"
+    assert s[8].metadata.Signal.quantity == ""
+    assert s[9].metadata.General.title == "Channel#1"
+    assert s[9].metadata.Signal.quantity == ""
+    assert s[10].metadata.General.title == "Channel#2"
+    assert s[10].metadata.Signal.quantity == ""
+    assert s[11].metadata.General.title == "Channel#3"
+    assert s[11].metadata.Signal.quantity == ""
+    assert s[12].metadata.General.title == "Channel#4"
+    assert s[12].metadata.Signal.quantity == ""
+
 
 class testSyncFile:
     def setup_method(self, method):
@@ -106,7 +102,7 @@ class testSyncFile:
         assert om.Room_temperature == 21
         assert om.Sample == "Gold"
         assert om.System_version == "G+"
-    
+
     def test_read_data(self):
         expected_data = np.load(
             os.path.join(dirpath, "StubExperiment_Synchronized data.npy")
@@ -136,7 +132,6 @@ class testSyncFileCSVreader:
             "Channel#4",
         ]
 
-
     def test_read_data(self):
         dicts = (
             self.isf._data_dictionary[key] for key in self.isf.logged_quantity_name_list
@@ -146,9 +141,6 @@ class testSyncFileCSVreader:
             os.path.join(dirpath, "StubExperiment_Synchronized data.npy")
         )
         np.testing.assert_allclose(data.T, expected_data)
-
-
-
 
 
 # Loading a random csv file
@@ -174,7 +166,7 @@ def test_loading_invalid_impulse_filename():
 # Test raw data file
 
 
-class testRawFile():
+class testRawFile:
     def setup_method(self, method):
         filename = os.path.join(dirpath, "StubExperiment_Heat raw.csv")
         self.s_list = hs.load(filename, reader="impulse")

--- a/rsciio/tests/test_io.py
+++ b/rsciio/tests/test_io.py
@@ -96,43 +96,50 @@ class TestIOOverwriting:
     def teardown_method(self, method):
         self._clean_file()
 
-class TestNonUniformAxisCheck:
 
+class TestNonUniformAxisCheck:
     def setup_method(self, method):
-        axis = DataAxis(axis = 1/(np.arange(10)+1), navigate = False)
-        self.s = Signal1D(np.arange(10), axes=(axis.get_axis_dictionary(), ))
+        axis = DataAxis(axis=1 / (np.arange(10) + 1), navigate=False)
+        self.s = Signal1D(np.arange(10), axes=(axis.get_axis_dictionary(),))
         # make sure we start from a clean state
-    
+
     def test_io_nonuniform(self):
-        assert(self.s.axes_manager[0].is_uniform == False)
-        self.s.save('tmp.hspy', overwrite = True)
-        with pytest.raises(TypeError, match = "not supported for non-uniform"):
-            self.s.save('tmp.msa', overwrite = True)
+        assert self.s.axes_manager[0].is_uniform == False
+        self.s.save("tmp.hspy", overwrite=True)
+        with pytest.raises(TypeError, match="not supported for non-uniform"):
+            self.s.save("tmp.msa", overwrite=True)
 
     def test_nonuniform_writer_characteristic(self):
         for plugin in IO_PLUGINS:
             if not "non_uniform_axis" in plugin:
-                print(plugin.format_name + ' IO-plugin is missing the '
-                      'characteristic `non_uniform_axis`')
+                print(
+                    plugin.format_name + " IO-plugin is missing the "
+                    "characteristic `non_uniform_axis`"
+                )
 
     def test_nonuniform_error(self):
-        assert(self.s.axes_manager[0].is_uniform == False)
+        assert self.s.axes_manager[0].is_uniform == False
         incompatible_writers = [
             plugin["file_extensions"][plugin["default_extension"]]
-            for plugin in IO_PLUGINS if (plugin["writes"] is True or
-                      plugin["writes"] is not False and [1, 0] in plugin["writes"])
-                      and not plugin["non_uniform_axis"]]
+            for plugin in IO_PLUGINS
+            if (
+                plugin["writes"] is True
+                or plugin["writes"] is not False
+                and [1, 0] in plugin["writes"]
+            )
+            and not plugin["non_uniform_axis"]
+        ]
         for ext in incompatible_writers:
-            with pytest.raises(TypeError, match = "not supported for non-uniform"):
-                filename = 'tmp.' + ext
-                self.s.save(filename, overwrite = True)
+            with pytest.raises(TypeError, match="not supported for non-uniform"):
+                filename = "tmp." + ext
+                self.s.save(filename, overwrite=True)
 
     def teardown_method(self):
-        if os.path.exists('tmp.hspy'):
-            os.remove('tmp.hspy')
-        if os.path.exists('tmp.msa'):
-            os.remove('tmp.msa')
-            
+        if os.path.exists("tmp.hspy"):
+            os.remove("tmp.hspy")
+        if os.path.exists("tmp.msa"):
+            os.remove("tmp.msa")
+
 
 def test_glob_wildcards():
     s = Signal1D(np.arange(10))
@@ -155,7 +162,10 @@ def test_glob_wildcards():
         t = hs.load(os.path.join(dirpath, "temp*.hspy"))
         assert len(t) == 2
 
-        t = hs.load(os.path.join(dirpath, "temp[*].hspy"), escape_square_brackets=True,)
+        t = hs.load(
+            os.path.join(dirpath, "temp[*].hspy"),
+            escape_square_brackets=True,
+        )
         assert len(t) == 2
 
         with pytest.raises(ValueError, match="No filename matches the pattern"):
@@ -182,7 +192,7 @@ def test_file_not_found_error():
         if os.path.exists(temp_fname):
             os.remove(temp_fname)
 
-        with pytest.raises(ValueError, match='No filename matches the pattern'):
+        with pytest.raises(ValueError, match="No filename matches the pattern"):
             _ = hs.load(temp_fname)
 
         with pytest.raises(FileNotFoundError):
@@ -257,7 +267,9 @@ def test_load_original_metadata():
         assert s.original_metadata.as_dictionary() != {}
 
         t = hs.load(Path(dirpath, "temp.hspy"))
-        assert t.original_metadata.as_dictionary() == s.original_metadata.as_dictionary()
+        assert (
+            t.original_metadata.as_dictionary() == s.original_metadata.as_dictionary()
+        )
 
         t = hs.load(Path(dirpath, "temp.hspy"), load_original_metadata=False)
         assert t.original_metadata.as_dictionary() == {}
@@ -269,37 +281,34 @@ def test_load_save_filereader_metadata():
 
     my_path = os.path.dirname(__file__)
     s = hs.load(os.path.join(my_path, "msa_files", "example1.msa"))
-    assert s.metadata.General.FileIO.Number_0.io_plugin == \
-           'rsciio.msa.api'
-    assert s.metadata.General.FileIO.Number_0.operation == 'load'
+    assert s.metadata.General.FileIO.Number_0.io_plugin == "rsciio.msa.api"
+    assert s.metadata.General.FileIO.Number_0.operation == "load"
     assert s.metadata.General.FileIO.Number_0.hyperspy_version == hs_version
 
     with tempfile.TemporaryDirectory() as dirpath:
         f = os.path.join(dirpath, "temp")
         s.save(f)
         expected = {
-            '0': {
-                'io_plugin': 'rsciio.msa.api',
-                'operation': 'load',
-                'hyperspy_version': hs_version
+            "0": {
+                "io_plugin": "rsciio.msa.api",
+                "operation": "load",
+                "hyperspy_version": hs_version,
             },
-            '1': {
-                'io_plugin': 'rsciio.hspy.api',
-                'operation': 'save',
-                'hyperspy_version': hs_version
+            "1": {
+                "io_plugin": "rsciio.hspy.api",
+                "operation": "save",
+                "hyperspy_version": hs_version,
             },
-            '2': {
-                'io_plugin': 'rsciio.hspy.api',
-                'operation': 'load',
-                'hyperspy_version': hs_version
+            "2": {
+                "io_plugin": "rsciio.hspy.api",
+                "operation": "load",
+                "hyperspy_version": hs_version,
             },
         }
         del s.metadata.General.FileIO.Number_0.timestamp  # runtime dependent
         del s.metadata.General.FileIO.Number_1.timestamp  # runtime dependent
-        assert \
-            s.metadata.General.FileIO.Number_0.as_dictionary() == expected['0']
-        assert \
-            s.metadata.General.FileIO.Number_1.as_dictionary() == expected['1']
+        assert s.metadata.General.FileIO.Number_0.as_dictionary() == expected["0"]
+        assert s.metadata.General.FileIO.Number_1.as_dictionary() == expected["1"]
 
         t = hs.load(Path(dirpath, "temp.hspy"))
         del t.metadata.General.FileIO.Number_0.timestamp  # runtime dependent

--- a/rsciio/tests/test_jeol.py
+++ b/rsciio/tests/test_jeol.py
@@ -34,45 +34,47 @@ def teardown_module(module):
     gc.collect()
 
 
-TESTS_FILE_PATH = Path(__file__).resolve().parent / 'JEOL_files'
-TESTS_FILE_PATH2 = TESTS_FILE_PATH / 'InvalidFrame'
+TESTS_FILE_PATH = Path(__file__).resolve().parent / "JEOL_files"
+TESTS_FILE_PATH2 = TESTS_FILE_PATH / "InvalidFrame"
 
-test_files = ['rawdata.ASW',
-              'View000_0000000.img',
-              'View000_0000001.map',
-              'View000_0000002.map',
-              'View000_0000003.map',
-              'View000_0000004.map',
-              'View000_0000005.map',
-              'View000_0000006.pts'
-              ]
+test_files = [
+    "rawdata.ASW",
+    "View000_0000000.img",
+    "View000_0000001.map",
+    "View000_0000002.map",
+    "View000_0000003.map",
+    "View000_0000004.map",
+    "View000_0000005.map",
+    "View000_0000006.pts",
+]
 
-test_files2 = ['dummy2.ASW',
-               'Dummy-Data_0000000.img',
-               'Dummy-Data_0000001.map',
-               'Dummy-Data_0000002.map',
-               'Dummy-Data_0000003.map',
-               'Dummy-Data_0000004.map',
-               'Dummy-Data_0000005.map',
-               'Dummy-Data_0000006.map',
-               'Dummy-Data_0000007.pts',
-               'Dummy-Data_0000008.apb',
-               'Dummy-Data_0000009.map',
-               'Dummy-Data_0000010.map',
-               'Dummy-Data_0000011.map',
-               'Dummy-Data_0000012.map',
-               'Dummy-Data_0000013.map',
-               'Dummy-Data_0000014.map',
-               'Dummy-Data_0000015.pts',
-               'Dummy-Data_0000016.apb',
-               'Dummy-Data_0000017.map',
-               'Dummy-Data_0000018.map',
-               'Dummy-Data_0000019.map',
-               'Dummy-Data_0000020.map',
-               'Dummy-Data_0000021.map',
-               'Dummy-Data_0000022.map',
-               'Dummy-Data_0000023.pts',
-               'Dummy-Data_0000024.APB',
+test_files2 = [
+    "dummy2.ASW",
+    "Dummy-Data_0000000.img",
+    "Dummy-Data_0000001.map",
+    "Dummy-Data_0000002.map",
+    "Dummy-Data_0000003.map",
+    "Dummy-Data_0000004.map",
+    "Dummy-Data_0000005.map",
+    "Dummy-Data_0000006.map",
+    "Dummy-Data_0000007.pts",
+    "Dummy-Data_0000008.apb",
+    "Dummy-Data_0000009.map",
+    "Dummy-Data_0000010.map",
+    "Dummy-Data_0000011.map",
+    "Dummy-Data_0000012.map",
+    "Dummy-Data_0000013.map",
+    "Dummy-Data_0000014.map",
+    "Dummy-Data_0000015.pts",
+    "Dummy-Data_0000016.apb",
+    "Dummy-Data_0000017.map",
+    "Dummy-Data_0000018.map",
+    "Dummy-Data_0000019.map",
+    "Dummy-Data_0000020.map",
+    "Dummy-Data_0000021.map",
+    "Dummy-Data_0000022.map",
+    "Dummy-Data_0000023.pts",
+    "Dummy-Data_0000024.APB",
 ]
 
 
@@ -84,40 +86,42 @@ def test_load_project():
     assert s[0].data.dtype == np.uint8
     assert s[0].data.shape == (512, 512)
     assert s[0].axes_manager.signal_dimension == 2
-    assert s[0].axes_manager[0].units == 'µm'
-    assert s[0].axes_manager[0].name == 'x'
-    assert s[0].axes_manager[1].units == 'µm'
-    assert s[0].axes_manager[1].name == 'y'
+    assert s[0].axes_manager[0].units == "µm"
+    assert s[0].axes_manager[0].name == "x"
+    assert s[0].axes_manager[1].units == "µm"
+    assert s[0].axes_manager[1].name == "y"
     # 1 to 16 files are a 16bit image of work area and elemental maps
     for map in s[:-1]:
         assert map.data.dtype == np.uint8
         assert map.data.shape == (512, 512)
         assert map.axes_manager.signal_dimension == 2
-        assert map.axes_manager[0].units == 'µm'
-        assert map.axes_manager[0].name == 'x'
-        assert map.axes_manager[1].units == 'µm'
-        assert map.axes_manager[1].name == 'y'
+        assert map.axes_manager[0].units == "µm"
+        assert map.axes_manager[0].name == "x"
+        assert map.axes_manager[1].units == "µm"
+        assert map.axes_manager[1].name == "y"
     # last file is the datacube
     assert s[-1].data.dtype == np.uint8
     assert s[-1].data.shape == (512, 512, 4096)
     assert s[-1].axes_manager.signal_dimension == 1
     assert s[-1].axes_manager.navigation_dimension == 2
-    assert s[-1].axes_manager[0].units == 'µm'
-    assert s[-1].axes_manager[0].name == 'x'
-    assert s[-1].axes_manager[1].units == 'µm'
-    assert s[-1].axes_manager[1].name == 'y'
-    assert s[-1].axes_manager[2].units == 'keV'
-    np.testing.assert_allclose(s[-1].axes_manager[2].offset, -0.000789965-0.00999866*96)
+    assert s[-1].axes_manager[0].units == "µm"
+    assert s[-1].axes_manager[0].name == "x"
+    assert s[-1].axes_manager[1].units == "µm"
+    assert s[-1].axes_manager[1].name == "y"
+    assert s[-1].axes_manager[2].units == "keV"
+    np.testing.assert_allclose(
+        s[-1].axes_manager[2].offset, -0.000789965 - 0.00999866 * 96
+    )
     np.testing.assert_allclose(s[-1].axes_manager[2].scale, 0.00999866)
-    assert s[-1].axes_manager[2].name == 'Energy'
+    assert s[-1].axes_manager[2].name == "Energy"
 
     # check scale (image)
-    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[1]
+    filename = TESTS_FILE_PATH / "Sample" / "00_View000" / test_files[1]
     s1 = hs.load(filename)
     np.testing.assert_allclose(s[0].axes_manager[0].scale, s1.axes_manager[0].scale)
     assert s[0].axes_manager[0].units == s1.axes_manager[0].units
     # check scale (pts)
-    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
+    filename = TESTS_FILE_PATH / "Sample" / "00_View000" / test_files[7]
     s2 = hs.load(filename)
     np.testing.assert_allclose(s[6].axes_manager[0].scale, s2.axes_manager[0].scale)
     assert s[6].axes_manager[0].units == s2.axes_manager[0].units
@@ -125,48 +129,46 @@ def test_load_project():
 
 def test_load_image():
     # test load work area haadf image
-    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[1]
+    filename = TESTS_FILE_PATH / "Sample" / "00_View000" / test_files[1]
     s = hs.load(filename)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (512, 512)
     assert s.axes_manager.signal_dimension == 2
-    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[0].units == "µm"
     np.testing.assert_allclose(s.axes_manager[0].scale, 0.00869140587747097)
-    assert s.axes_manager[0].name == 'x'
-    assert s.axes_manager[1].units == 'µm'
+    assert s.axes_manager[0].name == "x"
+    assert s.axes_manager[1].units == "µm"
     np.testing.assert_allclose(s.axes_manager[1].scale, 0.00869140587747097)
-    assert s.axes_manager[1].name == 'y'
+    assert s.axes_manager[1].name == "y"
 
 
-@pytest.mark.parametrize('SI_dtype', [np.int8, np.uint8])
+@pytest.mark.parametrize("SI_dtype", [np.int8, np.uint8])
 def test_load_datacube(SI_dtype):
     # test load eds datacube
-    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
+    filename = TESTS_FILE_PATH / "Sample" / "00_View000" / test_files[7]
     s = hs.load(filename, SI_dtype=SI_dtype, cutoff_at_kV=5)
     assert s.data.dtype == SI_dtype
     assert s.data.shape == (512, 512, 596)
     assert s.axes_manager.signal_dimension == 1
     assert s.axes_manager.navigation_dimension == 2
-    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[0].units == "µm"
     np.testing.assert_allclose(s.axes_manager[0].scale, 0.00869140587747097)
-    assert s.axes_manager[0].name == 'x'
-    assert s.axes_manager[1].units == 'µm'
+    assert s.axes_manager[0].name == "x"
+    assert s.axes_manager[1].units == "µm"
     np.testing.assert_allclose(s.axes_manager[1].scale, 0.00869140587747097)
-    assert s.axes_manager[1].name == 'y'
-    assert s.axes_manager[2].units == 'keV'
-    np.testing.assert_allclose(s.axes_manager[2].offset, -0.000789965-0.00999866*96)
+    assert s.axes_manager[1].name == "y"
+    assert s.axes_manager[2].units == "keV"
+    np.testing.assert_allclose(s.axes_manager[2].offset, -0.000789965 - 0.00999866 * 96)
     np.testing.assert_allclose(s.axes_manager[2].scale, 0.00999866)
-    assert s.axes_manager[2].name == 'Energy'
+    assert s.axes_manager[2].name == "Energy"
 
 
 def test_load_datacube_rebin_energy():
-    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
+    filename = TESTS_FILE_PATH / "Sample" / "00_View000" / test_files[7]
     s = hs.load(filename, cutoff_at_kV=0.1)
     s_sum = s.sum()
 
-    ref_data = hs.signals.Signal1D(
-        np.array([   3,   23,   77,  200,  487,  984, 1599, 2391])
-        )
+    ref_data = hs.signals.Signal1D(np.array([3, 23, 77, 200, 487, 984, 1599, 2391]))
     np.testing.assert_allclose(s_sum.data[88:96], ref_data.data)
 
     rebin_energy = 8
@@ -175,14 +177,14 @@ def test_load_datacube_rebin_energy():
 
     np.testing.assert_allclose(s2_sum.data[11:12], ref_data.data.sum())
 
-    with pytest.raises(ValueError, match='must be a multiple'):
+    with pytest.raises(ValueError, match="must be a multiple"):
         _ = hs.load(filename, rebin_energy=10)
 
 
 def test_load_datacube_cutoff_at_kV():
     gc.collect()
-    cutoff_at_kV = 10.
-    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
+    cutoff_at_kV = 10.0
+    filename = TESTS_FILE_PATH / "Sample" / "00_View000" / test_files[7]
     s = hs.load(filename, cutoff_at_kV=None)
     s2 = hs.load(filename, cutoff_at_kV=cutoff_at_kV)
 
@@ -213,45 +215,62 @@ def test_load_datacube_downsample():
 
     np.testing.assert_allclose(s_sum.data, s2_sum.data)
 
-    with pytest.raises(ValueError, match='must be a multiple'):
+    with pytest.raises(ValueError, match="must be a multiple"):
         _ = hs.load(filename, downsample=10)[-1]
 
     downsample = [8, 16]
     s = hs.load(filename, downsample=downsample)[-1]
-    assert s.axes_manager['x'].size * downsample[0] == 512
-    assert s.axes_manager['y'].size * downsample[1] == 512
+    assert s.axes_manager["x"].size * downsample[0] == 512
+    assert s.axes_manager["y"].size * downsample[1] == 512
 
-    with pytest.raises(ValueError, match='must be a multiple'):
+    with pytest.raises(ValueError, match="must be a multiple"):
         _ = hs.load(filename, downsample=[256, 100])[-1]
 
-    with pytest.raises(ValueError, match='must be a multiple'):
+    with pytest.raises(ValueError, match="must be a multiple"):
         _ = hs.load(filename, downsample=[100, 256])[-1]
 
 
 def test_load_datacube_frames():
     rebin_energy = 2048
-    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
+    filename = TESTS_FILE_PATH / "Sample" / "00_View000" / test_files[7]
     s = hs.load(filename, sum_frames=True, rebin_energy=rebin_energy)
     assert s.data.shape == (512, 512, 2)
     s_frame = hs.load(filename, sum_frames=False, rebin_energy=rebin_energy)
     assert s_frame.data.shape == (14, 512, 512, 2)
-    np.testing.assert_allclose(s_frame.sum(axis='Frame').data, s.data)
-    np.testing.assert_allclose(s_frame.sum(axis=['x', 'y', 'Energy']).data,
-                               np.array([22355, 21975, 22038, 21904, 21846,
-                                         22115, 22021, 21917, 22123, 21919,
-                                         22141, 22024, 22086, 21797]))
+    np.testing.assert_allclose(s_frame.sum(axis="Frame").data, s.data)
+    np.testing.assert_allclose(
+        s_frame.sum(axis=["x", "y", "Energy"]).data,
+        np.array(
+            [
+                22355,
+                21975,
+                22038,
+                21904,
+                21846,
+                22115,
+                22021,
+                21917,
+                22123,
+                21919,
+                22141,
+                22024,
+                22086,
+                21797,
+            ]
+        ),
+    )
 
 
-@pytest.mark.parametrize('filename_as_string', [True, False])
+@pytest.mark.parametrize("filename_as_string", [True, False])
 def test_load_eds_file(filename_as_string):
-    filename = TESTS_FILE_PATH / 'met03.EDS'
+    filename = TESTS_FILE_PATH / "met03.EDS"
     if filename_as_string:
         filename = str(filename)
     s = hs.load(filename)
     assert isinstance(s, hs.signals.EDSTEMSpectrum)
     assert s.data.shape == (2048,)
     axis = s.axes_manager[0]
-    assert axis.name == 'Energy'
+    assert axis.name == "Energy"
     assert axis.size == 2048
     assert axis.offset == -0.00176612
     assert axis.scale == 0.0100004
@@ -260,32 +279,38 @@ def test_load_eds_file(filename_as_string):
     del s.metadata.General.FileIO.Number_0.timestamp
 
     md_dict = s.metadata.as_dictionary()
-    assert md_dict['General'] == {'original_filename': 'met03.EDS',
-                                  'time': '14:14:51',
-                                  'date': '2018-06-25',
-                                  'title': 'EDX',
-                                  'FileIO': {
-                                    '0': {
-                                        'operation': 'load',
-                                        'hyperspy_version': hs_version,
-                                        'io_plugin':
-                                            'rsciio.jeol.api'
-                                    }
-                                  }
-                                  }
-    TEM_dict = md_dict['Acquisition_instrument']['TEM']
-    assert TEM_dict == {'beam_energy': 200.0,
-                        'Detector': {'EDS': {'azimuth_angle': 90.0,
-                                             'detector_type': 'EX24075JGT',
-                                             'elevation_angle': 22.299999237060547,
-                                             'energy_resolution_MnKa': 138.0,
-                                             'live_time': 30.0}},
-                        'Stage': {'tilt_alpha': 0.0}}
+    assert md_dict["General"] == {
+        "original_filename": "met03.EDS",
+        "time": "14:14:51",
+        "date": "2018-06-25",
+        "title": "EDX",
+        "FileIO": {
+            "0": {
+                "operation": "load",
+                "hyperspy_version": hs_version,
+                "io_plugin": "rsciio.jeol.api",
+            }
+        },
+    }
+    TEM_dict = md_dict["Acquisition_instrument"]["TEM"]
+    assert TEM_dict == {
+        "beam_energy": 200.0,
+        "Detector": {
+            "EDS": {
+                "azimuth_angle": 90.0,
+                "detector_type": "EX24075JGT",
+                "elevation_angle": 22.299999237060547,
+                "energy_resolution_MnKa": 138.0,
+                "live_time": 30.0,
+            }
+        },
+        "Stage": {"tilt_alpha": 0.0},
+    }
 
 
 def test_shift_jis_encoding():
     # See https://github.com/hyperspy/hyperspy/issues/2812
-    filename = TESTS_FILE_PATH / '181019-BN.ASW'
+    filename = TESTS_FILE_PATH / "181019-BN.ASW"
     # make sure we can open the file
     with open(filename, "br"):
         pass
@@ -297,14 +322,14 @@ def test_shift_jis_encoding():
 
 
 def test_number_of_frames():
-    dir1 = TESTS_FILE_PATH / 'Sample' / '00_View000'
-    dir2 = TESTS_FILE_PATH / 'InvalidFrame' / 'Sample' / '00_Dummy-Data'
+    dir1 = TESTS_FILE_PATH / "Sample" / "00_View000"
+    dir2 = TESTS_FILE_PATH / "InvalidFrame" / "Sample" / "00_Dummy-Data"
 
     test_list = [  # dir, file, num_frames, num_valid_frames
-        [ dir1, test_files[7], 14, 14 ],
-        [ dir2, test_files2[8], 1, 0 ],
-        [ dir2, test_files2[16], 2, 1 ],
-        [ dir2, test_files2[24], 1, 1 ]
+        [dir1, test_files[7], 14, 14],
+        [dir2, test_files2[8], 1, 0],
+        [dir2, test_files2[16], 2, 1],
+        [dir2, test_files2[24], 1, 1],
     ]
 
     for item in test_list:
@@ -312,84 +337,127 @@ def test_number_of_frames():
         fname = str(dirname / filename)
 
         # Count number of frames including incomplete frame
-        data = hs.load(fname, sum_frames = False, only_valid_data = False,
-                       downsample=[32,32], rebin_energy=512, SI_dtype=np.int32)
+        data = hs.load(
+            fname,
+            sum_frames=False,
+            only_valid_data=False,
+            downsample=[32, 32],
+            rebin_energy=512,
+            SI_dtype=np.int32,
+        )
         assert data.axes_manager["Frame"].size == frames
 
         # Count number of valid frames
-        data = hs.load(fname, sum_frames = False, only_valid_data = True,
-                       downsample=[32,32], rebin_energy=512, SI_dtype=np.int32)
+        data = hs.load(
+            fname,
+            sum_frames=False,
+            only_valid_data=True,
+            downsample=[32, 32],
+            rebin_energy=512,
+            SI_dtype=np.int32,
+        )
         assert data.axes_manager["Frame"].size == valid
 
 
 def test_em_image_in_pts():
     dir1 = TESTS_FILE_PATH
-    dir2 = TESTS_FILE_PATH / 'InvalidFrame'
-    dir2p = dir2 / 'Sample' / '00_Dummy-Data'
+    dir2 = TESTS_FILE_PATH / "InvalidFrame"
+    dir2p = dir2 / "Sample" / "00_Dummy-Data"
 
     # no SEM/STEM image
-    s = hs.load(dir1 / test_files[0],
-                read_em_image=False, only_valid_data=False,
-                cutoff_at_kV=1)
+    s = hs.load(
+        dir1 / test_files[0], read_em_image=False, only_valid_data=False, cutoff_at_kV=1
+    )
     assert len(s) == 7
 
-    s = hs.load(dir1 / test_files[0],
-                read_em_image=True, only_valid_data=False,
-                cutoff_at_kV=1)
+    s = hs.load(
+        dir1 / test_files[0], read_em_image=True, only_valid_data=False, cutoff_at_kV=1
+    )
     assert len(s) == 7
 
     # with SEM/STEM image
-    s = hs.load(dir2 / test_files2[0],
-                read_em_image=False, only_valid_data=False,
-                cutoff_at_kV=1)
+    s = hs.load(
+        dir2 / test_files2[0],
+        read_em_image=False,
+        only_valid_data=False,
+        cutoff_at_kV=1,
+    )
     assert len(s) == 22
-    s = hs.load(dir2 / test_files2[0],
-                read_em_image=True, only_valid_data=False,
-                cutoff_at_kV=1)
+    s = hs.load(
+        dir2 / test_files2[0], read_em_image=True, only_valid_data=False, cutoff_at_kV=1
+    )
     assert len(s) == 25
-    assert s[8].metadata.General.title == "S(T)EM Image extracted from " + s[8].metadata.General.original_filename
-    assert s[8].data[38,15] == 87
-    assert s[8].data[38,16] == 0
+    assert (
+        s[8].metadata.General.title
+        == "S(T)EM Image extracted from " + s[8].metadata.General.original_filename
+    )
+    assert s[8].data[38, 15] == 87
+    assert s[8].data[38, 16] == 0
 
     # integrate SEM/STEM image along frame axis
-    s = hs.load(dir2p / test_files2[16], read_em_image=True,
-                only_valid_data=False, sum_frames=True, cutoff_at_kV=1,
-                frame_list=[0,0,0,1])
-    assert(s[1].data[0,0] == 87*4)
-    assert(s[1].data[63,63] == 87*3)
+    s = hs.load(
+        dir2p / test_files2[16],
+        read_em_image=True,
+        only_valid_data=False,
+        sum_frames=True,
+        cutoff_at_kV=1,
+        frame_list=[0, 0, 0, 1],
+    )
+    assert s[1].data[0, 0] == 87 * 4
+    assert s[1].data[63, 63] == 87 * 3
 
-    s = hs.load(dir2p / test_files2[16], read_em_image=True,
-                only_valid_data=False, sum_frames=False, cutoff_at_kV=1)
-    s2 = hs.load(dir2p / test_files2[16], read_em_image=True,
-                 only_valid_data=False, sum_frames=True, cutoff_at_kV=1)
+    s = hs.load(
+        dir2p / test_files2[16],
+        read_em_image=True,
+        only_valid_data=False,
+        sum_frames=False,
+        cutoff_at_kV=1,
+    )
+    s2 = hs.load(
+        dir2p / test_files2[16],
+        read_em_image=True,
+        only_valid_data=False,
+        sum_frames=True,
+        cutoff_at_kV=1,
+    )
     s1 = [s[0].data.sum(axis=0), s[1].data.sum(axis=0)]
     assert np.array_equal(s1[0], s2[0].data)
     assert np.array_equal(s1[1], s2[1].data)
 
 
 def test_pts_lazy():
-    dir2 = TESTS_FILE_PATH / 'InvalidFrame'
-    dir2p = dir2 / 'Sample' / '00_Dummy-Data'
-    s = hs.load(dir2p / test_files2[16], read_em_image=True,
-                only_valid_data=False, sum_frames=False, lazy=True)
-    s1 = [s[0].data.sum(axis=0).compute(),
-          s[1].data.sum(axis=0).compute()]
-    s2 = hs.load(dir2p / test_files2[16], read_em_image=True,
-                only_valid_data=False, sum_frames=True, lazy=False)
+    dir2 = TESTS_FILE_PATH / "InvalidFrame"
+    dir2p = dir2 / "Sample" / "00_Dummy-Data"
+    s = hs.load(
+        dir2p / test_files2[16],
+        read_em_image=True,
+        only_valid_data=False,
+        sum_frames=False,
+        lazy=True,
+    )
+    s1 = [s[0].data.sum(axis=0).compute(), s[1].data.sum(axis=0).compute()]
+    s2 = hs.load(
+        dir2p / test_files2[16],
+        read_em_image=True,
+        only_valid_data=False,
+        sum_frames=True,
+        lazy=False,
+    )
     assert np.array_equal(s1[0], s2[0].data)
     assert np.array_equal(s1[1], s2[1].data)
 
 
 def test_pts_frame_shift():
-    file = TESTS_FILE_PATH2 / 'Sample' / '00_Dummy-Data' / test_files2[16]
+    file = TESTS_FILE_PATH2 / "Sample" / "00_Dummy-Data" / test_files2[16]
 
     # without frame shift
-    ref = hs.load(file, read_em_image=True, only_valid_data=False,
-                  sum_frames=False, lazy=False)
+    ref = hs.load(
+        file, read_em_image=True, only_valid_data=False, sum_frames=False, lazy=False
+    )
     #         x, y, en
-    points=[[24,23,106],[21,16,106]]
-    values=[3,1]
-    targets=np.asarray([[2,3,106],[20,3,100],[4,20,100]],dtype=np.int16)
+    points = [[24, 23, 106], [21, 16, 106]]
+    values = [3, 1]
+    targets = np.asarray([[2, 3, 106], [20, 3, 100], [4, 20, 100]], dtype=np.int16)
 
     # check values before shift
     d0 = np.zeros(len(points), dtype=np.int16)
@@ -401,33 +469,42 @@ def test_pts_frame_shift():
         assert d0[frame] == values[frame]
 
     for target in targets:
-        sfts = np.zeros((ref[0].axes_manager['Frame'].size,3),dtype=np.int16)
-        for frame in range(ref[0].axes_manager['Frame'].size):
+        sfts = np.zeros((ref[0].axes_manager["Frame"].size, 3), dtype=np.int16)
+        for frame in range(ref[0].axes_manager["Frame"].size):
             origin = points[frame]
             sfts[frame] = np.asarray(target) - np.asarray(origin)
-        shifts = sfts[:,[1,0,2]]
+        shifts = sfts[:, [1, 0, 2]]
 
         # test frame shifts for dense (normal) loading
-        s0 = hs.load(file, read_em_image=True,
-                     only_valid_data=False, sum_frames=False,
-                     frame_shifts = shifts, lazy=False)
+        s0 = hs.load(
+            file,
+            read_em_image=True,
+            only_valid_data=False,
+            sum_frames=False,
+            frame_shifts=shifts,
+            lazy=False,
+        )
 
-
-        for frame in range(s0[0].axes_manager['Frame'].size):
+        for frame in range(s0[0].axes_manager["Frame"].size):
             origin = points[frame]
             sfts0 = s0[0].original_metadata.jeol_pts_frame_shifts[frame]
-            pos = [origin[0]+sfts0[1], origin[1]+sfts0[0], origin[2]+sfts0[2]]
+            pos = [origin[0] + sfts0[1], origin[1] + sfts0[0], origin[2] + sfts0[2]]
             d1[frame] = s0[0].data[frame, pos[1], pos[0], pos[2]]
             assert d1[frame] == d0[frame]
 
-	# test frame shifts for lazy loading
-        s1 = hs.load(file, read_em_image=True,
-                     only_valid_data=False, sum_frames=False,
-                     frame_shifts=shifts, lazy=True)
+        # test frame shifts for lazy loading
+        s1 = hs.load(
+            file,
+            read_em_image=True,
+            only_valid_data=False,
+            sum_frames=False,
+            frame_shifts=shifts,
+            lazy=True,
+        )
         dt = s1[0].data.compute()
-        for frame in range(s0[0].axes_manager['Frame'].size):
+        for frame in range(s0[0].axes_manager["Frame"].size):
             origin = points[frame]
             sfts0 = s0[0].original_metadata.jeol_pts_frame_shifts[frame]
-            pos = [origin[0]+sfts0[1], origin[1]+sfts0[0], origin[2]+sfts0[2]]
+            pos = [origin[0] + sfts0[1], origin[1] + sfts0[0], origin[2] + sfts0[2]]
             d2[frame] = dt[frame, pos[1], pos[0], pos[2]]
             assert d2[frame] == d0[frame]

--- a/rsciio/tests/test_mrcz.py
+++ b/rsciio/tests/test_mrcz.py
@@ -34,21 +34,21 @@ from hyperspy import __version__ as hs_version
 mrcz = pytest.importorskip("mrcz", reason="mrcz not installed")
 
 
-#==============================================================================
+# ==============================================================================
 # MRCZ Test
 #
 # Internal python-only test. Build a random image and save and re-load it.
-#==============================================================================
+# ==============================================================================
 tmpDir = tempfile.gettempdir()
 
 MAX_ASYNC_TIME = 10.0
-dtype_list = ['float32', 'int8', 'int16', 'uint16', 'complex64']
+dtype_list = ["float32", "int8", "int16", "uint16", "complex64"]
 
 
 def _generate_parameters():
     parameters = []
     for dtype in dtype_list:
-        for compressor in [None, 'zstd', 'lz4']:
+        for compressor in [None, "zstd", "lz4"]:
             for clevel in [1, 9]:
                 for lazy in [True, False]:
                     parameters.append([dtype, compressor, clevel, lazy])
@@ -56,22 +56,29 @@ def _generate_parameters():
 
 
 class TestPythonMrcz:
-
     def setup_method(self, method):
         pass
 
-    def compareSaveLoad(self, testShape, dtype='int8', compressor=None,
-                        clevel=1, lazy=False, do_async=False, **kwargs):
+    def compareSaveLoad(
+        self,
+        testShape,
+        dtype="int8",
+        compressor=None,
+        clevel=1,
+        lazy=False,
+        do_async=False,
+        **kwargs
+    ):
         # This is the main function which reads and writes from disk.
-        mrcName = os.path.join(
-            tmpDir, "testMage_{}_lazy_{}.mrcz".format(dtype, lazy))
+        mrcName = os.path.join(tmpDir, "testMage_{}_lazy_{}.mrcz".format(dtype, lazy))
 
         dtype = np.dtype(dtype)
-        if dtype == 'float32' or dtype == 'float64':
+        if dtype == "float32" or dtype == "float64":
             testData = np.random.normal(size=testShape).astype(dtype)
-        elif dtype == 'complex64' or dtype == 'complex128':
+        elif dtype == "complex64" or dtype == "complex128":
             testData = np.random.normal(size=testShape).astype(
-                dtype) + 1.0j * np.random.normal(size=testShape).astype(dtype)
+                dtype
+            ) + 1.0j * np.random.normal(size=testShape).astype(dtype)
         else:  # integers
             testData = np.random.randint(10, size=testShape).astype(dtype)
 
@@ -80,54 +87,64 @@ class TestPythonMrcz:
             testSignal = testSignal.as_lazy()
 
         # Add "File" metadata to testSignal
-        testSignal.metadata.General.add_dictionary({
-            'FileIO': {
-                '0': {
-                    'operation': 'load',
-                    'hyperspy_version': hs_version,
-                    'io_plugin': 'rsciio.mrcz',
-                    'timestamp': datetime.now().astimezone().isoformat()
+        testSignal.metadata.General.add_dictionary(
+            {
+                "FileIO": {
+                    "0": {
+                        "operation": "load",
+                        "hyperspy_version": hs_version,
+                        "io_plugin": "rsciio.mrcz",
+                        "timestamp": datetime.now().astimezone().isoformat(),
+                    }
                 }
             }
-        })
+        )
 
         # Unfortunately one cannot iterate over axes_manager in a Pythonic way
         # for axis in testSignal.axes_manager:
-        testSignal.axes_manager[0].name = 'z'
+        testSignal.axes_manager[0].name = "z"
         testSignal.axes_manager[0].scale = np.random.uniform(low=0.0, high=1.0)
-        testSignal.axes_manager[0].units = 'nm'
-        testSignal.axes_manager[1].name = 'x'
+        testSignal.axes_manager[0].units = "nm"
+        testSignal.axes_manager[1].name = "x"
         testSignal.axes_manager[1].scale = np.random.uniform(low=0.0, high=1.0)
-        testSignal.axes_manager[1].units = 'nm'
-        testSignal.axes_manager[2].name = 'y'
+        testSignal.axes_manager[1].units = "nm"
+        testSignal.axes_manager[2].name = "y"
         testSignal.axes_manager[2].scale = np.random.uniform(low=0.0, high=1.0)
-        testSignal.axes_manager[2].units = 'nm'
+        testSignal.axes_manager[2].units = "nm"
 
         # Meta-data that goes into MRC fixed header
-        testSignal.metadata.set_item(
-            'Acquisition_instrument.TEM.beam_energy', 300.0)
+        testSignal.metadata.set_item("Acquisition_instrument.TEM.beam_energy", 300.0)
         # Meta-data that goes into JSON extended header
+        testSignal.metadata.set_item("Acquisition_instrument.TEM.magnification", 25000)
         testSignal.metadata.set_item(
-            'Acquisition_instrument.TEM.magnification', 25000)
-        testSignal.metadata.set_item(
-            'Signal.Noise_properties.Variance_linear_model.gain_factor', 1.0)
+            "Signal.Noise_properties.Variance_linear_model.gain_factor", 1.0
+        )
 
-        save(mrcName, testSignal, compressor=compressor,
-             clevel=clevel, do_async=do_async, **kwargs)
+        save(
+            mrcName,
+            testSignal,
+            compressor=compressor,
+            clevel=clevel,
+            do_async=do_async,
+            **kwargs
+        )
         if do_async:
             # Poll file on disk since we don't return the
             # concurrent.futures.Future
             t_stop = perf_counter() + MAX_ASYNC_TIME
             sleep(0.005)
-            while(perf_counter() < t_stop):
+            while perf_counter() < t_stop:
                 try:
-                    fh = open(mrcName, 'a')
+                    fh = open(mrcName, "a")
                     fh.close()
                     break
                 except IOError:
                     sleep(0.001)
-            print("Time to save file: {} s".format(
-                perf_counter() - (t_stop - MAX_ASYNC_TIME)))
+            print(
+                "Time to save file: {} s".format(
+                    perf_counter() - (t_stop - MAX_ASYNC_TIME)
+                )
+            )
             sleep(0.1)
 
         reSignal = load(mrcName)
@@ -141,41 +158,45 @@ class TestPythonMrcz:
             reSignal.metadata.General.FileIO.Number_0.timestamp
         )
 
-        npt.assert_array_almost_equal(
-            testSignal.data.shape,
-            reSignal.data.shape)
+        npt.assert_array_almost_equal(testSignal.data.shape, reSignal.data.shape)
         npt.assert_array_almost_equal(testSignal.data, reSignal.data)
         npt.assert_almost_equal(
             testSignal.metadata.Acquisition_instrument.TEM.beam_energy,
-            reSignal.metadata.Acquisition_instrument.TEM.beam_energy)
+            reSignal.metadata.Acquisition_instrument.TEM.beam_energy,
+        )
         npt.assert_almost_equal(
             testSignal.metadata.Acquisition_instrument.TEM.magnification,
-            reSignal.metadata.Acquisition_instrument.TEM.magnification)
+            reSignal.metadata.Acquisition_instrument.TEM.magnification,
+        )
 
-        for aName in ['x', 'y', 'z']:
+        for aName in ["x", "y", "z"]:
             npt.assert_equal(
-                testSignal.axes_manager[aName].size,
-                reSignal.axes_manager[aName].size)
+                testSignal.axes_manager[aName].size, reSignal.axes_manager[aName].size
+            )
             npt.assert_almost_equal(
-                testSignal.axes_manager[aName].scale,
-                reSignal.axes_manager[aName].scale)
+                testSignal.axes_manager[aName].scale, reSignal.axes_manager[aName].scale
+            )
 
-        if dtype == 'complex64':
+        if dtype == "complex64":
             assert isinstance(reSignal, signals.ComplexSignal2D)
         else:
             assert isinstance(reSignal, signals.Signal2D)
 
         # delete last load operation from reSignal metadata so we can compare
         del reSignal.metadata.General.FileIO.Number_2
-        assert_deep_almost_equal(testSignal.axes_manager.as_dictionary(),
-                                 reSignal.axes_manager.as_dictionary())
-        assert_deep_almost_equal(testSignal.metadata.as_dictionary(),
-                                 reSignal.metadata.as_dictionary())
+        assert_deep_almost_equal(
+            testSignal.axes_manager.as_dictionary(),
+            reSignal.axes_manager.as_dictionary(),
+        )
+        assert_deep_almost_equal(
+            testSignal.metadata.as_dictionary(), reSignal.metadata.as_dictionary()
+        )
 
         return reSignal
 
-    @pytest.mark.parametrize(("dtype", "compressor", "clevel", "lazy"),
-                             _generate_parameters())
+    @pytest.mark.parametrize(
+        ("dtype", "compressor", "clevel", "lazy"), _generate_parameters()
+    )
     def test_MRC(self, dtype, compressor, clevel, lazy):
         t_start = perf_counter()
 
@@ -188,21 +209,34 @@ class TestPythonMrcz:
 
         if not blosc_installed and compressor is not None:
             with pytest.raises(ImportError):
-                return self.compareSaveLoad([2, 64, 32], dtype=dtype,
-                                            compressor=compressor,
-                                            clevel=clevel, lazy=lazy)
+                return self.compareSaveLoad(
+                    [2, 64, 32],
+                    dtype=dtype,
+                    compressor=compressor,
+                    clevel=clevel,
+                    lazy=lazy,
+                )
         else:
-            return self.compareSaveLoad([2, 64, 32], dtype=dtype,
-                                        compressor=compressor,
-                                        clevel=clevel, lazy=lazy)
-        print("MRCZ test ({}, {}, {}, lazy:{}) finished in {} s".format(
-            dtype, compressor, clevel, lazy, perf_counter() - t_start))
+            return self.compareSaveLoad(
+                [2, 64, 32],
+                dtype=dtype,
+                compressor=compressor,
+                clevel=clevel,
+                lazy=lazy,
+            )
+        print(
+            "MRCZ test ({}, {}, {}, lazy:{}) finished in {} s".format(
+                dtype, compressor, clevel, lazy, perf_counter() - t_start
+            )
+        )
 
     @pytest.mark.parametrize("dtype", dtype_list)
     def test_Async(self, dtype):
-        blosc = pytest.importorskip('blosc', reason="skipping test_async, requires blosc")
+        blosc = pytest.importorskip(
+            "blosc", reason="skipping test_async, requires blosc"
+        )
         t_start = perf_counter()
-        self.compareSaveLoad([2, 64, 32], dtype=dtype, compressor='zstd',
-                             clevel=1, do_async=True)
-        print("MRCZ Asychronous test finished in {} s".format(
-            perf_counter() - t_start))
+        self.compareSaveLoad(
+            [2, 64, 32], dtype=dtype, compressor="zstd", clevel=1, do_async=True
+        )
+        print("MRCZ Asychronous test finished in {} s".format(perf_counter() - t_start))

--- a/rsciio/tests/test_msa.py
+++ b/rsciio/tests/test_msa.py
@@ -8,206 +8,229 @@ from hyperspy import __version__ as hs_version
 
 my_path = os.path.dirname(__file__)
 
-example1_TEM = {'Detector': {'EELS': {'collection_angle': 3.4,
-                                      'collection_angle_units': "mR",
-                                      'dwell_time': 100.0,
-                                      'dwell_time_units': "ms"}},
-                'beam_current': 12.345,
-                'beam_current_units': "nA",
-                'beam_energy': 120.0,
-                'beam_energy_units': "kV",
-                'convergence_angle': 1.5,
-                'convergence_angle_units': "mR"}
+example1_TEM = {
+    "Detector": {
+        "EELS": {
+            "collection_angle": 3.4,
+            "collection_angle_units": "mR",
+            "dwell_time": 100.0,
+            "dwell_time_units": "ms",
+        }
+    },
+    "beam_current": 12.345,
+    "beam_current_units": "nA",
+    "beam_energy": 120.0,
+    "beam_energy_units": "kV",
+    "convergence_angle": 1.5,
+    "convergence_angle_units": "mR",
+}
 
-example1_metadata = {'Acquisition_instrument': {'TEM': example1_TEM},
-                     'General': {'original_filename': "example1.msa",
-                                 'title': "NIO EELS OK SHELL",
-                                 'date': "1991-10-01",
-                                 'time': "12:00:00",
-                                 'FileIO': {'0': {
-                                     'operation': 'load',
-                                     'hyperspy_version': hs_version,
-                                     'io_plugin': 'rsciio.msa.api'}}
-                                 },
-                     'Sample': {'thickness': 50.0,
-                                'thickness_units': "nm"},
-                     'Signal': {# bit silly...
-                                'quantity': "Counts (Intensity)",
-                                'signal_type': 'EELS'},
-                     '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                               'unfolded': False,
-                                               'original_shape': None,
-                                               'signal_unfolded': False}}}
+example1_metadata = {
+    "Acquisition_instrument": {"TEM": example1_TEM},
+    "General": {
+        "original_filename": "example1.msa",
+        "title": "NIO EELS OK SHELL",
+        "date": "1991-10-01",
+        "time": "12:00:00",
+        "FileIO": {
+            "0": {
+                "operation": "load",
+                "hyperspy_version": hs_version,
+                "io_plugin": "rsciio.msa.api",
+            }
+        },
+    },
+    "Sample": {"thickness": 50.0, "thickness_units": "nm"},
+    "Signal": {"quantity": "Counts (Intensity)", "signal_type": "EELS"},  # bit silly...
+    "_HyperSpy": {
+        "Folding": {
+            "original_axes_manager": None,
+            "unfolded": False,
+            "original_shape": None,
+            "signal_unfolded": False,
+        }
+    },
+}
 minimum_md_om = {
-    'COMMENT': 'File created by HyperSpy version 1.1.2+dev',
-    'DATATYPE': 'Y',
-    'DATE': '',
-    'FORMAT': 'EMSA/MAS Spectral Data File',
-    'NCOLUMNS': 1.0,
-    'NPOINTS': 1.0,
-    'OFFSET': 0.0,
-    'OWNER': '',
-    'SIGNALTYPE': '',
-    'TIME': '',
-    'TITLE': '',
-    'VERSION': '1.0',
-    'XLABEL': '',
-    'XPERCHAN': 1.0,
-    'XUNITS': ''}
+    "COMMENT": "File created by HyperSpy version 1.1.2+dev",
+    "DATATYPE": "Y",
+    "DATE": "",
+    "FORMAT": "EMSA/MAS Spectral Data File",
+    "NCOLUMNS": 1.0,
+    "NPOINTS": 1.0,
+    "OFFSET": 0.0,
+    "OWNER": "",
+    "SIGNALTYPE": "",
+    "TIME": "",
+    "TITLE": "",
+    "VERSION": "1.0",
+    "XLABEL": "",
+    "XPERCHAN": 1.0,
+    "XUNITS": "",
+}
 
 
 example1_parameters = {
-    'BEAMDIAM -nm': 100.0,
-    'BEAMKV   -kV': 120.0,
-    'CHOFFSET': -168.0,
-    'COLLANGLE-mR': 3.4,
-    'CONVANGLE-mR': 1.5,
-    'DATATYPE': 'XY',
-    'DATE': '01-OCT-1991',
-    'DWELLTIME-ms': 100.0,
-    'ELSDET': 'SERIAL',
-    'EMISSION -uA': 5.5,
-    'FORMAT': 'EMSA/MAS Spectral Data File',
-    'MAGCAM': 100.0,
-    'NCOLUMNS': 1.0,
-    'NPOINTS': 20.0,
-    'OFFSET': 520.13,
-    'OPERMODE': 'IMAG',
-    'OWNER': 'EMSA/MAS TASK FORCE',
-    'PROBECUR -nA': 12.345,
-    'SIGNALTYPE': 'ELS',
-    'THICKNESS-nm': 50.0,
-    'TIME': '12:00',
-    'TITLE': 'NIO EELS OK SHELL',
-    'VERSION': '1.0',
-    'XLABEL': 'Energy',
-    'XPERCHAN': 3.1,
-    'XUNITS': 'eV',
-    'YLABEL': 'Counts',
-    'YUNITS': 'Intensity'}
+    "BEAMDIAM -nm": 100.0,
+    "BEAMKV   -kV": 120.0,
+    "CHOFFSET": -168.0,
+    "COLLANGLE-mR": 3.4,
+    "CONVANGLE-mR": 1.5,
+    "DATATYPE": "XY",
+    "DATE": "01-OCT-1991",
+    "DWELLTIME-ms": 100.0,
+    "ELSDET": "SERIAL",
+    "EMISSION -uA": 5.5,
+    "FORMAT": "EMSA/MAS Spectral Data File",
+    "MAGCAM": 100.0,
+    "NCOLUMNS": 1.0,
+    "NPOINTS": 20.0,
+    "OFFSET": 520.13,
+    "OPERMODE": "IMAG",
+    "OWNER": "EMSA/MAS TASK FORCE",
+    "PROBECUR -nA": 12.345,
+    "SIGNALTYPE": "ELS",
+    "THICKNESS-nm": 50.0,
+    "TIME": "12:00",
+    "TITLE": "NIO EELS OK SHELL",
+    "VERSION": "1.0",
+    "XLABEL": "Energy",
+    "XPERCHAN": 3.1,
+    "XUNITS": "eV",
+    "YLABEL": "Counts",
+    "YUNITS": "Intensity",
+}
 
-example2_TEM = {'Detector': {'EDS': {'EDS_det': "SIWLS",
-                                     'azimuth_angle': 90.0,
-                                     'azimuth_angle_units': "dg",
-                                     'elevation_angle': 20.0,
-                                     'elevation_angle_units': 'dg',
-                                     'live_time': 100.0,
-                                     'live_time_units': "s",
-                                     'real_time': 150.0,
-                                     'real_time_units': "s"}},
-                'beam_current': 12.345,
-                'beam_current_units': "nA",
-                'beam_energy': 120.0,
-                'beam_energy_units': "kV",
-                'Stage': {'tilt_alpha': 45.0,
-                          'tilt_alpha_units': "dg"}}
+example2_TEM = {
+    "Detector": {
+        "EDS": {
+            "EDS_det": "SIWLS",
+            "azimuth_angle": 90.0,
+            "azimuth_angle_units": "dg",
+            "elevation_angle": 20.0,
+            "elevation_angle_units": "dg",
+            "live_time": 100.0,
+            "live_time_units": "s",
+            "real_time": 150.0,
+            "real_time_units": "s",
+        }
+    },
+    "beam_current": 12.345,
+    "beam_current_units": "nA",
+    "beam_energy": 120.0,
+    "beam_energy_units": "kV",
+    "Stage": {"tilt_alpha": 45.0, "tilt_alpha_units": "dg"},
+}
 
-example2_metadata = {'Acquisition_instrument': {'TEM': example2_TEM},
-                     'General': {'original_filename': "example2.msa",
-                                 'title': "NIO Windowless Spectra OK NiL",
-                                 'date': "1991-10-01",
-                                 'time': "12:00:00",
-                                 'FileIO': {'0': {
-                                     'operation': 'load',
-                                     'hyperspy_version': hs_version,
-                                     'io_plugin': 'rsciio.msa.api'}}
-                                 },
-                     'Sample': {'thickness': 50.0,
-                                'thickness_units': "nm"},
-                     'Signal': {'quantity': "X-RAY INTENSITY (Intensity)",
-                                'signal_type': 'EDS'},
-                     '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                               'unfolded': False,
-                                               'original_shape': None,
-                                               'signal_unfolded': False}}}
+example2_metadata = {
+    "Acquisition_instrument": {"TEM": example2_TEM},
+    "General": {
+        "original_filename": "example2.msa",
+        "title": "NIO Windowless Spectra OK NiL",
+        "date": "1991-10-01",
+        "time": "12:00:00",
+        "FileIO": {
+            "0": {
+                "operation": "load",
+                "hyperspy_version": hs_version,
+                "io_plugin": "rsciio.msa.api",
+            }
+        },
+    },
+    "Sample": {"thickness": 50.0, "thickness_units": "nm"},
+    "Signal": {"quantity": "X-RAY INTENSITY (Intensity)", "signal_type": "EDS"},
+    "_HyperSpy": {
+        "Folding": {
+            "original_axes_manager": None,
+            "unfolded": False,
+            "original_shape": None,
+            "signal_unfolded": False,
+        }
+    },
+}
 
 example2_parameters = {
-    'ALPHA-1': '3.1415926535',
-    'AZIMANGLE-dg': 90.0,
-    'BEAMDIAM -nm': 100.0,
-    'BEAMKV   -kV': 120.0,
-    'CHOFFSET': -20.0,
-    'COMMENT': 'The next two lines are User Defined Keywords and values',
-    'DATATYPE': 'Y',
-    'DATE': '01-OCT-1991',
-    'EDSDET': 'SIWLS',
-    'ELEVANGLE-dg': 20.0,
-    'EMISSION -uA': 5.5,
-    'FORMAT': 'EMSA/MAS Spectral Data File',
-    'LIVETIME  -s': 100.0,
-    'MAGCAM': 100.0,
-    'NCOLUMNS': 5.0,
-    'NPOINTS': 80.0,
-    'OFFSET': 200.0,
-    'OPERMODE': 'IMAG',
-    'OWNER': 'EMSA/MAS TASK FORCE',
-    'PROBECUR -nA': 12.345,
-    'REALTIME  -s': 150.0,
-    'RESTMASS': '511.030',
-    'SIGNALTYPE': 'EDS',
-    'SOLIDANGL-sR': '0.13',
-    'TACTLYR  -cm': 0.3,
-    'TAUWIND  -cm': 2e-06,
-    'TBEWIND  -cm': 0.0,
-    'TDEADLYR -cm': 1e-06,
-    'THICKNESS-nm': 50.0,
-    'TIME': '12:00',
-    'TITLE': 'NIO Windowless Spectra OK NiL',
-    'VERSION': '1.0',
-    'XLABEL': 'X-RAY ENERGY',
-    'XPERCHAN': 10.0,
-    'XPOSITION': 123.0,
-    'XTILTSTGE-dg': 45.0,
-    'XUNITS': 'eV',
-    'YLABEL': 'X-RAY INTENSITY',
-    'YPOSITION': 456.0,
-    'YTILTSTGE-dg': 20.0,
-    'YUNITS': 'Intensity',
-    'ZPOSITION': 0.0}
+    "ALPHA-1": "3.1415926535",
+    "AZIMANGLE-dg": 90.0,
+    "BEAMDIAM -nm": 100.0,
+    "BEAMKV   -kV": 120.0,
+    "CHOFFSET": -20.0,
+    "COMMENT": "The next two lines are User Defined Keywords and values",
+    "DATATYPE": "Y",
+    "DATE": "01-OCT-1991",
+    "EDSDET": "SIWLS",
+    "ELEVANGLE-dg": 20.0,
+    "EMISSION -uA": 5.5,
+    "FORMAT": "EMSA/MAS Spectral Data File",
+    "LIVETIME  -s": 100.0,
+    "MAGCAM": 100.0,
+    "NCOLUMNS": 5.0,
+    "NPOINTS": 80.0,
+    "OFFSET": 200.0,
+    "OPERMODE": "IMAG",
+    "OWNER": "EMSA/MAS TASK FORCE",
+    "PROBECUR -nA": 12.345,
+    "REALTIME  -s": 150.0,
+    "RESTMASS": "511.030",
+    "SIGNALTYPE": "EDS",
+    "SOLIDANGL-sR": "0.13",
+    "TACTLYR  -cm": 0.3,
+    "TAUWIND  -cm": 2e-06,
+    "TBEWIND  -cm": 0.0,
+    "TDEADLYR -cm": 1e-06,
+    "THICKNESS-nm": 50.0,
+    "TIME": "12:00",
+    "TITLE": "NIO Windowless Spectra OK NiL",
+    "VERSION": "1.0",
+    "XLABEL": "X-RAY ENERGY",
+    "XPERCHAN": 10.0,
+    "XPOSITION": 123.0,
+    "XTILTSTGE-dg": 45.0,
+    "XUNITS": "eV",
+    "YLABEL": "X-RAY INTENSITY",
+    "YPOSITION": 456.0,
+    "YTILTSTGE-dg": 20.0,
+    "YUNITS": "Intensity",
+    "ZPOSITION": 0.0,
+}
 
 
 class TestExample1:
-
     def setup_method(self, method):
-        self.s = load(os.path.join(
-            my_path,
-            "msa_files",
-            "example1.msa"))
+        self.s = load(os.path.join(my_path, "msa_files", "example1.msa"))
         # delete timestamp from metadata since it's runtime dependent
         del self.s.metadata.General.FileIO.Number_0.timestamp
 
     def test_data(self):
-        assert (
-            [4066.0,
-             3996.0,
-             3932.0,
-             3923.0,
-             5602.0,
-             5288.0,
-             7234.0,
-             7809.0,
-             4710.0,
-             5015.0,
-             4366.0,
-             4524.0,
-             4832.0,
-             5474.0,
-             5718.0,
-             5034.0,
-             4651.0,
-             4613.0,
-             4637.0,
-             4429.0,
-             4217.0] == self.s.data.tolist())
+        assert [
+            4066.0,
+            3996.0,
+            3932.0,
+            3923.0,
+            5602.0,
+            5288.0,
+            7234.0,
+            7809.0,
+            4710.0,
+            5015.0,
+            4366.0,
+            4524.0,
+            4832.0,
+            5474.0,
+            5718.0,
+            5034.0,
+            4651.0,
+            4613.0,
+            4637.0,
+            4429.0,
+            4217.0,
+        ] == self.s.data.tolist()
 
     def test_parameters(self):
-        assert (
-            example1_parameters ==
-            self.s.original_metadata.as_dictionary())
+        assert example1_parameters == self.s.original_metadata.as_dictionary()
 
     def test_metadata(self):
-        assert_deep_almost_equal(self.s.metadata.as_dictionary(),
-                                 example1_metadata)
+        assert_deep_almost_equal(self.s.metadata.as_dictionary(), example1_metadata)
 
     def test_write_load_cycle(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -217,21 +240,18 @@ class TestExample1:
             # delete timestamp from metadata since it's runtime dependent
             del s2.metadata.General.FileIO.Number_0.timestamp
             del self.s.metadata.General.FileIO.Number_1
-            if 'timestamp' in self.s.metadata.General.FileIO.Number_0:
+            if "timestamp" in self.s.metadata.General.FileIO.Number_0:
                 del self.s.metadata.General.FileIO.Number_0.timestamp
-            assert (s2.metadata.General.original_filename ==
-                    "example1-export.msa")
+            assert s2.metadata.General.original_filename == "example1-export.msa"
             s2.metadata.General.original_filename = "example1.msa"
-            assert_deep_almost_equal(self.s.metadata.as_dictionary(),
-                                     s2.metadata.as_dictionary())
+            assert_deep_almost_equal(
+                self.s.metadata.as_dictionary(), s2.metadata.as_dictionary()
+            )
+
 
 class TestExample1WrongDate:
-
     def setup_method(self, method):
-        self.s = load(os.path.join(
-            my_path,
-            "msa_files",
-            "example1_wrong_date.msa"))
+        self.s = load(os.path.join(my_path, "msa_files", "example1_wrong_date.msa"))
         # delete timestamp from metadata since it's runtime dependent
         del self.s.metadata.General.FileIO.Number_0.timestamp
 
@@ -240,127 +260,118 @@ class TestExample1WrongDate:
         del md["General"]["date"]
         del md["General"]["time"]
         md["General"]["original_filename"] = "example1_wrong_date.msa"
-        assert_deep_almost_equal(self.s.metadata.as_dictionary(),
-                                 md)
-
-
+        assert_deep_almost_equal(self.s.metadata.as_dictionary(), md)
 
 
 class TestExample2:
-
     def setup_method(self, method):
-        self.s = load(os.path.join(
-            my_path,
-            "msa_files",
-            "example2.msa"))
+        self.s = load(os.path.join(my_path, "msa_files", "example2.msa"))
         # delete timestamp from metadata since it's runtime dependent
         del self.s.metadata.General.FileIO.Number_0.timestamp
 
     def test_data(self):
-        assert (
-            [65.82,
-             67.872,
-             65.626,
-             68.762,
-             71.395,
-             74.996,
-             78.132,
-             78.055,
-             77.861,
-             84.598,
-             83.088,
-             85.372,
-             89.786,
-             93.464,
-             93.387,
-             97.452,
-             109.96,
-             111.08,
-             119.64,
-             128.77,
-             138.38,
-             152.35,
-             176.01,
-             192.12,
-             222.12,
-             254.22,
-             281.55,
-             328.33,
-             348.92,
-             375.33,
-             385.51,
-             389.54,
-             378.77,
-             353.8,
-             328.91,
-             290.07,
-             246.09,
-             202.73,
-             176.47,
-             137.64,
-             119.56,
-             106.4,
-             92.496,
-             96.213,
-             94.664,
-             101.13,
-             114.57,
-             118.82,
-             131.68,
-             145.04,
-             165.44,
-             187.51,
-             207.49,
-             238.04,
-             269.71,
-             301.46,
-             348.65,
-             409.36,
-             475.3,
-             554.51,
-             631.64,
-             715.19,
-             793.44,
-             847.99,
-             872.97,
-             862.59,
-             834.87,
-             778.49,
-             688.63,
-             599.39,
-             495.39,
-             403.48,
-             312.88,
-             237.34,
-             184.14,
-             129.86,
-             101.59,
-             80.107,
-             58.657,
-             49.442] == self.s.data.tolist())
+        assert [
+            65.82,
+            67.872,
+            65.626,
+            68.762,
+            71.395,
+            74.996,
+            78.132,
+            78.055,
+            77.861,
+            84.598,
+            83.088,
+            85.372,
+            89.786,
+            93.464,
+            93.387,
+            97.452,
+            109.96,
+            111.08,
+            119.64,
+            128.77,
+            138.38,
+            152.35,
+            176.01,
+            192.12,
+            222.12,
+            254.22,
+            281.55,
+            328.33,
+            348.92,
+            375.33,
+            385.51,
+            389.54,
+            378.77,
+            353.8,
+            328.91,
+            290.07,
+            246.09,
+            202.73,
+            176.47,
+            137.64,
+            119.56,
+            106.4,
+            92.496,
+            96.213,
+            94.664,
+            101.13,
+            114.57,
+            118.82,
+            131.68,
+            145.04,
+            165.44,
+            187.51,
+            207.49,
+            238.04,
+            269.71,
+            301.46,
+            348.65,
+            409.36,
+            475.3,
+            554.51,
+            631.64,
+            715.19,
+            793.44,
+            847.99,
+            872.97,
+            862.59,
+            834.87,
+            778.49,
+            688.63,
+            599.39,
+            495.39,
+            403.48,
+            312.88,
+            237.34,
+            184.14,
+            129.86,
+            101.59,
+            80.107,
+            58.657,
+            49.442,
+        ] == self.s.data.tolist()
 
     def test_parameters(self):
-        assert (
-            example2_parameters ==
-            self.s.original_metadata.as_dictionary())
+        assert example2_parameters == self.s.original_metadata.as_dictionary()
 
     def test_metadata(self):
-        assert_deep_almost_equal(self.s.metadata.as_dictionary(),
-                                 example2_metadata)
+        assert_deep_almost_equal(self.s.metadata.as_dictionary(), example2_metadata)
 
     def test_write_load_cycle(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             fname2 = os.path.join(tmpdir, "example2-export.msa")
             self.s.save(fname2)
             s2 = load(fname2)
-            assert (s2.metadata.General.original_filename ==
-                    "example2-export.msa")
+            assert s2.metadata.General.original_filename == "example2-export.msa"
             s2.metadata.General.original_filename = "example2.msa"
             # delete timestamp from metadata since it's runtime dependent
             del s2.metadata.General.FileIO.Number_0.timestamp
             del self.s.metadata.General.FileIO.Number_1
-            assert_deep_almost_equal(self.s.metadata.as_dictionary(),
-                                     s2.metadata.as_dictionary())
+            assert_deep_almost_equal(
+                self.s.metadata.as_dictionary(), s2.metadata.as_dictionary()
+            )
 
 
 def test_minimum_metadata_example():

--- a/rsciio/tests/test_nexus_hdf.py
+++ b/rsciio/tests/test_nexus_hdf.py
@@ -29,40 +29,51 @@ from hyperspy._signals.signal2d import Signal2D
 from rsciio.exceptions import VisibleDeprecationWarning
 from hyperspy.exceptions import VisibleDeprecationWarning as HSVisibleDeprecationWarning
 from hyperspy.io import load
-from rsciio.nexus.api import (_byte_to_string, _fix_exclusion_keys,
-                                       _is_int, _is_numeric_data, file_writer,
-                                       list_datasets_in_file, _get_nav_list,
-                                       read_metadata_from_file, _getlink,
-                                       _check_search_keys, _parse_from_file,
-                                       _nexus_dataset_to_signal)
+from rsciio.nexus.api import (
+    _byte_to_string,
+    _fix_exclusion_keys,
+    _is_int,
+    _is_numeric_data,
+    file_writer,
+    list_datasets_in_file,
+    _get_nav_list,
+    read_metadata_from_file,
+    _getlink,
+    _check_search_keys,
+    _parse_from_file,
+    _nexus_dataset_to_signal,
+)
 from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.signals import BaseSignal
 
 
 dirpath = os.path.dirname(__file__)
 
-file1 = os.path.join(dirpath, 'nexus_files', 'simple_signal.nxs')
-file2 = os.path.join(dirpath, 'nexus_files', 'saved_multi_signal.nxs')
-file3 = os.path.join(dirpath, 'nexus_files', 'nexus_dls_example.nxs')
-file4 = os.path.join(dirpath, 'nexus_files', 'nexus_dls_example_no_axes.nxs')
-file5 = os.path.join(dirpath, 'nexus_files', 'nexus_test_datakey.nxs')
+file1 = os.path.join(dirpath, "nexus_files", "simple_signal.nxs")
+file2 = os.path.join(dirpath, "nexus_files", "saved_multi_signal.nxs")
+file3 = os.path.join(dirpath, "nexus_files", "nexus_dls_example.nxs")
+file4 = os.path.join(dirpath, "nexus_files", "nexus_dls_example_no_axes.nxs")
+file5 = os.path.join(dirpath, "nexus_files", "nexus_test_datakey.nxs")
 
 
 my_path = os.path.dirname(__file__)
 
 
-class TestDLSNexus():
-
+class TestDLSNexus:
     def setup_method(self, method):
         self.file = file3
-        self.s = load(file3, metadata_key=None, dataset_key=None,
-                      nxdata_only=True, hardlinks_only=True)
+        self.s = load(
+            file3,
+            metadata_key=None,
+            dataset_key=None,
+            nxdata_only=True,
+            hardlinks_only=True,
+        )
 
     @pytest.mark.parametrize("nxdata_only", [True, False])
     @pytest.mark.parametrize("hardlinks_only", [True, False])
     def test_nxdata_only(self, nxdata_only, hardlinks_only):
-        s = load(self.file, nxdata_only=nxdata_only,
-                 hardlinks_only=hardlinks_only)
+        s = load(self.file, nxdata_only=nxdata_only, hardlinks_only=hardlinks_only)
         if nxdata_only and not hardlinks_only:
             assert len(s) == 2
         if nxdata_only and hardlinks_only:
@@ -77,88 +88,92 @@ class TestDLSNexus():
         s = load(file3, nxdata_only=True, metadata_key=metadata_key)
         # hardlinks are false - soft linked data is loaded
         if metadata_key == "m1_y":
-            assert s[1].original_metadata.alias_metadata.\
-                m1_y.attrs.units == "mm"
+            assert s[1].original_metadata.alias_metadata.m1_y.attrs.units == "mm"
         else:
             with pytest.raises(AttributeError):
-                assert s[0].original_metadata.alias_metadata.\
-                    m1_y.attrs.units == "mm"
+                assert s[0].original_metadata.alias_metadata.m1_y.attrs.units == "mm"
 
     def test_value(self):
-        assert self.s.original_metadata.instrument.\
-            beamline.M1.m1_y.value == -4.0
+        assert self.s.original_metadata.instrument.beamline.M1.m1_y.value == -4.0
 
     def test_class(self):
-        assert self.s.original_metadata.instrument.\
-            beamline.M1.attrs.NX_class == "NXmirror"
+        assert (
+            self.s.original_metadata.instrument.beamline.M1.attrs.NX_class == "NXmirror"
+        )
 
     def test_axes_names(self):
         assert self.s.axes_manager[0].name == "x"
         assert self.s.axes_manager[1].name == "y"
 
     def test_string(self):
-        assert self.s.original_metadata.instrument.\
-            beamline.M1.m1_y.attrs.units == "mm"
+        assert self.s.original_metadata.instrument.beamline.M1.m1_y.attrs.units == "mm"
 
     def test_save_hspy(self, tmp_path):
         try:
-            self.s.save(tmp_path / 'test.hspy')
+            self.s.save(tmp_path / "test.hspy")
         except:
             pytest.fail("unexpected error saving hdf5")
 
-    @pytest.mark.parametrize("dataset_path",
-                             ('/entry1/testdata/nexustest',
-                               ['/entry1/testdata/nexustest', 'wrong']))
+    @pytest.mark.parametrize(
+        "dataset_path",
+        ("/entry1/testdata/nexustest", ["/entry1/testdata/nexustest", "wrong"]),
+    )
     def test_dataset_paths(self, dataset_path):
         s = load(self.file, dataset_path=dataset_path)
         title = s.metadata.General.title
-        assert title == 'nexustest'
+        assert title == "nexustest"
 
     def test_skip_load_array_metadata(self):
-        s = load(self.file, nxdata_only=True, hardlinks_only=True,
-                 metadata_key='stage1_x', skip_array_metadata=True)
+        s = load(
+            self.file,
+            nxdata_only=True,
+            hardlinks_only=True,
+            metadata_key="stage1_x",
+            skip_array_metadata=True,
+        )
         with pytest.raises(AttributeError):
             s.original_metadata.entry1.instrument.stage1_x.value_set.value
 
     def test_deprecated_metadata_keys(self):
         with pytest.warns(VisibleDeprecationWarning):
-            load(self.file, metadata_keys='stage1_x')
+            load(self.file, metadata_keys="stage1_x")
 
     def test_deprecated_dataset_keys(self):
         with pytest.warns(VisibleDeprecationWarning):
-            load(self.file, dataset_keys='rocks')
+            load(self.file, dataset_keys="rocks")
 
     def test_deprecated_dataset_paths(self):
         with pytest.warns(VisibleDeprecationWarning):
-            load(self.file, dataset_paths='/entry1/testdata/nexustest/data')
+            load(self.file, dataset_paths="/entry1/testdata/nexustest/data")
 
 
-class TestDLSNexusNoAxes():
-
+class TestDLSNexusNoAxes:
     def setup_method(self, method):
         self.file = file4
-        self.s = load(file4, hardlinks_only=True,
-                      nxdata_only=True)
+        self.s = load(file4, hardlinks_only=True, nxdata_only=True)
 
     @pytest.mark.parametrize("metadata_key", [None, "m1_x"])
     def test_meta_keys(self, metadata_key):
         s = load(file3, nxdata_only=True, metadata_key=metadata_key)
         # hardlinks are false - soft linked data is loaded
         if metadata_key is None:
-            assert s[1].original_metadata.instrument.beamline.M1.\
-                m1_y.attrs.units == "mm"
+            assert (
+                s[1].original_metadata.instrument.beamline.M1.m1_y.attrs.units == "mm"
+            )
         else:
             with pytest.raises(AttributeError):
-                assert s[1].original_metadata.instrument.beamline.M1.\
-                    m1_y.attrs.units == "mm"
+                assert (
+                    s[1].original_metadata.instrument.beamline.M1.m1_y.attrs.units
+                    == "mm"
+                )
 
     def test_value(self):
-        assert self.s.original_metadata.instrument.\
-             beamline.M1.m1_y.value == -4.0
+        assert self.s.original_metadata.instrument.beamline.M1.m1_y.value == -4.0
 
     def test_class(self):
-        assert self.s.original_metadata.instrument.\
-            beamline.M1.attrs.NX_class == "NXmirror"
+        assert (
+            self.s.original_metadata.instrument.beamline.M1.attrs.NX_class == "NXmirror"
+        )
 
     def test_signal_loaded(self):
         assert self.s.metadata.General.title == "nexustest"
@@ -168,38 +183,37 @@ class TestDLSNexusNoAxes():
         assert self.s.axes_manager[1].name == t.Undefined
 
     def test_string(self):
-        assert self.s.original_metadata.instrument.\
-                 beamline.M1.m1_y.attrs.units == "mm"
+        assert self.s.original_metadata.instrument.beamline.M1.m1_y.attrs.units == "mm"
 
     def test_save_hspy(self, tmp_path):
         try:
-            self.s.save(tmp_path / 'test.hspy')
+            self.s.save(tmp_path / "test.hspy")
         except:
             pytest.fail("unexpected error saving hdf5")
 
 
-class TestSavedSignalLoad():
-
+class TestSavedSignalLoad:
     def setup_method(self, method):
         with pytest.warns(HSVisibleDeprecationWarning):
             self.s = load(file1, nxdata_only=True)
 
     def test_string(self):
-        assert self.s.original_metadata.instrument.\
-            energy.attrs.units == "keV"
+        assert self.s.original_metadata.instrument.energy.attrs.units == "keV"
 
     def test_value(self):
-        assert self.s.original_metadata.instrument.\
-            energy.value == 12.0
+        assert self.s.original_metadata.instrument.energy.value == 12.0
 
     def test_string_array(self):
         np.testing.assert_array_equal(
             self.s.original_metadata.instrument.energy.attrs.test,
-            np.array([b"a", b"1.0", b"c"]))
+            np.array([b"a", b"1.0", b"c"]),
+        )
 
     def test_class(self):
-        assert self.s.original_metadata.instrument.\
-            energy.attrs.NX_class == "NXmonochromater"
+        assert (
+            self.s.original_metadata.instrument.energy.attrs.NX_class
+            == "NXmonochromater"
+        )
 
     def test_signal_loaded(self):
         assert self.s.metadata.General.title == "rocks"
@@ -209,32 +223,33 @@ class TestSavedSignalLoad():
         assert self.s.axes_manager[1].name == "yaxis"
 
 
-class TestSavedMultiSignalLoad():
-
+class TestSavedMultiSignalLoad:
     def setup_method(self, method):
         with pytest.warns(HSVisibleDeprecationWarning):
-            self.s = load(file2, nxdata_only=True,
-                          hardlinks_only=True, use_default=False)
+            self.s = load(
+                file2, nxdata_only=True, hardlinks_only=True, use_default=False
+            )
 
     def test_signals(self):
         assert len(self.s) == 2
 
     def test_signal1_string(self):
-        assert self.s[0].original_metadata.instrument.\
-            energy.attrs.units == "keV"
+        assert self.s[0].original_metadata.instrument.energy.attrs.units == "keV"
 
     def test_signal1_value(self):
-        assert self.s[0].original_metadata.instrument.\
-            energy.value == 12.0
+        assert self.s[0].original_metadata.instrument.energy.value == 12.0
 
     def test_signal1_string_array(self):
         np.testing.assert_array_equal(
             self.s[0].original_metadata.instrument.energy.attrs.test,
-            np.array([b"a", b"1.0", b"c"]))
+            np.array([b"a", b"1.0", b"c"]),
+        )
 
     def test_signal1_class(self):
-        assert self.s[0].original_metadata.instrument.\
-            energy.attrs.NX_class == "NXmonochromater"
+        assert (
+            self.s[0].original_metadata.instrument.energy.attrs.NX_class
+            == "NXmonochromater"
+        )
 
     def test_signal1_signal_loaded(self):
         assert self.s[0].metadata.General.title == "rocks"
@@ -244,18 +259,16 @@ class TestSavedMultiSignalLoad():
         assert self.s[0].axes_manager[1].name == "yaxis"
 
     def test_signal2_float(self):
-        assert (
-            self.s[1].original_metadata.instrument.processing.window_size
-            == 20.0)
+        assert self.s[1].original_metadata.instrument.processing.window_size == 20.0
 
     def test_signal2_string_array(self):
         np.testing.assert_array_equal(
             self.s[1].original_metadata.instrument.processing.lines,
-            np.array([b"Fe_Ka", b"Cu_Ka", b"Compton"]))
+            np.array([b"Fe_Ka", b"Cu_Ka", b"Compton"]),
+        )
 
     def test_signal2_string(self):
-        assert self.s[1].original_metadata.instrument.scantype\
-              == "XRF"
+        assert self.s[1].original_metadata.instrument.scantype == "XRF"
 
     def test_signal2_signal_loaded(self):
         assert self.s[1].metadata.General.title == "unnamed__1"
@@ -265,16 +278,15 @@ class TestSavedMultiSignalLoad():
 
 
 class TestSavingMetadataContainers:
-
     def setup_method(self, method):
         self.s = BaseSignal([0.1, 0.2, 0.3])
 
     def test_save_scalers(self, tmp_path):
         s = self.s
-        s.original_metadata.set_item('test1', 44.0)
-        s.original_metadata.set_item('test2', 54.0)
-        s.original_metadata.set_item('test3', 64.0)
-        fname = tmp_path / 'test.nxs'
+        s.original_metadata.set_item("test1", 44.0)
+        s.original_metadata.set_item("test2", 54.0)
+        s.original_metadata.set_item("test3", 64.0)
+        fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = load(fname, nxdata_only=True)
         assert isinstance(lin.original_metadata.test1, float)
@@ -287,22 +299,25 @@ class TestSavingMetadataContainers:
         s.original_metadata.set_item("testarray1", ["a", 2, "b", 4, 5])
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
         s.original_metadata.set_item("testarray3", np.array([1, 2, 3, 4, 5]))
-        fname = tmp_path / 'test.nxs'
+        fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = load(fname, nxdata_only=True)
-        np.testing.assert_array_equal(lin.original_metadata.testarray1,
-                                      np.array([b"a", b'2', b'b', b'4', b'5']))
-        np.testing.assert_array_equal(lin.original_metadata.testarray2,
-                                      np.array([1, 2, 3, 4, 5]))
-        np.testing.assert_array_equal(lin.original_metadata.testarray3,
-                                      np.array([1, 2, 3, 4, 5]))
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray1, np.array([b"a", b"2", b"b", b"4", b"5"])
+        )
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray2, np.array([1, 2, 3, 4, 5])
+        )
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray3, np.array([1, 2, 3, 4, 5])
+        )
 
     def test_save_original_metadata(self, tmp_path):
         s = self.s
         s.original_metadata.set_item("testarray1", ["a", 2, "b", 4, 5])
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
         s.original_metadata.set_item("testarray3", np.array([1, 2, 3, 4, 5]))
-        fname = tmp_path / 'test.nxs'
+        fname = tmp_path / "test.nxs"
         s.save(fname, save_original_metadata=False)
         lin = load(fname, nxdata_only=True)
         with pytest.raises(AttributeError):
@@ -313,23 +328,23 @@ class TestSavingMetadataContainers:
         s.original_metadata.set_item("testarray1", ["a", 2, "b", 4, 5])
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
         s.original_metadata.set_item("testarray3", np.array([1, 2, 3, 4, 5]))
-        fname = tmp_path / 'test.nxs'
-        s.save(fname, skip_metadata_key='testarray2')
+        fname = tmp_path / "test.nxs"
+        s.save(fname, skip_metadata_key="testarray2")
         lin = load(fname, nxdata_only=True)
         with pytest.raises(AttributeError):
             lin.original_metadata.testarray2
 
     def test_save_use_default(self, tmp_path):
         s = self.s
-        fname = tmp_path / 'test.nxs'
+        fname = tmp_path / "test.nxs"
         s.save(fname, use_default=True)
-        with h5py.File(fname, 'r') as f:
-            root_default_attrs = f['/'].attrs['default']
-        assert root_default_attrs == 'entry1'
+        with h5py.File(fname, "r") as f:
+            root_default_attrs = f["/"].attrs["default"]
+        assert root_default_attrs == "entry1"
 
     def test_save_without_default_load_with_default(self, tmp_path):
         s = self.s
-        fname = tmp_path / 'test.nxs'
+        fname = tmp_path / "test.nxs"
         s.save(fname, use_default=False)
         lin = load(fname, nxdata_only=True, use_default=True)
         assert np.isclose(lin.data, s.data).all()
@@ -340,64 +355,71 @@ class TestSavingMetadataContainers:
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
         s.original_metadata.set_item("testarray3", np.array([1, 2, 3, 4, 5]))
 
-        with pytest.warns(UserWarning,
-                          match="Setting the `original_metadata` attribute"):
+        with pytest.warns(
+            UserWarning, match="Setting the `original_metadata` attribute"
+        ):
             s.original_metadata = s.original_metadata.as_dictionary()
-        with pytest.warns(UserWarning,
-                          match="Setting the `metadata` attribute"):
+        with pytest.warns(UserWarning, match="Setting the `metadata` attribute"):
             s.metadata = s.metadata.as_dictionary()
 
         assert isinstance(s.metadata, DictionaryTreeBrowser)
         assert isinstance(s.original_metadata, DictionaryTreeBrowser)
 
-        fname = tmp_path / 'test.nxs'
+        fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = load(fname, nxdata_only=True)
-        np.testing.assert_array_equal(lin.original_metadata.testarray1,
-                                      np.array([b"a", b'2', b'b', b'4', b'5']))
-        np.testing.assert_array_equal(lin.original_metadata.testarray2,
-                                      np.array([1, 2, 3, 4, 5]))
-        np.testing.assert_array_equal(lin.original_metadata.testarray3,
-                                      np.array([1, 2, 3, 4, 5]))
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray1, np.array([b"a", b"2", b"b", b"4", b"5"])
+        )
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray2, np.array([1, 2, 3, 4, 5])
+        )
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray3, np.array([1, 2, 3, 4, 5])
+        )
 
     def test_save_hyperspy_signal_metadata(self, tmp_path):
         s = self.s
         s.original_metadata.set_item("testarray1", BaseSignal([1.2, 2.3, 3.4]))
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
-        s.original_metadata.set_item("testarray3", Signal2D(np.ones((2,3,5,4))))
-        fname = tmp_path / 'test.nxs'
+        s.original_metadata.set_item("testarray3", Signal2D(np.ones((2, 3, 5, 4))))
+        fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = load(fname, nxdata_only=True)
-        np.testing.assert_allclose(lin.original_metadata.testarray1.data,
-                                   np.array([1.2, 2.3, 3.4]))
-        np.testing.assert_array_equal(lin.original_metadata.testarray2,
-                                      np.array([1, 2, 3, 4, 5]))
-        np.testing.assert_array_equal(lin.original_metadata.testarray3.data,
-                                      np.ones((2,3,5,4)))
+        np.testing.assert_allclose(
+            lin.original_metadata.testarray1.data, np.array([1.2, 2.3, 3.4])
+        )
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray2, np.array([1, 2, 3, 4, 5])
+        )
+        np.testing.assert_array_equal(
+            lin.original_metadata.testarray3.data, np.ones((2, 3, 5, 4))
+        )
 
     def test_save_3D_signal(self, tmp_path):
-        s = BaseSignal(np.zeros((2,3,4)))
-        fname = tmp_path / 'test.nxs'
+        s = BaseSignal(np.zeros((2, 3, 4)))
+        fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = load(fname, nxdata_only=True)
         assert lin.axes_manager.signal_dimension == 3
-        np.testing.assert_array_equal(lin.data, np.zeros((2,3,4)))
+        np.testing.assert_array_equal(lin.data, np.zeros((2, 3, 4)))
 
     def test_save_title_with_slash(self, tmp_path):
         s = self.s
-        s.metadata.General.title = '/entry/something'
-        fname = tmp_path / 'test.nxs'
+        s.metadata.General.title = "/entry/something"
+        fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = load(fname, nxdata_only=True)
-        assert lin.metadata.General.title == '_entry_something'
+        assert lin.metadata.General.title == "_entry_something"
 
     def test_save_title_double_underscore(self, tmp_path):
         s = self.s
-        s.metadata.General.title = '__entry/something'
-        fname = tmp_path / 'test.nxs'
+        s.metadata.General.title = "__entry/something"
+        fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = load(fname, nxdata_only=True)
-        assert lin.metadata.General.title == 'entry_something'
+        assert lin.metadata.General.title == "entry_something"
+
 
 def test_saving_multi_signals(tmp_path):
 
@@ -414,7 +436,7 @@ def test_saving_multi_signals(tmp_path):
     sig2.original_metadata.set_item("stage_x.value", 8.0)
     sig2.original_metadata.set_item("stage_x.attrs.units", "mm")
 
-    fname = tmp_path / 'test.nxs'
+    fname = tmp_path / "test.nxs"
     sig.save(fname)
     file_writer(fname, [sig._to_dictionary(), sig2._to_dictionary()])
     lin = load(fname, nxdata_only=True)
@@ -444,19 +466,30 @@ def test_read_file2_signal1():
 
 def test_read_file2_default():
     with pytest.warns(HSVisibleDeprecationWarning):
-        s = hs.load(file2, use_default=False, nxdata_only=True,
-                    hardlinks_only=True, dataset_key=["unnamed__1"])
+        s = hs.load(
+            file2,
+            use_default=False,
+            nxdata_only=True,
+            hardlinks_only=True,
+            dataset_key=["unnamed__1"],
+        )
     assert s.metadata.General.title == "unnamed__1"
     with pytest.warns(HSVisibleDeprecationWarning):
-        s = hs.load(file2, use_default=True, nxdata_only=True,
-                    hardlinks_only=True, dataset_key=["unnamed__1"])
+        s = hs.load(
+            file2,
+            use_default=True,
+            nxdata_only=True,
+            hardlinks_only=True,
+            dataset_key=["unnamed__1"],
+        )
     assert s.metadata.General.title == "rocks"
 
 
 def test_read_file2_metadata_keys():
     with pytest.warns(HSVisibleDeprecationWarning):
-        s = hs.load(file2, nxdata_only=True,
-                    dataset_key=["rocks"], metadata_key=["energy"])
+        s = hs.load(
+            file2, nxdata_only=True, dataset_key=["rocks"], metadata_key=["energy"]
+        )
     assert s.original_metadata.instrument.energy.value == 12.0
 
 
@@ -468,8 +501,7 @@ def test_read_lazy_file():
 @pytest.mark.parametrize("verbose", [True, False])
 @pytest.mark.parametrize("dataset_key", ["testdata", "nexustest", "xyz"])
 def test_list_datasets(verbose, dataset_key):
-    s = list_datasets_in_file(file3, verbose=verbose,
-                              dataset_key=dataset_key)
+    s = list_datasets_in_file(file3, verbose=verbose, dataset_key=dataset_key)
     if dataset_key == "testdata":
         assert len(s[1]) == 3
     elif dataset_key == "nexustest":
@@ -481,8 +513,7 @@ def test_list_datasets(verbose, dataset_key):
 
 @pytest.mark.parametrize("metadata_key", [None, "xxxxx"])
 def test_read_metdata(metadata_key):
-    s = read_metadata_from_file(file3, verbose=True,
-                                metadata_key=metadata_key)
+    s = read_metadata_from_file(file3, verbose=True, metadata_key=metadata_key)
     # hardlinks are false - soft linked data is loaded
     if metadata_key is None:
         assert s["alias_metadata"]["m1_y"]["attrs"]["units"] == "mm"
@@ -505,18 +536,17 @@ def test_exclusion_keys():
 
 
 def test_unicode_error():
-    assert _byte_to_string(b'\xff\xfeW[') == "ÿþW["
+    assert _byte_to_string(b"\xff\xfeW[") == "ÿþW["
 
 
-class TestParseFromFile():
-
+class TestParseFromFile:
     def test_length_1_array(self):
         val = np.array([10])
         assert _parse_from_file(val) == 10
 
     def test_bytes(self):
-        val = b'\x66\x6f\x6f'
-        assert _parse_from_file(val) == 'foo'
+        val = b"\x66\x6f\x6f"
+        assert _parse_from_file(val) == "foo"
 
     def test_int_float(self):
         val = 145
@@ -525,22 +555,21 @@ class TestParseFromFile():
         assert np.isclose(_parse_from_file(val), 1.45)
 
     def test_unicode_array(self):
-        val = np.array(['foo', 'bar']).astype('U')
-        assert _parse_from_file(val)[0] == b'foo'
-        assert _parse_from_file(val)[1] == b'bar'
+        val = np.array(["foo", "bar"]).astype("U")
+        assert _parse_from_file(val)[0] == b"foo"
+        assert _parse_from_file(val)[1] == b"bar"
 
 
-class TestCheckSearchKeys():
-
+class TestCheckSearchKeys:
     def test_check_search_keys_input_None(self):
         assert _check_search_keys(None) is None
 
     def test_check_search_keys_input_str(self):
-        assert type(_check_search_keys('[1234]')) is list
+        assert type(_check_search_keys("[1234]")) is list
 
     def test_check_search_keys_input_list_all_str(self):
-        assert _check_search_keys(['[1234]', '[5678]'])[0] == '[1234]'
-        assert _check_search_keys(['[1234]', '[5678]'])[1] == '[5678]'
+        assert _check_search_keys(["[1234]", "[5678]"])[0] == "[1234]"
+        assert _check_search_keys(["[1234]", "[5678]"])[1] == "[5678]"
 
     def test_check_search_keys_input_list_all_not_str(self):
         with pytest.raises(ValueError):
@@ -548,36 +577,34 @@ class TestCheckSearchKeys():
 
     def test_check_search_keys_input_list_some_elements_not_str(self):
         with pytest.raises(ValueError):
-            _check_search_keys(['[1234]', 56, 78])
+            _check_search_keys(["[1234]", 56, 78])
 
     def test_check_search_keys_input_not_str_not_list(self):
         with pytest.raises(ValueError):
-            _check_search_keys(np.array(['123', '456']))
+            _check_search_keys(np.array(["123", "456"]))
 
 
-class TestLoadDatasetKey():
-
+class TestLoadDatasetKey:
     def test_int_signal_attrs(self):
-        with h5py.File(file5, 'r') as f:
-            d = _nexus_dataset_to_signal(f, '/entry1/testdata/nexustest1')
-        np.testing.assert_almost_equal(d['data'], np.zeros((2,3,4)))
+        with h5py.File(file5, "r") as f:
+            d = _nexus_dataset_to_signal(f, "/entry1/testdata/nexustest1")
+        np.testing.assert_almost_equal(d["data"], np.zeros((2, 3, 4)))
 
     def test_no_signal_attrs_with_data(self):
-        with h5py.File(file5, 'r') as f:
-            d = _nexus_dataset_to_signal(f, '/entry1/testdata/nexustest2')
-        np.testing.assert_almost_equal(d['data'], np.zeros((4,5,6)))
+        with h5py.File(file5, "r") as f:
+            d = _nexus_dataset_to_signal(f, "/entry1/testdata/nexustest2")
+        np.testing.assert_almost_equal(d["data"], np.zeros((4, 5, 6)))
 
     def test_no_signal_attrs_no_data(self):
-        with h5py.File(file5, 'r') as f:
+        with h5py.File(file5, "r") as f:
             with pytest.raises(ValueError):
-                _nexus_dataset_to_signal(f, '/entry1/testdata/nexustest3')
+                _nexus_dataset_to_signal(f, "/entry1/testdata/nexustest3")
 
 
 def test_dataset_with_chunks_attrs():
-    with h5py.File(file5, 'r') as f:
-        d = _nexus_dataset_to_signal(f, '/entry1/testdata/nexustest1',
-                                     lazy=True)
-    assert d['data'].chunksize == (1, 1, 2)
+    with h5py.File(file5, "r") as f:
+        d = _nexus_dataset_to_signal(f, "/entry1/testdata/nexustest1", lazy=True)
+    assert d["data"].chunksize == (1, 1, 2)
 
 
 def test_extract_hdf5():
@@ -589,18 +616,18 @@ def test_extract_hdf5():
 
 
 def test_getlink_same_rootkey_key():
-    with h5py.File(file5, 'r') as f:
-        target = _getlink(f['/entry1/testdata/nexustest2'],
-                          '/entry1/testdata/nexustest2',
-                          'data')
+    with h5py.File(file5, "r") as f:
+        target = _getlink(
+            f["/entry1/testdata/nexustest2"], "/entry1/testdata/nexustest2", "data"
+        )
     assert target is None
 
 
 def test_axes_key_str_or_bytes_with_nonlinear_axis():
-    with h5py.File(file5, 'r') as f:
-        dataset = f['/entry1/testdata/nexustest_axistest1/data']
-        group = f['/entry1/testdata/nexustest_axistest1']
+    with h5py.File(file5, "r") as f:
+        dataset = f["/entry1/testdata/nexustest_axistest1/data"]
+        group = f["/entry1/testdata/nexustest_axistest1"]
         nav_list = _get_nav_list(dataset, group)
 
-    assert nav_list[0]['offset'] == 6
-    assert nav_list[1]['offset'] == 0
+    assert nav_list[0]["offset"] == 6
+    assert nav_list[1]["offset"] == 0

--- a/rsciio/tests/test_panta_rhei.py
+++ b/rsciio/tests/test_panta_rhei.py
@@ -25,47 +25,58 @@ my_path = Path(__file__).parent
 
 class TestLoadingPrzFiles:
     def test_metadata_prz_v5(self):
-        md = {'General': {'title': 'AD', 'original_filename': 'panta_rhei_sample_v5.prz'},
-              'Signal': {'signal_type': ''},
-              'Acquisition_instrument': {'TEM': {'beam_energy': 200.0,
-                                                 'acquisition_mode': 'STEM',
-                                                 'magnification': 10000000,
-                                                 'camera_length': 0.02,
-                                                 }}}
-        am = {'axis-0': {'_type': 'UniformDataAxis',
-                         'name': 'Y',
-                         'units': 'm',
-                         'navigate': False,
-                         'is_binned': False,
-                         'size': 16,
-                         'scale': 7.795828292907633e-09,
-                         'offset': 0.0},
-              'axis-1': {'_type': 'UniformDataAxis',
-                         'name': 'X',
-                         'units': 'm',
-                         'navigate': False,
-                         'is_binned': False,
-                         'size': 16,
-                         'scale': 7.795828292907633e-09,
-                         'offset': 0.0}}
+        md = {
+            "General": {"title": "AD", "original_filename": "panta_rhei_sample_v5.prz"},
+            "Signal": {"signal_type": ""},
+            "Acquisition_instrument": {
+                "TEM": {
+                    "beam_energy": 200.0,
+                    "acquisition_mode": "STEM",
+                    "magnification": 10000000,
+                    "camera_length": 0.02,
+                }
+            },
+        }
+        am = {
+            "axis-0": {
+                "_type": "UniformDataAxis",
+                "name": "Y",
+                "units": "m",
+                "navigate": False,
+                "is_binned": False,
+                "size": 16,
+                "scale": 7.795828292907633e-09,
+                "offset": 0.0,
+            },
+            "axis-1": {
+                "_type": "UniformDataAxis",
+                "name": "X",
+                "units": "m",
+                "navigate": False,
+                "is_binned": False,
+                "size": 16,
+                "scale": 7.795828292907633e-09,
+                "offset": 0.0,
+            },
+        }
 
-        s = hs.load(my_path / 'panta_rhei_files' / 'panta_rhei_sample_v5.prz')
+        s = hs.load(my_path / "panta_rhei_files" / "panta_rhei_sample_v5.prz")
 
         md_file = s.metadata.as_dictionary()
-        md_file.pop('_HyperSpy')
-        md_file['General'].pop('FileIO')
+        md_file.pop("_HyperSpy")
+        md_file["General"].pop("FileIO")
         assert_deep_almost_equal(md_file, md)
         assert_deep_almost_equal(s.axes_manager.as_dictionary(), am)
-        assert (s.data.shape == (16, 16))
-        assert (s.data.max() == 40571)
-        assert (s.data.min() == 36193)
+        assert s.data.shape == (16, 16)
+        assert s.data.max() == 40571
+        assert s.data.min() == 36193
         np.testing.assert_almost_equal(s.data.std(), 1025.115644550)
 
 
 def test_save_load_cycle(tmp_path):
-    fname = tmp_path / 'test_file.prz'
+    fname = tmp_path / "test_file.prz"
 
-    s = hs.load(my_path / 'panta_rhei_files' / 'panta_rhei_sample_v5.prz')
+    s = hs.load(my_path / "panta_rhei_files" / "panta_rhei_sample_v5.prz")
     s.save(fname)
     assert fname.is_file()
 
@@ -74,7 +85,7 @@ def test_save_load_cycle(tmp_path):
 
 
 def test_save_load_cycle_new_signal_1D_nav1(tmp_path):
-    fname = tmp_path / 'test_file_new_signal_1D_nav1.prz'
+    fname = tmp_path / "test_file_new_signal_1D_nav1.prz"
     data = np.arange(20).reshape(2, 10)
     s = hs.signals.Signal1D(data)
     s.save(fname)
@@ -86,7 +97,7 @@ def test_save_load_cycle_new_signal_1D_nav1(tmp_path):
 
 
 def test_save_load_cycle_new_signal_1D_nav2(tmp_path):
-    fname = tmp_path / 'test_file_new_signal1D_nav2.prz'
+    fname = tmp_path / "test_file_new_signal1D_nav2.prz"
     data = np.arange(100).reshape(2, 5, 10)
     s = hs.signals.Signal2D(data)
     s.save(fname)
@@ -98,7 +109,7 @@ def test_save_load_cycle_new_signal_1D_nav2(tmp_path):
 
 
 def test_save_load_cycle_new_signal_2D(tmp_path):
-    fname = tmp_path / 'test_file_new_signal2D.prz'
+    fname = tmp_path / "test_file_new_signal2D.prz"
     data = np.arange(100).reshape(2, 5, 10)
     s = hs.signals.Signal2D(data)
     s.save(fname)
@@ -110,7 +121,7 @@ def test_save_load_cycle_new_signal_2D(tmp_path):
 
 
 def test_save_load_cycle_new_signal_EELS(tmp_path):
-    fname = tmp_path / 'test_file_new_signal2D.prz'
+    fname = tmp_path / "test_file_new_signal2D.prz"
     data = np.arange(100).reshape(2, 5, 10)
     s = hs.signals.EELSSpectrum(data)
     s.save(fname)
@@ -122,27 +133,27 @@ def test_save_load_cycle_new_signal_EELS(tmp_path):
 
 
 def test_metadata_STEM(tmp_path):
-    fname = tmp_path / 'test_file_new_signal_metadata_STEM.prz'
+    fname = tmp_path / "test_file_new_signal_metadata_STEM.prz"
     data = np.arange(20).reshape(2, 10)
     s = hs.signals.EELSSpectrum(data)
     # Set some metadata
     md = {
-        'Acquisition_instrument': {
-            'TEM': {
-                'beam_energy': 200.0,
-                'acquisition_mode': 'STEM',
-                'magnification': 500000,
-                'camera_length': 200,
-                'convergence_angle': 20,
-                'Detector': {
-                    'EELS': {'collection_angle': 60, 'aperture_size': 5},
-                    },
+        "Acquisition_instrument": {
+            "TEM": {
+                "beam_energy": 200.0,
+                "acquisition_mode": "STEM",
+                "magnification": 500000,
+                "camera_length": 200,
+                "convergence_angle": 20,
+                "Detector": {
+                    "EELS": {"collection_angle": 60, "aperture_size": 5},
                 },
             },
-        }
+        },
+    }
 
     s.metadata.add_dictionary(md)
-    s.metadata.General.add_dictionary({'date':'2022-07-08', 'time':'16:00'})
+    s.metadata.General.add_dictionary({"date": "2022-07-08", "time": "16:00"})
     s.save(fname)
     assert fname.is_file()
 
@@ -152,31 +163,31 @@ def test_metadata_STEM(tmp_path):
 
     assert_deep_almost_equal(
         s2.metadata.Acquisition_instrument.as_dictionary(),
-        s.metadata.Acquisition_instrument.as_dictionary()
-        )
+        s.metadata.Acquisition_instrument.as_dictionary(),
+    )
 
 
 def test_metadata_TEM(tmp_path):
-    fname = tmp_path / 'test_file_new_signal_metadata_TEM.prz'
+    fname = tmp_path / "test_file_new_signal_metadata_TEM.prz"
     data = np.arange(20).reshape(2, 10)
     s = hs.signals.EELSSpectrum(data)
     # Set some metadata
     md = {
-        'Acquisition_instrument': {
-            'TEM': {
-                'beam_energy': 200.0,
-                'acquisition_mode': 'TEM',
-                'magnification': 500000,
-                'camera_length': 200,
-                'Detector': {
-                    'EELS': {'collection_angle': 60, 'aperture_size': 5},
-                    },
+        "Acquisition_instrument": {
+            "TEM": {
+                "beam_energy": 200.0,
+                "acquisition_mode": "TEM",
+                "magnification": 500000,
+                "camera_length": 200,
+                "Detector": {
+                    "EELS": {"collection_angle": 60, "aperture_size": 5},
                 },
             },
-        }
+        },
+    }
 
     s.metadata.add_dictionary(md)
-    s.metadata.General.add_dictionary({'date':'2022-07-08', 'time':'16:00'})
+    s.metadata.General.add_dictionary({"date": "2022-07-08", "time": "16:00"})
     s.save(fname)
     assert fname.is_file()
 
@@ -186,5 +197,5 @@ def test_metadata_TEM(tmp_path):
 
     assert_deep_almost_equal(
         s2.metadata.Acquisition_instrument.as_dictionary(),
-        s.metadata.Acquisition_instrument.as_dictionary()
-        )
+        s.metadata.Acquisition_instrument.as_dictionary(),
+    )

--- a/rsciio/tests/test_phenom.py
+++ b/rsciio/tests/test_phenom.py
@@ -23,148 +23,695 @@ import pytest
 
 import hyperspy.api as hs
 
-imagecodecs = pytest.importorskip("imagecodecs", reason="skipping test_phenom tests, requires imagecodecs")
+imagecodecs = pytest.importorskip(
+    "imagecodecs", reason="skipping test_phenom tests, requires imagecodecs"
+)
 
 DIRPATH = os.path.dirname(__file__)
-ELID2VERSION0 = os.path.join(DIRPATH, 'phenom_data', 'Elid2Version0.elid')
-ELID2VERSION1 = os.path.join(DIRPATH, 'phenom_data', 'Elid2Version1.elid')
-ELID2VERSION2 = os.path.join(DIRPATH, 'phenom_data', 'Elid2Version2.elid')
+ELID2VERSION0 = os.path.join(DIRPATH, "phenom_data", "Elid2Version0.elid")
+ELID2VERSION1 = os.path.join(DIRPATH, "phenom_data", "Elid2Version1.elid")
+ELID2VERSION2 = os.path.join(DIRPATH, "phenom_data", "Elid2Version2.elid")
 
 
-@pytest.mark.parametrize(('pathname'), [ELID2VERSION0, ELID2VERSION1, ELID2VERSION2])
+@pytest.mark.parametrize(("pathname"), [ELID2VERSION0, ELID2VERSION1, ELID2VERSION2])
 def test_elid(pathname):
     s = hs.load(pathname)
     assert len(s) == 11
 
     assert s[0].data.shape == (16, 20)
     assert s[0].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'y', 'scale': 0.9757792598920122, 'offset': 0.0, 'size': 16, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-1': {'_type': 'UniformDataAxis', 'name': 'x', 'scale': 0.9757792598920122, 'offset': 0.0, 'size': 20, 'units': 'µm', 'navigate': True, 'is_binned': False}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "y",
+            "scale": 0.9757792598920122,
+            "offset": 0.0,
+            "size": 16,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-1": {
+            "_type": "UniformDataAxis",
+            "name": "x",
+            "scale": 0.9757792598920122,
+            "offset": 0.0,
+            "size": 20,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
     }
-    assert s[0].metadata['Acquisition_instrument']['SEM']['Stage']['x'] == -2.586744298575455
-    assert s[0].metadata['Acquisition_instrument']['SEM']['Stage']['y'] == -0.7322168400784014
-    assert s[0].metadata['Acquisition_instrument']['SEM']['beam_energy'] == 15.0
-    assert s[0].metadata['Acquisition_instrument']['SEM']['microscope'] == 'MVE027364-0026-L'
-    assert s[0].metadata['General']['date'] == '2019-08-07'
-    assert s[0].metadata['General']['original_filename'] == os.path.split(pathname)[1]
-    assert s[0].metadata['General']['time'] == '09:37:31'
-    assert s[0].metadata['General']['title'] == 'Image 1'
-    assert s[0].metadata['Signal']['signal_type'] == ''
-    assert s[0].original_metadata['acquisition']['scan']['dwellTime']['value'] == '200'
-    assert s[0].original_metadata['acquisition']['scan']['dwellTime']['unit'] == 'ns'
-    assert s[0].original_metadata['acquisition']['scan']['fieldSize'] == 0.000019515585197840245
-    assert s[0].original_metadata['acquisition']['scan']['highVoltage']['value'] == '-15'
-    assert s[0].original_metadata['acquisition']['scan']['highVoltage']['unit'] == 'kV'
-    assert s[0].original_metadata['pixelWidth']['value'] == '975.7792598920121'
-    assert s[0].original_metadata['pixelWidth']['unit'] == 'nm'
-    assert s[0].original_metadata['pixelHeight']['value'] == '975.7792598920121'
-    assert s[0].original_metadata['pixelHeight']['unit'] == 'nm'
-    assert s[0].original_metadata['samplePosition']['x'] == '-0.002586744298575455'
-    assert s[0].original_metadata['samplePosition']['y'] == '-0.0007322168400784014'
-    assert s[0].original_metadata['workingDistance']['value'] == '8.141749999999993'
-    assert s[0].original_metadata['workingDistance']['unit'] == 'mm'
-    assert s[0].original_metadata['instrument']['softwareVersion'] == '5.4.5.rc1.bb8fbe3.23039'
-    assert s[0].original_metadata['instrument']['type'] == 'PhenomXL'
-    assert s[0].original_metadata['instrument']['uniqueID'] == 'MVE027364-0026-L'
+    assert (
+        s[0].metadata["Acquisition_instrument"]["SEM"]["Stage"]["x"]
+        == -2.586744298575455
+    )
+    assert (
+        s[0].metadata["Acquisition_instrument"]["SEM"]["Stage"]["y"]
+        == -0.7322168400784014
+    )
+    assert s[0].metadata["Acquisition_instrument"]["SEM"]["beam_energy"] == 15.0
+    assert (
+        s[0].metadata["Acquisition_instrument"]["SEM"]["microscope"]
+        == "MVE027364-0026-L"
+    )
+    assert s[0].metadata["General"]["date"] == "2019-08-07"
+    assert s[0].metadata["General"]["original_filename"] == os.path.split(pathname)[1]
+    assert s[0].metadata["General"]["time"] == "09:37:31"
+    assert s[0].metadata["General"]["title"] == "Image 1"
+    assert s[0].metadata["Signal"]["signal_type"] == ""
+    assert s[0].original_metadata["acquisition"]["scan"]["dwellTime"]["value"] == "200"
+    assert s[0].original_metadata["acquisition"]["scan"]["dwellTime"]["unit"] == "ns"
+    assert (
+        s[0].original_metadata["acquisition"]["scan"]["fieldSize"]
+        == 0.000019515585197840245
+    )
+    assert (
+        s[0].original_metadata["acquisition"]["scan"]["highVoltage"]["value"] == "-15"
+    )
+    assert s[0].original_metadata["acquisition"]["scan"]["highVoltage"]["unit"] == "kV"
+    assert s[0].original_metadata["pixelWidth"]["value"] == "975.7792598920121"
+    assert s[0].original_metadata["pixelWidth"]["unit"] == "nm"
+    assert s[0].original_metadata["pixelHeight"]["value"] == "975.7792598920121"
+    assert s[0].original_metadata["pixelHeight"]["unit"] == "nm"
+    assert s[0].original_metadata["samplePosition"]["x"] == "-0.002586744298575455"
+    assert s[0].original_metadata["samplePosition"]["y"] == "-0.0007322168400784014"
+    assert s[0].original_metadata["workingDistance"]["value"] == "8.141749999999993"
+    assert s[0].original_metadata["workingDistance"]["unit"] == "mm"
+    assert (
+        s[0].original_metadata["instrument"]["softwareVersion"]
+        == "5.4.5.rc1.bb8fbe3.23039"
+    )
+    assert s[0].original_metadata["instrument"]["type"] == "PhenomXL"
+    assert s[0].original_metadata["instrument"]["uniqueID"] == "MVE027364-0026-L"
 
-    assert s[1].metadata['General']['title'] == 'Image 1, Spot 1'
+    assert s[1].metadata["General"]["title"] == "Image 1, Spot 1"
     assert s[1].data.shape == (2048,)
     assert s[1].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'Energy', 'scale': 0.00988676802994421, 'offset': -0.03634370080990722, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "Energy",
+            "scale": 0.00988676802994421,
+            "offset": -0.03634370080990722,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        }
     }
     assert s[1].data.tolist()[0:300] == [
-        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,15,16,19,30,52,61,98,125,
-        145,129,114,69,45,22,14,11,18,17,30,26,29,19,16,20,26,29,35,51,59,103,
-        139,157,209,220,179,113,99,65,49,31,36,39,42,35,48,37,55,50,45,46,49,
-        40,49,54,35,49,57,63,71,64,75,76,92,98,83,81,94,118,120,160,215,325,
-        363,368,429,403,376,254,204,173,136,124,102,89,97,84,83,75,83,71,85,
-        101,81,72,87,84,90,93,84,68,93,91,82,86,112,85,84,100,110,118,132,118,
-        125,138,128,135,143,143,136,148,227,301,538,1077,1946,3319,5108,7249,
-        9032,10755,11441,10804,9219,7245,5335,3568,2213,1455,825,543,338,283,
-        196,160,123,104,105,92,88,109,89,88,82,95,88,91,87,108,86,85,59,77,72,
-        58,66,69,64,76,56,67,58,60,59,71,56,57,62,50,67,59,59,52,45,60,53,57,
-        59,39,43,55,54,40,43,37,39,41,52,39,53,41,48,40,41,45,36,45,32,40,44,
-        43,55,50,45,59,45,44,66,52,67,74,83,90,92,114,130,131,114,100,100,106,
-        103,84,87,77,76,82,83,78,81,63,49,54,64,45,41,40,41,38,50,39,45,44,42,
-        44,31,36,38,37,55,40,32,34,32,34,37,27,28,45,35,24,40,22,29,33,33,44,34]
-    assert s[1].original_metadata['acquisition']['scan']['detectors']['EDS']['live_time'] == 5.7203385
-    assert s[1].original_metadata['acquisition']['scan']['detectors']['EDS']['real_time'] == 10.162500000000001
-    assert s[1].original_metadata['acquisition']['scan']['detectors']['EDS']['fast_peaking_time'] == 100e-9
-    assert s[1].original_metadata['acquisition']['scan']['detectors']['EDS']['slow_peaking_time'] == 11.2e-6
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        15,
+        16,
+        19,
+        30,
+        52,
+        61,
+        98,
+        125,
+        145,
+        129,
+        114,
+        69,
+        45,
+        22,
+        14,
+        11,
+        18,
+        17,
+        30,
+        26,
+        29,
+        19,
+        16,
+        20,
+        26,
+        29,
+        35,
+        51,
+        59,
+        103,
+        139,
+        157,
+        209,
+        220,
+        179,
+        113,
+        99,
+        65,
+        49,
+        31,
+        36,
+        39,
+        42,
+        35,
+        48,
+        37,
+        55,
+        50,
+        45,
+        46,
+        49,
+        40,
+        49,
+        54,
+        35,
+        49,
+        57,
+        63,
+        71,
+        64,
+        75,
+        76,
+        92,
+        98,
+        83,
+        81,
+        94,
+        118,
+        120,
+        160,
+        215,
+        325,
+        363,
+        368,
+        429,
+        403,
+        376,
+        254,
+        204,
+        173,
+        136,
+        124,
+        102,
+        89,
+        97,
+        84,
+        83,
+        75,
+        83,
+        71,
+        85,
+        101,
+        81,
+        72,
+        87,
+        84,
+        90,
+        93,
+        84,
+        68,
+        93,
+        91,
+        82,
+        86,
+        112,
+        85,
+        84,
+        100,
+        110,
+        118,
+        132,
+        118,
+        125,
+        138,
+        128,
+        135,
+        143,
+        143,
+        136,
+        148,
+        227,
+        301,
+        538,
+        1077,
+        1946,
+        3319,
+        5108,
+        7249,
+        9032,
+        10755,
+        11441,
+        10804,
+        9219,
+        7245,
+        5335,
+        3568,
+        2213,
+        1455,
+        825,
+        543,
+        338,
+        283,
+        196,
+        160,
+        123,
+        104,
+        105,
+        92,
+        88,
+        109,
+        89,
+        88,
+        82,
+        95,
+        88,
+        91,
+        87,
+        108,
+        86,
+        85,
+        59,
+        77,
+        72,
+        58,
+        66,
+        69,
+        64,
+        76,
+        56,
+        67,
+        58,
+        60,
+        59,
+        71,
+        56,
+        57,
+        62,
+        50,
+        67,
+        59,
+        59,
+        52,
+        45,
+        60,
+        53,
+        57,
+        59,
+        39,
+        43,
+        55,
+        54,
+        40,
+        43,
+        37,
+        39,
+        41,
+        52,
+        39,
+        53,
+        41,
+        48,
+        40,
+        41,
+        45,
+        36,
+        45,
+        32,
+        40,
+        44,
+        43,
+        55,
+        50,
+        45,
+        59,
+        45,
+        44,
+        66,
+        52,
+        67,
+        74,
+        83,
+        90,
+        92,
+        114,
+        130,
+        131,
+        114,
+        100,
+        100,
+        106,
+        103,
+        84,
+        87,
+        77,
+        76,
+        82,
+        83,
+        78,
+        81,
+        63,
+        49,
+        54,
+        64,
+        45,
+        41,
+        40,
+        41,
+        38,
+        50,
+        39,
+        45,
+        44,
+        42,
+        44,
+        31,
+        36,
+        38,
+        37,
+        55,
+        40,
+        32,
+        34,
+        32,
+        34,
+        37,
+        27,
+        28,
+        45,
+        35,
+        24,
+        40,
+        22,
+        29,
+        33,
+        33,
+        44,
+        34,
+    ]
+    assert (
+        s[1].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["live_time"]
+        == 5.7203385
+    )
+    assert (
+        s[1].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["real_time"]
+        == 10.162500000000001
+    )
+    assert (
+        s[1].original_metadata["acquisition"]["scan"]["detectors"]["EDS"][
+            "fast_peaking_time"
+        ]
+        == 100e-9
+    )
+    assert (
+        s[1].original_metadata["acquisition"]["scan"]["detectors"]["EDS"][
+            "slow_peaking_time"
+        ]
+        == 11.2e-6
+    )
 
-    assert s[2].metadata['General']['title'] == 'Image 1, Region 2'
+    assert s[2].metadata["General"]["title"] == "Image 1, Region 2"
     assert s[2].data.shape == (2048,)
     assert s[2].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'Energy', 'scale': 0.00988676802994421, 'offset': -0.03634370080990722, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "Energy",
+            "scale": 0.00988676802994421,
+            "offset": -0.03634370080990722,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        }
     }
-    assert s[2].original_metadata['acquisition']['scan']['detectors']['EDS']['live_time'] == 6.5802053
-    assert s[2].original_metadata['acquisition']['scan']['detectors']['EDS']['real_time'] == 10.177700000000003
+    assert (
+        s[2].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["live_time"]
+        == 6.5802053
+    )
+    assert (
+        s[2].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["real_time"]
+        == 10.177700000000003
+    )
 
-    assert s[3].metadata['General']['title'] == 'Image 1, Map 3'
+    assert s[3].metadata["General"]["title"] == "Image 1, Map 3"
     assert s[3].data.shape == (16, 16, 2048)
     assert s[3].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'y', 'scale': 1.2197240748650153, 'offset': 0.0, 'size': 16, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-1': {'_type': 'UniformDataAxis', 'name': 'x', 'scale': 1.2197240748650153, 'offset': 0.0, 'size': 16, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-2': {'_type': 'UniformDataAxis', 'name': 'X-ray energy', 'scale': 0.00988676802994421, 'offset': -0.03634370080990722, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "y",
+            "scale": 1.2197240748650153,
+            "offset": 0.0,
+            "size": 16,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-1": {
+            "_type": "UniformDataAxis",
+            "name": "x",
+            "scale": 1.2197240748650153,
+            "offset": 0.0,
+            "size": 16,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-2": {
+            "_type": "UniformDataAxis",
+            "name": "X-ray energy",
+            "scale": 0.00988676802994421,
+            "offset": -0.03634370080990722,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        },
     }
-    assert s[3].original_metadata['acquisition']['scan']['detectors']['EDS']['live_time'] == 4.047052
-    assert s[3].original_metadata['acquisition']['scan']['detectors']['EDS']['real_time'] == 3.0005599999999997
+    assert (
+        s[3].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["live_time"]
+        == 4.047052
+    )
+    assert (
+        s[3].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["real_time"]
+        == 3.0005599999999997
+    )
 
-    assert s[4].metadata['General']['title'] == 'Image 1, Line 4'
+    assert s[4].metadata["General"]["title"] == "Image 1, Line 4"
     assert s[4].data.shape == (64, 2048)
     assert s[4].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'i', 'scale': 1.0, 'offset': 0.0, 'size': 64, 'units': 'points', 'navigate': True, 'is_binned': False},
-        'axis-1': {'_type': 'UniformDataAxis', 'name': 'X-ray energy', 'scale': 0.00988676802994421, 'offset': -0.03634370080990722, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "i",
+            "scale": 1.0,
+            "offset": 0.0,
+            "size": 64,
+            "units": "points",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-1": {
+            "_type": "UniformDataAxis",
+            "name": "X-ray energy",
+            "scale": 0.00988676802994421,
+            "offset": -0.03634370080990722,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        },
     }
-    assert s[4].original_metadata['acquisition']['scan']['detectors']['EDS']['live_time'] == 5.504343599999998
-    assert s[4].original_metadata['acquisition']['scan']['detectors']['EDS']['real_time'] == 6.410299999999996
+    assert (
+        s[4].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["live_time"]
+        == 5.504343599999998
+    )
+    assert (
+        s[4].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["real_time"]
+        == 6.410299999999996
+    )
 
-    assert s[5].metadata['General']['title'] == 'Image 1, Map 6'
+    assert s[5].metadata["General"]["title"] == "Image 1, Map 6"
     assert s[5].data.shape == (16, 16, 2048)
     assert s[5].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'y', 'scale': 1.2197240748650153, 'offset': 0.0, 'size': 16, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-1': {'_type': 'UniformDataAxis', 'name': 'x', 'scale': 1.2197240748650153, 'offset': 0.0, 'size': 16, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-2': {'_type': 'UniformDataAxis', 'name': 'X-ray energy', 'scale': 0.009886797201840245, 'offset': -0.04478043655810262, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "y",
+            "scale": 1.2197240748650153,
+            "offset": 0.0,
+            "size": 16,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-1": {
+            "_type": "UniformDataAxis",
+            "name": "x",
+            "scale": 1.2197240748650153,
+            "offset": 0.0,
+            "size": 16,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-2": {
+            "_type": "UniformDataAxis",
+            "name": "X-ray energy",
+            "scale": 0.009886797201840245,
+            "offset": -0.04478043655810262,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        },
     }
-    assert s[5].original_metadata['acquisition']['scan']['detectors']['EDS']['live_time'] == 4.5919591
-    assert s[5].original_metadata['acquisition']['scan']['detectors']['EDS']['real_time'] == 3.00056
+    assert (
+        s[5].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["live_time"]
+        == 4.5919591
+    )
+    assert (
+        s[5].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["real_time"]
+        == 3.00056
+    )
 
-    assert s[6].metadata['General']['title'] == 'Image 1, Difference 3 - 6'
+    assert s[6].metadata["General"]["title"] == "Image 1, Difference 3 - 6"
     assert s[6].data.shape == (2048,)
     assert s[6].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'Energy', 'scale': 0.00988676802994421, 'offset': -0.03634370080990722, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "Energy",
+            "scale": 0.00988676802994421,
+            "offset": -0.03634370080990722,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        }
     }
 
-    assert s[7].metadata['General']['title'] == '385test - spectrum'
+    assert s[7].metadata["General"]["title"] == "385test - spectrum"
     assert s[7].data.shape == (24, 32)
     assert s[7].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'y', 'scale': 1.0, 'offset': 0.0, 'size': 24, 'units': 'points', 'navigate': True, 'is_binned': False},
-        'axis-1': {'_type': 'UniformDataAxis', 'name': 'x', 'scale': 1.0, 'offset': 0.0, 'size': 32, 'units': 'points', 'navigate': True, 'is_binned': False}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "y",
+            "scale": 1.0,
+            "offset": 0.0,
+            "size": 24,
+            "units": "points",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-1": {
+            "_type": "UniformDataAxis",
+            "name": "x",
+            "scale": 1.0,
+            "offset": 0.0,
+            "size": 32,
+            "units": "points",
+            "navigate": True,
+            "is_binned": False,
+        },
     }
-    assert not 'acquisition' in s[7].original_metadata
+    assert not "acquisition" in s[7].original_metadata
 
-    assert s[8].metadata['General']['title'] == '385test - spectrum, MSA 1'
+    assert s[8].metadata["General"]["title"] == "385test - spectrum, MSA 1"
     assert s[8].data.shape == (2048,)
     assert s[8].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'Energy', 'scale': 0.0098868, 'offset': -0.0363437, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "Energy",
+            "scale": 0.0098868,
+            "offset": -0.0363437,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        }
     }
-    assert s[8].original_metadata['acquisition']['scan']['detectors']['EDS']['live_time'] == 0.0
-    assert s[8].original_metadata['acquisition']['scan']['detectors']['EDS']['real_time'] == 5.066
+    assert (
+        s[8].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["live_time"]
+        == 0.0
+    )
+    assert (
+        s[8].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["real_time"]
+        == 5.066
+    )
 
-    assert s[9].metadata['General']['title'] == 'Image 1'
+    assert s[9].metadata["General"]["title"] == "Image 1"
     assert s[9].data.shape == (35, 40)
     assert s[9].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'y', 'scale': 0.8120422280865187, 'offset': 0.0, 'size': 35, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-1': {'_type': 'UniformDataAxis', 'name': 'x', 'scale': 0.8120422280865187, 'offset': 0.0, 'size': 40, 'units': 'µm', 'navigate': True, 'is_binned': False}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "y",
+            "scale": 0.8120422280865187,
+            "offset": 0.0,
+            "size": 35,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-1": {
+            "_type": "UniformDataAxis",
+            "name": "x",
+            "scale": 0.8120422280865187,
+            "offset": 0.0,
+            "size": 40,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
     }
-    assert not 'EDS' in s[9].original_metadata['acquisition']['scan']['detectors']
+    assert not "EDS" in s[9].original_metadata["acquisition"]["scan"]["detectors"]
 
-    assert s[10].metadata['General']['title'] == 'Image 1, Map 1'
+    assert s[10].metadata["General"]["title"] == "Image 1, Map 1"
     assert s[10].data.shape == (16, 16, 2048)
     assert s[10].axes_manager.as_dictionary() == {
-        'axis-0': {'_type': 'UniformDataAxis', 'name': 'y', 'scale': 2.0301055702162967, 'offset': 0.0, 'size': 16, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-1': {'_type': 'UniformDataAxis', 'name': 'x', 'scale': 2.0301055702162967, 'offset': 0.0, 'size': 16, 'units': 'µm', 'navigate': True, 'is_binned': False},
-        'axis-2': {'_type': 'UniformDataAxis', 'name': 'X-ray energy', 'scale': 0.009886797201840245, 'offset': -0.04478043655810262, 'size': 2048, 'units': 'keV', 'navigate': False, 'is_binned': True}
+        "axis-0": {
+            "_type": "UniformDataAxis",
+            "name": "y",
+            "scale": 2.0301055702162967,
+            "offset": 0.0,
+            "size": 16,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-1": {
+            "_type": "UniformDataAxis",
+            "name": "x",
+            "scale": 2.0301055702162967,
+            "offset": 0.0,
+            "size": 16,
+            "units": "µm",
+            "navigate": True,
+            "is_binned": False,
+        },
+        "axis-2": {
+            "_type": "UniformDataAxis",
+            "name": "X-ray energy",
+            "scale": 0.009886797201840245,
+            "offset": -0.04478043655810262,
+            "size": 2048,
+            "units": "keV",
+            "navigate": False,
+            "is_binned": True,
+        },
     }
-    assert s[10].original_metadata['acquisition']['scan']['detectors']['EDS']['live_time'] == 4.821238
-    assert s[10].original_metadata['acquisition']['scan']['detectors']['EDS']['real_time'] == 3.0005600000000006
+    assert (
+        s[10].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["live_time"]
+        == 4.821238
+    )
+    assert (
+        s[10].original_metadata["acquisition"]["scan"]["detectors"]["EDS"]["real_time"]
+        == 3.0005600000000006
+    )

--- a/rsciio/tests/test_protochips.py
+++ b/rsciio/tests/test_protochips.py
@@ -25,7 +25,7 @@ import hyperspy.api as hs
 from rsciio.protochips.api import ProtochipsCSV, invalid_file_error
 
 testdirpath = os.path.dirname(__file__)
-dirpath = os.path.join(testdirpath, 'protochips_data')
+dirpath = os.path.join(testdirpath, "protochips_data")
 
 # To generate a new reference numpy file
 generate_numpy_file = False
@@ -36,212 +36,219 @@ def create_numpy_file(filename, obj):
     data = np.vstack(list(gen))
     np.save(filename, data.T)
 
+
 #######################
 # Protochips gas cell #
 #######################
 
 
 def test_read_protochips_gas_cell():
-    filename = os.path.join(dirpath, 'protochips_gas_cell.csv')
-    s = hs.load(filename, reader='protochips')
+    filename = os.path.join(dirpath, "protochips_gas_cell.csv")
+    s = hs.load(filename, reader="protochips")
     assert len(s) == 5
-    assert (s[0].metadata.General.title ==
-            'Holder Temperature (Degrees C)')
-    assert s[0].metadata.Signal.signal_type == ''
-    assert s[0].metadata.Signal.quantity == 'Temperature (Degrees C)'
-    assert s[1].metadata.General.title == 'Holder Pressure (Torr)'
-    assert s[1].metadata.Signal.signal_type == ''
-    assert s[1].metadata.Signal.quantity == 'Pressure (Torr)'
-    assert s[2].metadata.General.title == 'Tank1 Pressure (Torr)'
-    assert s[2].metadata.Signal.signal_type == ''
-    assert s[2].metadata.Signal.quantity == 'Pressure (Torr)'
-    assert s[3].metadata.General.title == 'Tank2 Pressure (Torr)'
-    assert s[3].metadata.Signal.signal_type == ''
-    assert s[3].metadata.Signal.quantity == 'Pressure (Torr)'
-    assert s[4].metadata.General.title == 'Vacuum Tank Pressure (Torr)'
-    assert s[4].metadata.Signal.signal_type == ''
-    assert s[4].metadata.Signal.quantity == 'Pressure (Torr)'
+    assert s[0].metadata.General.title == "Holder Temperature (Degrees C)"
+    assert s[0].metadata.Signal.signal_type == ""
+    assert s[0].metadata.Signal.quantity == "Temperature (Degrees C)"
+    assert s[1].metadata.General.title == "Holder Pressure (Torr)"
+    assert s[1].metadata.Signal.signal_type == ""
+    assert s[1].metadata.Signal.quantity == "Pressure (Torr)"
+    assert s[2].metadata.General.title == "Tank1 Pressure (Torr)"
+    assert s[2].metadata.Signal.signal_type == ""
+    assert s[2].metadata.Signal.quantity == "Pressure (Torr)"
+    assert s[3].metadata.General.title == "Tank2 Pressure (Torr)"
+    assert s[3].metadata.Signal.signal_type == ""
+    assert s[3].metadata.Signal.quantity == "Pressure (Torr)"
+    assert s[4].metadata.General.title == "Vacuum Tank Pressure (Torr)"
+    assert s[4].metadata.Signal.signal_type == ""
+    assert s[4].metadata.Signal.quantity == "Pressure (Torr)"
 
 
 def get_datetime(dt):
     dt_np = np.datetime64(dt)
     dt_str = np.datetime_as_string(dt_np)
-    date, time = dt_str.split('T')
+    date, time = dt_str.split("T")
     return date, time, dt_np
 
 
-datetime_gas_cell = get_datetime('2014-12-15T19:07:04.165000')
-datetime_gas_cell_no_user = get_datetime('2016-10-17T16:59:20.391000')
+datetime_gas_cell = get_datetime("2014-12-15T19:07:04.165000")
+datetime_gas_cell_no_user = get_datetime("2016-10-17T16:59:20.391000")
 
 
 def test_loading_random_csv_file():
-    filename = os.path.join(dirpath, 'random_csv_file.csv')
+    filename = os.path.join(dirpath, "random_csv_file.csv")
     with pytest.raises(IOError) as cm:
         ProtochipsCSV(filename)
         cm.match(invalid_file_error)
 
 
 def test_loading_invalid_protochips_file():
-    filename = os.path.join(dirpath, 'invalid_protochips_file.csv')
+    filename = os.path.join(dirpath, "invalid_protochips_file.csv")
     with pytest.raises(IOError) as cm:
-        hs.load(filename, reader='protochips')
+        hs.load(filename, reader="protochips")
         cm.match(invalid_file_error)
 
 
-class TestProtochipsGasCellCSV():
-
+class TestProtochipsGasCellCSV:
     def setup_method(self, method):
-        filename = os.path.join(dirpath, 'protochips_gas_cell.csv')
-        self.s_list = hs.load(filename, reader='protochips')
+        filename = os.path.join(dirpath, "protochips_gas_cell.csv")
+        self.s_list = hs.load(filename, reader="protochips")
 
     def test_read_metadata(self):
         date, time, dt_np = datetime_gas_cell
         for s in self.s_list:
             assert s.metadata.General.date == date
             assert s.metadata.General.time == time
-            assert s.axes_manager[0].units == 's'
-            np.testing.assert_allclose(s.axes_manager[0].scale, 0.25995, atol=1E-5)
+            assert s.axes_manager[0].units == "s"
+            np.testing.assert_allclose(s.axes_manager[0].scale, 0.25995, atol=1e-5)
             assert s.axes_manager[0].offset == 0
 
     def test_read_original_metadata(self):
         om = self.s_list[0].original_metadata.Protochips_header
-        assert (om.Calibration_file_path == "The calibration files names"
-                " are saved in the 'Original notes' array of the "
-                "original metadata.")
-        assert om.Holder_Pressure_units == 'Torr'
-        assert om.Holder_Temperature_units == 'Degrees C'
+        assert (
+            om.Calibration_file_path == "The calibration files names"
+            " are saved in the 'Original notes' array of the "
+            "original metadata."
+        )
+        assert om.Holder_Pressure_units == "Torr"
+        assert om.Holder_Temperature_units == "Degrees C"
         assert om.Start_time == datetime_gas_cell[2]
-        assert om.Holder_Pressure_units == 'Torr'
-        assert om.Tank1_Pressure_units == 'Torr'
-        assert om.Tank2_Pressure_units == 'Torr'
-        assert om.Vacuum_Tank_Pressure_units == 'Torr'
-        assert om.Time_units == 'Milliseconds'
-        assert om.User == 'eric'
+        assert om.Holder_Pressure_units == "Torr"
+        assert om.Tank1_Pressure_units == "Torr"
+        assert om.Tank2_Pressure_units == "Torr"
+        assert om.Vacuum_Tank_Pressure_units == "Torr"
+        assert om.Time_units == "Milliseconds"
+        assert om.User == "eric"
 
 
-class TestProtochipsGasCellCSVNoUser():
-
+class TestProtochipsGasCellCSVNoUser:
     def setup_method(self, method):
-        filename = os.path.join(dirpath, 'protochips_gas_cell_no_user.csv')
-        self.s_list = hs.load(filename, reader='protochips')
+        filename = os.path.join(dirpath, "protochips_gas_cell_no_user.csv")
+        self.s_list = hs.load(filename, reader="protochips")
 
     def test_read_metadata(self):
         date, time, dt_np = datetime_gas_cell_no_user
         for s in self.s_list:
             assert s.metadata.General.date == date
             assert s.metadata.General.time == time
-            assert s.axes_manager[0].units == 's'
-            np.testing.assert_allclose(s.axes_manager[0].scale, 0.26029, atol=1E-5)
+            assert s.axes_manager[0].units == "s"
+            np.testing.assert_allclose(s.axes_manager[0].scale, 0.26029, atol=1e-5)
             assert s.axes_manager[0].offset == 0
 
     def test_read_original_metadata(self):
         om = self.s_list[0].original_metadata.Protochips_header
-        assert (om.Calibration_file_path == "The calibration files names"
-                " are saved in the 'Original notes' array of the "
-                "original metadata.")
-        assert om.Holder_Pressure_units == 'Torr'
-        assert om.Holder_Temperature_units == 'Degrees C'
+        assert (
+            om.Calibration_file_path == "The calibration files names"
+            " are saved in the 'Original notes' array of the "
+            "original metadata."
+        )
+        assert om.Holder_Pressure_units == "Torr"
+        assert om.Holder_Temperature_units == "Degrees C"
         assert om.Start_time == datetime_gas_cell_no_user[2]
-        assert om.Holder_Pressure_units == 'Torr'
-        assert om.Tank1_Pressure_units == 'Torr'
-        assert om.Tank2_Pressure_units == 'Torr'
-        assert om.Vacuum_Tank_Pressure_units == 'Torr'
-        assert om.Time_units == 'Milliseconds'
+        assert om.Holder_Pressure_units == "Torr"
+        assert om.Tank1_Pressure_units == "Torr"
+        assert om.Tank2_Pressure_units == "Torr"
+        assert om.Vacuum_Tank_Pressure_units == "Torr"
+        assert om.Time_units == "Milliseconds"
 
 
-class TestProtochipsGasCellCSVReader():
-
+class TestProtochipsGasCellCSVReader:
     def setup_method(self, method):
-        self.filename = os.path.join(dirpath, 'protochips_gas_cell.csv')
+        self.filename = os.path.join(dirpath, "protochips_gas_cell.csv")
         self.pgc = ProtochipsCSV(self.filename)
         if generate_numpy_file:
-            create_numpy_file(self.filename.replace('.csv', '.npy'), self.pgc)
+            create_numpy_file(self.filename.replace(".csv", ".npy"), self.pgc)
 
     def test_read_column_name(self):
-        assert self.pgc.column_name == ['Time', 'Notes',
-                                        'Holder Temperature',
-                                        'Holder Pressure',
-                                        'Tank1 Pressure',
-                                        'Tank2 Pressure',
-                                        'Vacuum Tank Pressure']
+        assert self.pgc.column_name == [
+            "Time",
+            "Notes",
+            "Holder Temperature",
+            "Holder Pressure",
+            "Tank1 Pressure",
+            "Tank2 Pressure",
+            "Vacuum Tank Pressure",
+        ]
 
     def test_read_start_datetime(self):
         assert self.pgc.start_datetime == datetime_gas_cell[2]
 
     def test_read_data(self):
-        gen = (self.pgc._data_dictionary[key]
-               for key in self.pgc.logged_quantity_name_list)
+        gen = (
+            self.pgc._data_dictionary[key] for key in self.pgc.logged_quantity_name_list
+        )
         data = np.vstack(list(gen))
-        expected_data = np.load(os.path.join(
-            dirpath, 'protochips_gas_cell.npy'))
+        expected_data = np.load(os.path.join(dirpath, "protochips_gas_cell.npy"))
         np.testing.assert_allclose(data.T, expected_data)
 
     def test_read_metadata_header(self):
-        assert self.pgc.time_units == 'Milliseconds'
-        assert self.pgc.time_units == 'Milliseconds'
-        assert self.pgc.temperature_units == 'Degrees C'
-        assert self.pgc.pressure_units == 'Torr'
-        assert self.pgc.current_units == 'Amps'
-        assert self.pgc.voltage_units == 'Volts'
-        assert self.pgc.resistance_units == 'Ohms'
-        assert self.pgc.user == 'eric'
+        assert self.pgc.time_units == "Milliseconds"
+        assert self.pgc.time_units == "Milliseconds"
+        assert self.pgc.temperature_units == "Degrees C"
+        assert self.pgc.pressure_units == "Torr"
+        assert self.pgc.current_units == "Amps"
+        assert self.pgc.voltage_units == "Volts"
+        assert self.pgc.resistance_units == "Ohms"
+        assert self.pgc.user == "eric"
 
 
 #########################
 # Protochips electrical #
 #########################
 
+
 def test_read_protochips_electrical():
-    filename = os.path.join(dirpath, 'protochips_electrical.csv')
-    s = hs.load(filename, reader='protochips')
+    filename = os.path.join(dirpath, "protochips_electrical.csv")
+    s = hs.load(filename, reader="protochips")
     assert len(s) == 6
-    assert s[0].metadata.General.title == 'Channel A Current (Amps)'
-    assert s[0].metadata.Signal.signal_type == ''
-    assert s[0].metadata.Signal.quantity == 'Current (Amps)'
-    assert s[1].metadata.General.title == 'Channel A Voltage (Volts)'
-    assert s[1].metadata.Signal.signal_type == ''
-    assert s[1].metadata.Signal.quantity == 'Voltage (Volts)'
-    assert s[2].metadata.General.title == 'Channel A Resistance (Ohms)'
-    assert s[2].metadata.Signal.signal_type == ''
-    assert s[2].metadata.Signal.quantity == 'Resistance (Ohms)'
-    assert s[3].metadata.General.title == 'Channel B Current (Amps)'
-    assert s[3].metadata.Signal.signal_type == ''
-    assert s[3].metadata.Signal.quantity == 'Current (Amps)'
-    assert s[4].metadata.General.title == 'Channel B Voltage (Volts)'
-    assert s[4].metadata.Signal.signal_type == ''
-    assert s[4].metadata.Signal.quantity == 'Voltage (Volts)'
-    assert s[5].metadata.General.title == 'Channel B Resistance (Ohms)'
-    assert s[5].metadata.Signal.signal_type == ''
-    assert s[5].metadata.Signal.quantity == 'Resistance (Ohms)'
+    assert s[0].metadata.General.title == "Channel A Current (Amps)"
+    assert s[0].metadata.Signal.signal_type == ""
+    assert s[0].metadata.Signal.quantity == "Current (Amps)"
+    assert s[1].metadata.General.title == "Channel A Voltage (Volts)"
+    assert s[1].metadata.Signal.signal_type == ""
+    assert s[1].metadata.Signal.quantity == "Voltage (Volts)"
+    assert s[2].metadata.General.title == "Channel A Resistance (Ohms)"
+    assert s[2].metadata.Signal.signal_type == ""
+    assert s[2].metadata.Signal.quantity == "Resistance (Ohms)"
+    assert s[3].metadata.General.title == "Channel B Current (Amps)"
+    assert s[3].metadata.Signal.signal_type == ""
+    assert s[3].metadata.Signal.quantity == "Current (Amps)"
+    assert s[4].metadata.General.title == "Channel B Voltage (Volts)"
+    assert s[4].metadata.Signal.signal_type == ""
+    assert s[4].metadata.Signal.quantity == "Voltage (Volts)"
+    assert s[5].metadata.General.title == "Channel B Resistance (Ohms)"
+    assert s[5].metadata.Signal.signal_type == ""
+    assert s[5].metadata.Signal.quantity == "Resistance (Ohms)"
 
 
-class TestProtochipsElectricalCSVReader():
-
+class TestProtochipsElectricalCSVReader:
     def setup_method(self, method):
-        self.filename = os.path.join(dirpath, 'protochips_electrical.csv')
+        self.filename = os.path.join(dirpath, "protochips_electrical.csv")
         self.pa = ProtochipsCSV(self.filename)
         if generate_numpy_file:
-            create_numpy_file(self.filename.replace('.csv', '.npy'), self.pa)
+            create_numpy_file(self.filename.replace(".csv", ".npy"), self.pa)
 
     def test_read_column_name(self):
-        assert self.pa.column_name == ['Time', 'Notes',
-                                       'Channel A Current',
-                                       'Channel A Voltage',
-                                       'Channel A Resistance',
-                                       'Channel B Current',
-                                       'Channel B Voltage',
-                                       'Channel B Resistance']
+        assert self.pa.column_name == [
+            "Time",
+            "Notes",
+            "Channel A Current",
+            "Channel A Voltage",
+            "Channel A Resistance",
+            "Channel B Current",
+            "Channel B Voltage",
+            "Channel B Resistance",
+        ]
 
     def test_read_start_datetime(self):
-        dt = np.datetime64('2014-10-08T16:26:51.738000')
+        dt = np.datetime64("2014-10-08T16:26:51.738000")
         assert self.pa.start_datetime == dt
 
     def test_read_data(self):
-        gen = (self.pa._data_dictionary[key]
-               for key in self.pa.logged_quantity_name_list)
+        gen = (
+            self.pa._data_dictionary[key] for key in self.pa.logged_quantity_name_list
+        )
         data = np.vstack(list(gen))
-        expected_data = np.load(os.path.join(
-            dirpath, 'protochips_electrical.npy'))
+        expected_data = np.load(os.path.join(dirpath, "protochips_electrical.npy"))
         np.testing.assert_allclose(data.T, expected_data)
 
 
@@ -249,39 +256,36 @@ class TestProtochipsElectricalCSVReader():
 # Protochips thermal #
 ######################
 
+
 def test_read_protochips_thermal():
-    filename = os.path.join(dirpath, 'protochips_thermal.csv')
-    s = hs.load(filename, reader='protochips')
-    assert (s.metadata.General.title ==
-            'Channel A Temperature (Degrees C)')
-    assert s.metadata.Signal.signal_type == ''
-    assert s.metadata.Signal.quantity == 'Temperature (Degrees C)'
-    assert (s.metadata.General.notes ==
-            'Calibration file name: AD21013_8.cal')
+    filename = os.path.join(dirpath, "protochips_thermal.csv")
+    s = hs.load(filename, reader="protochips")
+    assert s.metadata.General.title == "Channel A Temperature (Degrees C)"
+    assert s.metadata.Signal.signal_type == ""
+    assert s.metadata.Signal.quantity == "Temperature (Degrees C)"
+    assert s.metadata.General.notes == "Calibration file name: AD21013_8.cal"
 
 
-class TestProtochipsThermallCSVReader():
-
+class TestProtochipsThermallCSVReader:
     def setup_method(self, method):
-        self.filename = os.path.join(dirpath, 'protochips_thermal.csv')
+        self.filename = os.path.join(dirpath, "protochips_thermal.csv")
         self.pt = ProtochipsCSV(self.filename)
         if generate_numpy_file:
-            create_numpy_file(self.filename.replace('.csv', '.npy'), self.pt)
+            create_numpy_file(self.filename.replace(".csv", ".npy"), self.pt)
 
     def test_read_column_name(self):
-        assert self.pt.column_name == [
-            'Time', 'Notes', 'Channel A Temperature']
+        assert self.pt.column_name == ["Time", "Notes", "Channel A Temperature"]
 
     def test_read_start_datetime(self):
-        dt = np.datetime64('2014-12-03T17:15:37.192000')
+        dt = np.datetime64("2014-12-03T17:15:37.192000")
         np.testing.assert_equal(self.pt.start_datetime, dt)
 
     def test_read_data(self):
-        gen = (self.pt._data_dictionary[key]
-               for key in self.pt.logged_quantity_name_list)
+        gen = (
+            self.pt._data_dictionary[key] for key in self.pt.logged_quantity_name_list
+        )
         data = np.vstack(list(gen))
-        expected_data = np.load(os.path.join(
-            dirpath, 'protochips_thermal.npy'))
+        expected_data = np.load(os.path.join(dirpath, "protochips_thermal.npy"))
         np.testing.assert_allclose(data.T, expected_data)
 
 
@@ -289,50 +293,53 @@ class TestProtochipsThermallCSVReader():
 # Protochips electrothermal #
 #############################
 
+
 def test_read_protochips_electrothermal():
-    filename = os.path.join(dirpath, 'protochips_electrothermal.csv')
-    s = hs.load(filename, reader='protochips')
+    filename = os.path.join(dirpath, "protochips_electrothermal.csv")
+    s = hs.load(filename, reader="protochips")
     assert len(s) == 4
-    assert (s[0].metadata.General.title ==
-            'Channel A Temperature (Degrees C)')
-    assert s[0].metadata.Signal.signal_type == ''
-    assert s[0].metadata.Signal.quantity == 'Temperature (Degrees C)'
-    assert s[1].metadata.General.title == 'Channel B Current (Amps)'
-    assert s[1].metadata.Signal.signal_type == ''
-    assert (s[0].metadata.General.notes ==
-            'Calibration file name: AD21018_4.cal')
-    assert s[1].metadata.Signal.quantity == 'Current (Amps)'
-    assert s[2].metadata.General.title == 'Channel B Voltage (Volts)'
-    assert s[2].metadata.Signal.signal_type == ''
-    assert s[2].metadata.Signal.quantity == 'Voltage (Volts)'
-    assert s[3].metadata.General.title == 'Channel B Resistance (Ohms)'
-    assert s[3].metadata.Signal.signal_type == ''
-    assert s[3].metadata.Signal.quantity == 'Resistance (Ohms)'
+    assert s[0].metadata.General.title == "Channel A Temperature (Degrees C)"
+    assert s[0].metadata.Signal.signal_type == ""
+    assert s[0].metadata.Signal.quantity == "Temperature (Degrees C)"
+    assert s[1].metadata.General.title == "Channel B Current (Amps)"
+    assert s[1].metadata.Signal.signal_type == ""
+    assert s[0].metadata.General.notes == "Calibration file name: AD21018_4.cal"
+    assert s[1].metadata.Signal.quantity == "Current (Amps)"
+    assert s[2].metadata.General.title == "Channel B Voltage (Volts)"
+    assert s[2].metadata.Signal.signal_type == ""
+    assert s[2].metadata.Signal.quantity == "Voltage (Volts)"
+    assert s[3].metadata.General.title == "Channel B Resistance (Ohms)"
+    assert s[3].metadata.Signal.signal_type == ""
+    assert s[3].metadata.Signal.quantity == "Resistance (Ohms)"
 
 
-class TestProtochipsElectrothermalCSVReader():
-
+class TestProtochipsElectrothermalCSVReader:
     def setup_method(self, method):
-        self.filename = os.path.join(dirpath, 'protochips_electrothermal.csv')
+        self.filename = os.path.join(dirpath, "protochips_electrothermal.csv")
         self.pet = ProtochipsCSV(self.filename)
         if generate_numpy_file:
-            create_numpy_file(self.filename.replace('.csv', '.npy'), self.pet)
+            create_numpy_file(self.filename.replace(".csv", ".npy"), self.pet)
 
     def test_read_column_name(self):
-        assert self.pet.column_name == ['Time', 'Notes',
-                                        'Channel A Temperature',
-                                        'Channel B Current',
-                                        'Channel B Voltage',
-                                        'Channel B Resistance']
+        assert self.pet.column_name == [
+            "Time",
+            "Notes",
+            "Channel A Temperature",
+            "Channel B Current",
+            "Channel B Voltage",
+            "Channel B Resistance",
+        ]
 
     def test_read_start_datetime(self):
-        dt = np.datetime64('2014-11-05T14:42:51.369000')
+        dt = np.datetime64("2014-11-05T14:42:51.369000")
         np.testing.assert_equal(self.pet.start_datetime, dt)
 
     def test_read_data(self):
-        gen = (self.pet._data_dictionary[key]
-               for key in self.pet.logged_quantity_name_list)
+        gen = (
+            self.pet._data_dictionary[key] for key in self.pet.logged_quantity_name_list
+        )
         data = np.vstack(list(gen))
-        expected_data = np.load(os.path.join(dirpath,
-                                             self.filename.replace('.csv', '.npy')))
+        expected_data = np.load(
+            os.path.join(dirpath, self.filename.replace(".csv", ".npy"))
+        )
         np.testing.assert_allclose(data.T, expected_data)

--- a/rsciio/tests/test_ripple.py
+++ b/rsciio/tests/test_ripple.py
@@ -11,10 +11,11 @@ from hyperspy.io import load
 from rsciio.ripple import api as ripple
 
 # Tuple of tuples (data shape, signal_dimensions)
-SHAPES_SDIM = (((3,), (1, )),
-               ((2, 3), (1, 2)),
-               ((2, 3, 4), (1, 2)),
-               )
+SHAPES_SDIM = (
+    ((3,), (1,)),
+    ((2, 3), (1, 2)),
+    ((2, 3, 4), (1, 2)),
+)
 
 MYPATH = os.path.dirname(__file__)
 
@@ -23,14 +24,14 @@ def test_write_unsupported_data_shape():
     data = np.arange(5 * 10 * 15 * 20).reshape((5, 10, 15, 20))
     s = signals.Signal1D(data)
     with pytest.raises(TypeError):
-        s.save('test_write_unsupported_data_shape.rpl')
+        s.save("test_write_unsupported_data_shape.rpl")
 
 
 def test_write_unsupported_data_type():
     data = np.arange(5 * 10 * 15).reshape((5, 10, 15)).astype(np.float16)
     s = signals.Signal1D(data)
     with pytest.raises(IOError):
-        s.save('test_write_unsupported_data_type.rpl')
+        s.save("test_write_unsupported_data_type.rpl")
 
 
 # Test failing
@@ -48,7 +49,7 @@ def test_write_without_metadata():
     data = np.arange(5 * 10 * 15).reshape((5, 10, 15))
     s = signals.Signal1D(data)
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test_write_without_metadata.rpl')
+        fname = os.path.join(tmpdir, "test_write_without_metadata.rpl")
         s.save(fname)
         s2 = load(fname)
         np.testing.assert_allclose(s.data, s2.data)
@@ -60,17 +61,17 @@ def test_write_without_metadata():
 def test_write_with_metadata():
     data = np.arange(5 * 10).reshape((5, 10))
     s = signals.Signal1D(data)
-    s.metadata.set_item('General.date', "2016-08-06")
-    s.metadata.set_item('General.time', "10:55:00")
-    s.metadata.set_item('General.title', "Test title")
+    s.metadata.set_item("General.date", "2016-08-06")
+    s.metadata.set_item("General.time", "10:55:00")
+    s.metadata.set_item("General.title", "Test title")
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test_write_with_metadata.rpl')
+        fname = os.path.join(tmpdir, "test_write_with_metadata.rpl")
         s.save(fname)
         s2 = load(fname)
         np.testing.assert_allclose(s.data, s2.data)
         assert s.metadata.General.date == s2.metadata.General.date
-        assert (s.metadata.General.title == s2.metadata.General.title)
-        assert (s.metadata.General.time == s2.metadata.General.time)
+        assert s.metadata.General.title == s2.metadata.General.title
+        assert s.metadata.General.time == s2.metadata.General.time
         del s2
         gc.collect()
 
@@ -81,11 +82,14 @@ def generate_parameters():
         for shape, dims in SHAPES_SDIM:
             for dim in dims:
                 for metadata in [True, False]:
-                    parameters.append({
-                        "dtype": dtype,
-                        "shape": shape,
-                        "dim": dim,
-                        "metadata": metadata, })
+                    parameters.append(
+                        {
+                            "dtype": dtype,
+                            "shape": shape,
+                            "dim": dim,
+                            "metadata": metadata,
+                        }
+                    )
     return parameters
 
 
@@ -94,31 +98,31 @@ def _get_filename(s, metadata):
         s.axes_manager.signal_dimension,
         s.axes_manager.navigation_dimension,
         s.data.dtype.name,
-        "_meta" if metadata else "")
+        "_meta" if metadata else "",
+    )
     return filename
 
 
 def _create_signal(shape, dim, dtype, metadata):
-    data = np.arange(np.product(shape)).reshape(
-        shape).astype(dtype)
+    data = np.arange(np.product(shape)).reshape(shape).astype(dtype)
     if dim == 1:
         if len(shape) > 2:
             s = signals.EELSSpectrum(data)
             if metadata:
                 s.set_microscope_parameters(
-                    beam_energy=100.,
-                    convergence_angle=1.,
-                    collection_angle=10.)
+                    beam_energy=100.0, convergence_angle=1.0, collection_angle=10.0
+                )
         else:
             s = signals.EDSTEMSpectrum(data)
             if metadata:
                 s.set_microscope_parameters(
-                    beam_energy=100.,
-                    live_time=1.,
-                    tilt_stage=2.,
-                    azimuth_angle=3.,
-                    elevation_angle=4.,
-                    energy_resolution_MnKa=5.)
+                    beam_energy=100.0,
+                    live_time=1.0,
+                    tilt_stage=2.0,
+                    azimuth_angle=3.0,
+                    elevation_angle=4.0,
+                    energy_resolution_MnKa=5.0,
+                )
     else:
         s = signals.BaseSignal(data).transpose(signal_axes=dim)
     if metadata:
@@ -141,13 +145,13 @@ def _create_signal(shape, dim, dtype, metadata):
 @pytest.mark.parametrize("pdict", generate_parameters())
 def test_data(pdict):
     dtype, shape, dim, metadata = (
-        pdict["dtype"], pdict["shape"], pdict["dim"], pdict["metadata"])
+        pdict["dtype"],
+        pdict["shape"],
+        pdict["dim"],
+        pdict["metadata"],
+    )
     with tempfile.TemporaryDirectory() as tmpdir:
-        s = _create_signal(
-            shape=shape,
-            dim=dim,
-            dtype=dtype,
-            metadata=metadata)
+        s = _create_signal(shape=shape, dim=dim, dtype=dtype, metadata=metadata)
         filename = _get_filename(s, metadata)
         s.save(os.path.join(tmpdir, filename))
         s_just_saved = load(os.path.join(tmpdir, filename))
@@ -156,16 +160,17 @@ def test_data(pdict):
             for stest in (s_just_saved, s_ref):
                 npt.assert_array_equal(s.data, stest.data)
                 assert s.data.dtype == stest.data.dtype
-                assert (s.axes_manager.signal_dimension ==
-                        stest.axes_manager.signal_dimension)
-                assert (s.metadata.General.title ==
-                        stest.metadata.General.title)
-                mdpaths = ("Signal.signal_type", )
+                assert (
+                    s.axes_manager.signal_dimension
+                    == stest.axes_manager.signal_dimension
+                )
+                assert s.metadata.General.title == stest.metadata.General.title
+                mdpaths = ("Signal.signal_type",)
                 if s.metadata.Signal.signal_type == "EELS" and metadata:
                     mdpaths += (
                         "Acquisition_instrument.TEM.convergence_angle",
                         "Acquisition_instrument.TEM.beam_energy",
-                        "Acquisition_instrument.TEM.Detector.EELS.collection_angle"
+                        "Acquisition_instrument.TEM.Detector.EELS.collection_angle",
                     )
                 elif "EDS" in s.metadata.Signal.signal_type and metadata:
                     mdpaths += (
@@ -180,13 +185,13 @@ def test_data(pdict):
                     mdpaths = (
                         "General.date",
                         "General.time",
-                        "General.title",)
+                        "General.title",
+                    )
                 for mdpath in mdpaths:
-                    assert (
-                        s.metadata.get_item(mdpath) ==
-                        stest.metadata.get_item(mdpath))
-                for saxis, taxis in zip(
-                        s.axes_manager._axes, stest.axes_manager._axes):
+                    assert s.metadata.get_item(mdpath) == stest.metadata.get_item(
+                        mdpath
+                    )
+                for saxis, taxis in zip(s.axes_manager._axes, stest.axes_manager._axes):
                     taxis.convert_to_units()
                     assert saxis.scale == taxis.scale
                     assert saxis.offset == taxis.offset
@@ -217,8 +222,9 @@ def generate_files():
         for shape, dims in SHAPES_SDIM:
             for dim in dims:
                 for metadata in [True, False]:
-                    s = _create_signal(shape=shape, dim=dim, dtype=dtype,
-                                       metadata=metadata)
+                    s = _create_signal(
+                        shape=shape, dim=dim, dtype=dtype, metadata=metadata
+                    )
                     filename = _get_filename(s, metadata)
                     filepath = os.path.join(MYPATH, "ripple_files", filename)
                     s.save(filepath, overwrite=True)

--- a/rsciio/tests/test_semper_unf.py
+++ b/rsciio/tests/test_semper_unf.py
@@ -29,36 +29,37 @@ from hyperspy.signals import BaseSignal, ComplexSignal, Signal1D, Signal2D
 my_path = os.path.dirname(__file__)
 
 # Reference data:
-data_signal = np.arange(27, dtype=np.float32).reshape((3, 3, 3)) / 2.
-data_image = np.arange(16, dtype=np.float32).reshape((4, 4)) / 2.
-data_spectrum = np.arange(10, dtype=np.float32) / 2.
-data_image_byte = np.arange(
-    25, dtype=np.byte).reshape(
-    (5, 5))  # Odd dim. tests strange read/write
+data_signal = np.arange(27, dtype=np.float32).reshape((3, 3, 3)) / 2.0
+data_image = np.arange(16, dtype=np.float32).reshape((4, 4)) / 2.0
+data_spectrum = np.arange(10, dtype=np.float32) / 2.0
+data_image_byte = np.arange(25, dtype=np.byte).reshape(
+    (5, 5)
+)  # Odd dim. tests strange read/write
 data_image_int16 = np.arange(16, dtype=np.int16).reshape((4, 4))
 data_image_int32 = np.arange(16, dtype=np.int32).reshape((4, 4))
 data_image_complex = (data_image_int32 + 1j * data_image).astype(np.complex64)
-test_title = 'This is a test!'
+test_title = "This is a test!"
 
 
 def test_writing_unsupported_data_type():
     data = np.arange(5 * 10).reshape((5, 10))
-    s = BaseSignal(data.astype('int64'))
+    s = BaseSignal(data.astype("int64"))
     with tempfile.TemporaryDirectory() as tmpdir:
         with pytest.raises(IOError) as cm:
-            fname = os.path.join(tmpdir,
-                                 'test_writing_unsupported_data_type.unf')
+            fname = os.path.join(tmpdir, "test_writing_unsupported_data_type.unf")
             s.save(fname)
-            cm.match("The SEMPER file format does not support int64 data type",)
+            cm.match(
+                "The SEMPER file format does not support int64 data type",
+            )
 
 
 def test_writing_loading_metadata():
     data = np.arange(5 * 10).reshape((5, 10)).astype(np.int8)
     s = BaseSignal(data)
-    s.metadata.set_item('General.date', "2016-08-06")
-    s.metadata.set_item('General.time', "11:55:00")
+    s.metadata.set_item("General.date", "2016-08-06")
+    s.metadata.set_item("General.time", "11:55:00")
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test_write_with_metadata.unf')
+        fname = os.path.join(tmpdir, "test_write_with_metadata.unf")
         s.save(fname)
         s2 = load(fname)
         np.testing.assert_allclose(s.data, s2.data)
@@ -67,72 +68,56 @@ def test_writing_loading_metadata():
 
 
 def test_signal_3d_loading():
-    signal = load(os.path.join(my_path, 'unf_files', 'example_signal_3d.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_signal_3d.unf"))
     np.testing.assert_equal(signal.data, data_signal)
     np.testing.assert_equal(signal.original_metadata.IFORM, 2)  # float
     assert isinstance(signal, BaseSignal)
 
 
 def test_image_2d_loading():
-    signal = load(os.path.join(my_path, 'unf_files', 'example_image_2d.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_image_2d.unf"))
     np.testing.assert_equal(signal.data, data_image)
     np.testing.assert_equal(signal.original_metadata.IFORM, 2)  # float
     assert isinstance(signal, Signal2D)
 
 
 def test_spectrum_1d_loading():
-    signal = load(
-        os.path.join(
-            my_path,
-            'unf_files',
-            'example_spectrum_1d.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_spectrum_1d.unf"))
     np.testing.assert_equal(signal.data, data_spectrum)
     np.testing.assert_equal(signal.original_metadata.IFORM, 2)  # float
     assert isinstance(signal, Signal1D)
 
 
 def test_image_byte_loading():
-    signal = load(os.path.join(my_path, 'unf_files', 'example_image_byte.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_image_byte.unf"))
     np.testing.assert_equal(signal.data, data_image_byte)
     np.testing.assert_equal(signal.original_metadata.IFORM, 0)  # byte
     assert isinstance(signal, Signal2D)
 
 
 def test_image_int16_loading():
-    signal = load(
-        os.path.join(
-            my_path,
-            'unf_files',
-            'example_image_int16.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_image_int16.unf"))
     np.testing.assert_equal(signal.data, data_image_int16)
     np.testing.assert_equal(signal.original_metadata.IFORM, 1)  # int16
     assert isinstance(signal, Signal2D)
 
 
 def test_image_int32_loading():
-    signal = load(
-        os.path.join(
-            my_path,
-            'unf_files',
-            'example_image_int32.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_image_int32.unf"))
     np.testing.assert_equal(signal.data, data_image_int32)
     np.testing.assert_equal(signal.original_metadata.IFORM, 4)  # int32
     assert isinstance(signal, Signal2D)
 
 
 def test_image_complex_loading():
-    signal = load(
-        os.path.join(
-            my_path,
-            'unf_files',
-            'example_image_complex.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_image_complex.unf"))
     np.testing.assert_equal(signal.data, data_image_complex)
     np.testing.assert_equal(signal.original_metadata.IFORM, 3)  # complex
     assert isinstance(signal, ComplexSignal)
 
 
 def test_with_title_loading():
-    signal = load(os.path.join(my_path, 'unf_files', 'example_with_title.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_with_title.unf"))
     np.testing.assert_equal(signal.data, data_image)
     np.testing.assert_equal(signal.original_metadata.IFORM, 2)  # float
     np.testing.assert_equal(signal.metadata.General.title, test_title)
@@ -140,43 +125,39 @@ def test_with_title_loading():
 
 
 def test_no_label_loading():
-    signal = load(os.path.join(my_path, 'unf_files', 'example_no_label.unf'))
+    signal = load(os.path.join(my_path, "unf_files", "example_no_label.unf"))
     np.testing.assert_equal(signal.data, data_image)
     np.testing.assert_equal(signal.original_metadata.ILABEL, 0)
     assert isinstance(signal, Signal2D)
 
 
-class TestCaseSaveAndReadImage():
-
+class TestCaseSaveAndReadImage:
     def test_save_and_read(self):
         signal_ref = Signal2D(data_image)
         signal_ref.metadata.General.title = test_title
         signal_ref.save(
-            os.path.join(
-                my_path,
-                'unf_files',
-                'example_temp.unf'),
-            overwrite=True)
-        signal = load(os.path.join(my_path, 'unf_files', 'example_temp.unf'))
+            os.path.join(my_path, "unf_files", "example_temp.unf"), overwrite=True
+        )
+        signal = load(os.path.join(my_path, "unf_files", "example_temp.unf"))
         np.testing.assert_equal(signal.data, signal_ref.data)
         np.testing.assert_equal(signal.metadata.General.title, test_title)
         assert isinstance(signal, Signal2D)
 
     def teardown_method(self, method):
-        remove(os.path.join(my_path, 'unf_files', 'example_temp.unf'))
+        remove(os.path.join(my_path, "unf_files", "example_temp.unf"))
 
 
-class TestCaseSaveAndReadByte():
-
+class TestCaseSaveAndReadByte:
     def test_save_and_read(self):
         signal_ref = Signal2D(data_image_byte)
         signal_ref.metadata.General.title = test_title
-        signal_ref.save(os.path.join(my_path, 'unf_files', 'example_temp.unf'),
-                        overwrite=True)
-        signal = load(os.path.join(my_path, 'unf_files', 'example_temp.unf'))
+        signal_ref.save(
+            os.path.join(my_path, "unf_files", "example_temp.unf"), overwrite=True
+        )
+        signal = load(os.path.join(my_path, "unf_files", "example_temp.unf"))
         np.testing.assert_equal(signal.data, signal_ref.data)
         np.testing.assert_equal(signal.metadata.General.title, test_title)
         assert isinstance(signal, Signal2D)
 
     def teardown_method(self, method):
-        remove(os.path.join(my_path, 'unf_files', 'example_temp.unf'))
+        remove(os.path.join(my_path, "unf_files", "example_temp.unf"))

--- a/rsciio/tests/test_sur.py
+++ b/rsciio/tests/test_sur.py
@@ -24,223 +24,229 @@ from hyperspy.io import load
 
 MY_PATH = os.path.dirname(__file__)
 
-header_keys = ['H01_Signature',
-                 'H02_Format',
-                 'H03_Number_of_Objects',
-                 'H04_Version',
-                 'H05_Object_Type',
-                 'H06_Object_Name',
-                 'H07_Operator_Name',
-                 'H08_P_Size',
-                 'H09_Acquisition_Type',
-                 'H10_Range_Type',
-                 'H11_Special_Points',
-                 'H12_Absolute',
-                 'H13_Gauge_Resolution',
-                 'H14_W_Size',
-                 'H15_Size_of_Points',
-                 'H16_Zmin',
-                 'H17_Zmax',
-                 'H18_Number_of_Points',
-                 'H19_Number_of_Lines',
-                 'H20_Total_Nb_of_Pts',
-                 'H21_X_Spacing',
-                 'H22_Y_Spacing',
-                 'H23_Z_Spacing',
-                 'H24_Name_of_X_Axis',
-                 'H25_Name_of_Y_Axis',
-                 'H26_Name_of_Z_Axis',
-                 'H27_X_Step_Unit',
-                 'H28_Y_Step_Unit',
-                 'H29_Z_Step_Unit',
-                 'H30_X_Length_Unit',
-                 'H31_Y_Length_Unit',
-                 'H32_Z_Length_Unit',
-                 'H33_X_Unit_Ratio',
-                 'H34_Y_Unit_Ratio',
-                 'H35_Z_Unit_Ratio',
-                 'H36_Imprint',
-                 'H37_Inverted',
-                 'H38_Levelled',
-                 'H39_Obsolete',
-                 'H40_Seconds',
-                 'H41_Minutes',
-                 'H42_Hours',
-                 'H43_Day',
-                 'H44_Month',
-                 'H45_Year',
-                 'H46_Day_of_week',
-                 'H47_Measurement_duration',
-                 'H48_Compressed_data_size',
-                 'H49_Obsolete',
-                 'H50_Comment_size',
-                 'H51_Private_size',
-                 'H52_Client_zone',
-                 'H53_X_Offset',
-                 'H54_Y_Offset',
-                 'H55_Z_Offset',
-                 'H56_T_Spacing',
-                 'H57_T_Offset',
-                 'H58_T_Axis_Name',
-                 'H59_T_Step_Unit',
-                 'H60_Comment',
-                 ]
+header_keys = [
+    "H01_Signature",
+    "H02_Format",
+    "H03_Number_of_Objects",
+    "H04_Version",
+    "H05_Object_Type",
+    "H06_Object_Name",
+    "H07_Operator_Name",
+    "H08_P_Size",
+    "H09_Acquisition_Type",
+    "H10_Range_Type",
+    "H11_Special_Points",
+    "H12_Absolute",
+    "H13_Gauge_Resolution",
+    "H14_W_Size",
+    "H15_Size_of_Points",
+    "H16_Zmin",
+    "H17_Zmax",
+    "H18_Number_of_Points",
+    "H19_Number_of_Lines",
+    "H20_Total_Nb_of_Pts",
+    "H21_X_Spacing",
+    "H22_Y_Spacing",
+    "H23_Z_Spacing",
+    "H24_Name_of_X_Axis",
+    "H25_Name_of_Y_Axis",
+    "H26_Name_of_Z_Axis",
+    "H27_X_Step_Unit",
+    "H28_Y_Step_Unit",
+    "H29_Z_Step_Unit",
+    "H30_X_Length_Unit",
+    "H31_Y_Length_Unit",
+    "H32_Z_Length_Unit",
+    "H33_X_Unit_Ratio",
+    "H34_Y_Unit_Ratio",
+    "H35_Z_Unit_Ratio",
+    "H36_Imprint",
+    "H37_Inverted",
+    "H38_Levelled",
+    "H39_Obsolete",
+    "H40_Seconds",
+    "H41_Minutes",
+    "H42_Hours",
+    "H43_Day",
+    "H44_Month",
+    "H45_Year",
+    "H46_Day_of_week",
+    "H47_Measurement_duration",
+    "H48_Compressed_data_size",
+    "H49_Obsolete",
+    "H50_Comment_size",
+    "H51_Private_size",
+    "H52_Client_zone",
+    "H53_X_Offset",
+    "H54_Y_Offset",
+    "H55_Z_Offset",
+    "H56_T_Spacing",
+    "H57_T_Offset",
+    "H58_T_Axis_Name",
+    "H59_T_Step_Unit",
+    "H60_Comment",
+]
 
-atto_head_keys = ['WAFER',
-                            'SITE IMAGE',
-                            'SEM',
-                            'CHANNELS',
-                            'SPECTROMETER',
-                            'SCAN',
-                            ]
+atto_head_keys = [
+    "WAFER",
+    "SITE IMAGE",
+    "SEM",
+    "CHANNELS",
+    "SPECTROMETER",
+    "SCAN",
+]
 
-atto_wafer_keys = ['Lot Number',
-                     'ID',
-                     'Type',
-                     'Center Position X',
-                     'Center Position X_units',
-                     'Center Position Y',
-                     'Center Position Y_units',
-                     'Orientation',
-                     'Orientation_units',
-                     'Diameter',
-                     'Diameter_units',
-                     'Flat Length',
-                     'Flat Length_units',
-                     'Edge Exclusion',
-                     'Edge Exclusion_units',
-                     ]
+atto_wafer_keys = [
+    "Lot Number",
+    "ID",
+    "Type",
+    "Center Position X",
+    "Center Position X_units",
+    "Center Position Y",
+    "Center Position Y_units",
+    "Orientation",
+    "Orientation_units",
+    "Diameter",
+    "Diameter_units",
+    "Flat Length",
+    "Flat Length_units",
+    "Edge Exclusion",
+    "Edge Exclusion_units",
+]
 
-atto_scan_keys = ['Mode',
-                 'HYP Dwelltime',
-                 'HYP Dwelltime_units',
-                 'Resolution_X',
-                 'Resolution_X_units',
-                 'Resolution_Y',
-                 'Resolution_Y_units',
-                 'Reference_Size_X',
-                 'Reference_Size_Y',
-                 'Voltage Calibration Range_X',
-                 'Voltage Calibration Range_X_units',
-                 'Voltage Calibration Range_Y',
-                 'Voltage Calibration Range_Y_units',
-                 'Start_X',
-                 'Size_X',
-                 'Start_Y',
-                 'Size_Y',
-                 'Rotate',
-                 'Rotate_units',
-                 ]
+atto_scan_keys = [
+    "Mode",
+    "HYP Dwelltime",
+    "HYP Dwelltime_units",
+    "Resolution_X",
+    "Resolution_X_units",
+    "Resolution_Y",
+    "Resolution_Y_units",
+    "Reference_Size_X",
+    "Reference_Size_Y",
+    "Voltage Calibration Range_X",
+    "Voltage Calibration Range_X_units",
+    "Voltage Calibration Range_Y",
+    "Voltage Calibration Range_Y_units",
+    "Start_X",
+    "Size_X",
+    "Start_Y",
+    "Size_Y",
+    "Rotate",
+    "Rotate_units",
+]
+
 
 def test_load_profile():
-    #Signal loading
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_profile.pro")
+    # Signal loading
+    fname = os.path.join(MY_PATH, "sur_data", "test_profile.pro")
     s = load(fname)
 
-    #Verifying signal shape and axes dimensions, navigation (not data themselves)
+    # Verifying signal shape and axes dimensions, navigation (not data themselves)
     assert s.data.shape == (128,)
     assert s.data.dtype == np.dtype(float)
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252197e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    assert s.axes_manager[0].name == 'Width'
-    assert s.axes_manager[0].units == 'mm'
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252197e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.0)
+    assert s.axes_manager[0].name == "Width"
+    assert s.axes_manager[0].units == "mm"
     assert s.axes_manager[0].size == 128
     assert s.axes_manager[0].navigate == False
 
-    #Metadata verification
+    # Metadata verification
     md = s.metadata
-    assert md.Signal.quantity == 'CL Intensity (a.u.)'
+    assert md.Signal.quantity == "CL Intensity (a.u.)"
 
-    #Original metadata. We verify that the correct structure is given
-    #and the right headers but not the values
+    # Original metadata. We verify that the correct structure is given
+    # and the right headers but not the values
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
-    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                            == header_keys
+    assert list(omd.as_dictionary().keys()) == ["Object_0_Channel_0"]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header"]
+    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
+
 
 def test_load_RGB():
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_RGB.sur")
+    fname = os.path.join(MY_PATH, "sur_data", "test_RGB.sur")
     s = load(fname)
     assert s.data.shape == (200, 200)
-    assert s.data.dtype == np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1')])
+    assert s.data.dtype == np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1")])
 
-    np.testing.assert_allclose(s.axes_manager[0].scale,0.35277777)
-    np.testing.assert_allclose(s.axes_manager[0].offset,208.8444519)
-    np.testing.assert_allclose(s.axes_manager[1].scale,0.35277777)
-    np.testing.assert_allclose(s.axes_manager[1].offset,210.608337)
-    assert s.axes_manager[0].name == 'X'
-    assert s.axes_manager[0].units == 'mm'
-    assert s.axes_manager[1].name == 'Y'
-    assert s.axes_manager[1].units == 'mm'
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.35277777)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 208.8444519)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.35277777)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 210.608337)
+    assert s.axes_manager[0].name == "X"
+    assert s.axes_manager[0].units == "mm"
+    assert s.axes_manager[1].name == "Y"
+    assert s.axes_manager[1].units == "mm"
     assert s.axes_manager[0].size == 200
     assert s.axes_manager[0].navigate == False
     assert s.axes_manager[1].size == 200
     assert s.axes_manager[1].navigate == False
 
     md = s.metadata
-    assert md.Signal.quantity == 'Z'
+    assert md.Signal.quantity == "Z"
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0',
-                                                'Object_0_Channel_1',
-                                                'Object_0_Channel_2']
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
+    assert list(omd.as_dictionary().keys()) == [
+        "Object_0_Channel_0",
+        "Object_0_Channel_1",
+        "Object_0_Channel_2",
+    ]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header"]
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
 
+
 def test_load_spectra():
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_spectra.pro")
+    fname = os.path.join(MY_PATH, "sur_data", "test_spectra.pro")
     s = load(fname)
 
     assert s.data.shape == (65, 512)
-    assert s.data.dtype == np.dtype('float64')
+    assert s.data.dtype == np.dtype("float64")
 
     md = s.metadata
-    assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    np.testing.assert_allclose(s.axes_manager[0].scale,0.00011458775406936184)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    np.testing.assert_allclose(s.axes_manager[1].scale,1.084000246009964e-06)
-    np.testing.assert_allclose(s.axes_manager[1].offset,0.00017284281784668565)
-    assert s.axes_manager[0].name == 'Spectrum positi'
-    assert s.axes_manager[0].units == 'mm'
-    assert s.axes_manager[1].name == 'Wavelength'
-    assert s.axes_manager[1].units == 'mm'
+    assert md.Signal.quantity == "CL Intensity (a.u.)"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.00011458775406936184)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.0)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.084000246009964e-06)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 0.00017284281784668565)
+    assert s.axes_manager[0].name == "Spectrum positi"
+    assert s.axes_manager[0].units == "mm"
+    assert s.axes_manager[1].name == "Wavelength"
+    assert s.axes_manager[1].units == "mm"
     assert s.axes_manager[0].size == 65
     assert s.axes_manager[0].navigate == True
     assert s.axes_manager[1].size == 512
     assert s.axes_manager[1].navigate == False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0',]
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
-    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                                == header_keys
+    assert list(omd.as_dictionary().keys()) == [
+        "Object_0_Channel_0",
+    ]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header"]
+    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
+
 
 def test_load_spectral_map_compressed():
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_spectral_map_compressed.sur")
+    fname = os.path.join(MY_PATH, "sur_data", "test_spectral_map_compressed.sur")
     s = load(fname)
 
     assert s.data.shape == (12, 10, 281)
-    assert s.data.dtype == np.dtype('float64')
+    assert s.data.dtype == np.dtype("float64")
 
     md = s.metadata
-    assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.005694016348570585)
-    np.testing.assert_allclose(s.axes_manager[1].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[1].offset,0.0054464503191411495)
-    np.testing.assert_allclose(s.axes_manager[2].scale,1.084000246009964e-06)
-    np.testing.assert_allclose(s.axes_manager[2].offset,0.00034411484375596046)
-    assert s.axes_manager[0].name == 'Width'
-    assert s.axes_manager[0].units == 'mm'
-    assert s.axes_manager[1].name == 'Height'
-    assert s.axes_manager[1].units == 'mm'
-    assert s.axes_manager[2].name == 'Wavelength'
-    assert s.axes_manager[2].units == 'mm'
+    assert md.Signal.quantity == "CL Intensity (a.u.)"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.005694016348570585)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 0.0054464503191411495)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.084000246009964e-06)
+    np.testing.assert_allclose(s.axes_manager[2].offset, 0.00034411484375596046)
+    assert s.axes_manager[0].name == "Width"
+    assert s.axes_manager[0].units == "mm"
+    assert s.axes_manager[1].name == "Height"
+    assert s.axes_manager[1].units == "mm"
+    assert s.axes_manager[2].name == "Wavelength"
+    assert s.axes_manager[2].units == "mm"
     assert s.axes_manager[0].size == 10
     assert s.axes_manager[0].navigate == True
     assert s.axes_manager[1].size == 12
@@ -249,43 +255,46 @@ def test_load_spectral_map_compressed():
     assert s.axes_manager[2].navigate == False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0',]
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) \
-                                                            == ['Header','Parsed']
-    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                            == header_keys
+    assert list(omd.as_dictionary().keys()) == [
+        "Object_0_Channel_0",
+    ]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header", "Parsed"]
+    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
 
-    assert list(omd.Object_0_Channel_0.Parsed.as_dictionary().keys()) \
-                                                            == atto_head_keys
+    assert list(omd.Object_0_Channel_0.Parsed.as_dictionary().keys()) == atto_head_keys
 
-    assert list(omd.Object_0_Channel_0.Parsed.WAFER.as_dictionary().keys()) \
-                                                            == atto_wafer_keys
+    assert (
+        list(omd.Object_0_Channel_0.Parsed.WAFER.as_dictionary().keys())
+        == atto_wafer_keys
+    )
 
-    assert list(omd.Object_0_Channel_0.Parsed.SCAN.as_dictionary().keys()) \
-                                                            == atto_scan_keys
+    assert (
+        list(omd.Object_0_Channel_0.Parsed.SCAN.as_dictionary().keys())
+        == atto_scan_keys
+    )
+
 
 def test_load_spectral_map():
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_spectral_map.sur")
+    fname = os.path.join(MY_PATH, "sur_data", "test_spectral_map.sur")
     s = load(fname)
 
     assert s.data.shape == (12, 10, 310)
-    assert s.data.dtype == np.dtype('float64')
+    assert s.data.dtype == np.dtype("float64")
 
     md = s.metadata
-    assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252197585534304e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.00701436772942543)
-    np.testing.assert_allclose(s.axes_manager[1].scale,8.252197585534304e-05)
-    np.testing.assert_allclose(s.axes_manager[1].offset,0.003053313121199608)
-    np.testing.assert_allclose(s.axes_manager[2].scale,1.084000246009964e-6)
-    np.testing.assert_allclose(s.axes_manager[2].offset,0.0003332748601678759)
-    assert s.axes_manager[0].name == 'Width'
-    assert s.axes_manager[0].units == 'mm'
-    assert s.axes_manager[1].name == 'Height'
-    assert s.axes_manager[1].units == 'mm'
-    assert s.axes_manager[2].name == 'Wavelength'
-    assert s.axes_manager[2].units == 'mm'
+    assert md.Signal.quantity == "CL Intensity (a.u.)"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252197585534304e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.00701436772942543)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 8.252197585534304e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 0.003053313121199608)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[2].offset, 0.0003332748601678759)
+    assert s.axes_manager[0].name == "Width"
+    assert s.axes_manager[0].units == "mm"
+    assert s.axes_manager[1].name == "Height"
+    assert s.axes_manager[1].units == "mm"
+    assert s.axes_manager[2].name == "Wavelength"
+    assert s.axes_manager[2].units == "mm"
     assert s.axes_manager[0].size == 10
     assert s.axes_manager[0].navigate == True
     assert s.axes_manager[1].size == 12
@@ -293,100 +302,100 @@ def test_load_spectral_map():
     assert s.axes_manager[2].size == 310
     assert s.axes_manager[2].navigate == False
 
-
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0',]
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header','Parsed']
-    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                               == header_keys
+    assert list(omd.as_dictionary().keys()) == [
+        "Object_0_Channel_0",
+    ]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header", "Parsed"]
+    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
 
-    assert list(omd.Object_0_Channel_0.Parsed.as_dictionary().keys()) \
-                                                            == atto_head_keys
+    assert list(omd.Object_0_Channel_0.Parsed.as_dictionary().keys()) == atto_head_keys
 
-    assert list(omd.Object_0_Channel_0.Parsed.WAFER.as_dictionary().keys()) \
-                                                            == atto_wafer_keys
+    assert (
+        list(omd.Object_0_Channel_0.Parsed.WAFER.as_dictionary().keys())
+        == atto_wafer_keys
+    )
 
-    assert list(omd.Object_0_Channel_0.Parsed.SCAN.as_dictionary().keys())  \
-                                                            == atto_scan_keys
+    assert (
+        list(omd.Object_0_Channel_0.Parsed.SCAN.as_dictionary().keys())
+        == atto_scan_keys
+    )
+
 
 def test_load_spectrum_compressed():
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_spectrum_compressed.pro")
+    fname = os.path.join(MY_PATH, "sur_data", "test_spectrum_compressed.pro")
     s = load(fname)
     md = s.metadata
-    assert md.Signal.quantity == 'CL Intensity (a.u.)'
+    assert md.Signal.quantity == "CL Intensity (a.u.)"
     assert s.data.shape == (512,)
-    #np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
-    #np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    np.testing.assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
-    np.testing.assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
+    # np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
+    # np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 172.84281784668565e-6)
 
-    #assert s.axes_manager[0].name == 'T'
-    #assert s.axes_manager[0].units == ''
-    assert s.axes_manager[0].name == 'Wavelength'
-    assert s.axes_manager[0].units == 'mm'
-    #assert s.axes_manager[0].size == 1
-    #assert s.axes_manager[0].navigate == True
+    # assert s.axes_manager[0].name == 'T'
+    # assert s.axes_manager[0].units == ''
+    assert s.axes_manager[0].name == "Wavelength"
+    assert s.axes_manager[0].units == "mm"
+    # assert s.axes_manager[0].size == 1
+    # assert s.axes_manager[0].navigate == True
     assert s.axes_manager[0].size == 512
     assert s.axes_manager[0].navigate == False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
-    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                                == header_keys
+    assert list(omd.as_dictionary().keys()) == ["Object_0_Channel_0"]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header"]
+    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
+
 
 def test_load_spectrum():
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_spectrum.pro")
+    fname = os.path.join(MY_PATH, "sur_data", "test_spectrum.pro")
     s = load(fname)
     assert s.data.shape == (512,)
 
     md = s.metadata
-    assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    #np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
-    #np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    np.testing.assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
-    np.testing.assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
+    assert md.Signal.quantity == "CL Intensity (a.u.)"
+    # np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
+    # np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 172.84281784668565e-6)
 
-    #assert s.axes_manager[0].name == 'T'
-    #assert s.axes_manager[0].units == ''
-    assert s.axes_manager[0].name == 'Wavelength'
-    assert s.axes_manager[0].units == 'mm'
-    #assert s.axes_manager[0].size == 1
-    #assert s.axes_manager[0].navigate == True
+    # assert s.axes_manager[0].name == 'T'
+    # assert s.axes_manager[0].units == ''
+    assert s.axes_manager[0].name == "Wavelength"
+    assert s.axes_manager[0].units == "mm"
+    # assert s.axes_manager[0].size == 1
+    # assert s.axes_manager[0].navigate == True
     assert s.axes_manager[0].size == 512
     assert s.axes_manager[0].navigate == False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
-    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                                == header_keys
+    assert list(omd.as_dictionary().keys()) == ["Object_0_Channel_0"]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header"]
+    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
+
 
 def test_load_surface():
-    fname = os.path.join(MY_PATH, "sur_data",
-                         "test_surface.sur")
+    fname = os.path.join(MY_PATH, "sur_data", "test_surface.sur")
     s = load(fname)
     md = s.metadata
-    assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    assert s.data.shape == (128,128)
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    np.testing.assert_allclose(s.axes_manager[1].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[1].offset,0.0)
+    assert md.Signal.quantity == "CL Intensity (a.u.)"
+    assert s.data.shape == (128, 128)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.0)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 0.0)
 
-    assert s.axes_manager[0].name == 'Width'
-    assert s.axes_manager[0].units == 'mm'
-    assert s.axes_manager[1].name == 'Height'
-    assert s.axes_manager[1].units == 'mm'
+    assert s.axes_manager[0].name == "Width"
+    assert s.axes_manager[0].units == "mm"
+    assert s.axes_manager[1].name == "Height"
+    assert s.axes_manager[1].units == "mm"
     assert s.axes_manager[0].size == 128
     assert s.axes_manager[0].navigate == False
     assert s.axes_manager[1].size == 128
     assert s.axes_manager[1].navigate == False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
-    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                            == header_keys
+    assert list(omd.as_dictionary().keys()) == ["Object_0_Channel_0"]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ["Header"]
+    assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys

--- a/rsciio/tests/test_tiff.py
+++ b/rsciio/tests/test_tiff.py
@@ -29,20 +29,20 @@ def teardown_module():
 def test_rgba16():
     path = Path(TMP_DIR.name)
     zipf = os.path.join(MY_PATH2, "test_rgba16.zip")
-    with zipfile.ZipFile(zipf, 'r') as zipped:
+    with zipfile.ZipFile(zipf, "r") as zipped:
         zipped.extractall(path)
-    
-    s = hs.load(path / 'test_rgba16.tif')
-    data = np.load(Path(MY_PATH) / "npz_files" / "test_rgba16.npz")['a']
+
+    s = hs.load(path / "test_rgba16.tif")
+    data = np.load(Path(MY_PATH) / "npz_files" / "test_rgba16.npz")["a"]
     assert (s.data == data).all()
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
     assert s.axes_manager[2].units == t.Undefined
-    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[2].scale, 1.0, atol=1E-5)
-    assert s.metadata.General.date == '2014-03-31'
-    assert s.metadata.General.time == '16:35:46'
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.0, atol=1e-5)
+    assert s.metadata.General.date == "2014-03-31"
+    assert s.metadata.General.time == "16:35:46"
 
 
 def _compare_signal_shape_data(s0, s1):
@@ -52,203 +52,212 @@ def _compare_signal_shape_data(s0, s1):
 
 def test_read_unit_um():
     # Load DM file and save it as tif
-    s = hs.load(os.path.join(MY_PATH2, 'test_dm_image_um_unit.dm3'))
-    assert s.axes_manager[0].units == 'µm'
-    assert s.axes_manager[1].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
-    assert s.metadata.General.date == '2015-07-20'
-    assert s.metadata.General.time == '18:48:25'
+    s = hs.load(os.path.join(MY_PATH2, "test_dm_image_um_unit.dm3"))
+    assert s.axes_manager[0].units == "µm"
+    assert s.axes_manager[1].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1e-5)
+    assert s.metadata.General.date == "2015-07-20"
+    assert s.metadata.General.time == "18:48:25"
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'tiff_files', 'test_export_um_unit.tif')
+        fname = os.path.join(tmpdir, "tiff_files", "test_export_um_unit.tif")
         s.save(fname, overwrite=True, export_scale=True)
         # load tif file
         s2 = hs.load(fname)
-        assert s.axes_manager[0].units == 'µm'
-        assert s.axes_manager[1].units == 'µm'
-        np.testing.assert_allclose(s2.axes_manager[0].scale, 0.16867, atol=1E-5)
-        np.testing.assert_allclose(s2.axes_manager[1].scale, 0.16867, atol=1E-5)
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s2.axes_manager[0].scale, 0.16867, atol=1e-5)
+        np.testing.assert_allclose(s2.axes_manager[1].scale, 0.16867, atol=1e-5)
         assert s2.metadata.General.date == s.metadata.General.date
         assert s2.metadata.General.time == s.metadata.General.time
 
 
 def test_write_read_intensity_axes_DM():
-    s = hs.load(os.path.join(MY_PATH2, 'test_dm_image_um_unit.dm3'))
-    s.metadata.Signal.set_item('quantity', 'Electrons (Counts)')
-    d = {'gain_factor': 5.0,
-         'gain_offset': 2.0}
-    s.metadata.Signal.set_item('Noise_properties.Variance_linear_model', d)
+    s = hs.load(os.path.join(MY_PATH2, "test_dm_image_um_unit.dm3"))
+    s.metadata.Signal.set_item("quantity", "Electrons (Counts)")
+    d = {"gain_factor": 5.0, "gain_offset": 2.0}
+    s.metadata.Signal.set_item("Noise_properties.Variance_linear_model", d)
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'tiff_files', 'test_export_um_unit2.tif')
+        fname = os.path.join(tmpdir, "tiff_files", "test_export_um_unit2.tif")
         s.save(fname, overwrite=True, export_scale=True)
         s2 = hs.load(fname)
-        assert_deep_almost_equal(s.metadata.Signal.as_dictionary(),
-                                 s2.metadata.Signal.as_dictionary())
+        assert_deep_almost_equal(
+            s.metadata.Signal.as_dictionary(), s2.metadata.Signal.as_dictionary()
+        )
 
 
 def test_read_unit_from_imagej():
-    fname = os.path.join(MY_PATH, 'tiff_files',
-                         'test_loading_image_saved_with_imageJ.tif')
+    fname = os.path.join(
+        MY_PATH, "tiff_files", "test_loading_image_saved_with_imageJ.tif"
+    )
     s = hs.load(fname)
-    assert s.axes_manager[0].units == 'µm'
-    assert s.axes_manager[1].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    assert s.axes_manager[0].units == "µm"
+    assert s.axes_manager[1].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1e-5)
 
 
 def test_read_unit_from_imagej_stack():
-    fname = os.path.join(MY_PATH, 'tiff_files',
-                         'test_loading_image_saved_with_imageJ_stack.tif')
+    fname = os.path.join(
+        MY_PATH, "tiff_files", "test_loading_image_saved_with_imageJ_stack.tif"
+    )
     s = hs.load(fname)
     assert s.data.shape == (2, 68, 68)
     assert s.axes_manager[0].units == t.Undefined
-    assert s.axes_manager[1].units == 'µm'
-    assert s.axes_manager[2].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 2.5, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[2].scale, 0.16867, atol=1E-5)
+    assert s.axes_manager[1].units == "µm"
+    assert s.axes_manager[2].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 2.5, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 0.16867, atol=1e-5)
 
 
 @pytest.mark.parametrize("lazy", [True, False])
 def test_read_unit_from_DM_stack(lazy):
-    fname = os.path.join(MY_PATH, 'tiff_files',
-                         'test_loading_image_saved_with_DM_stack.tif')
+    fname = os.path.join(
+        MY_PATH, "tiff_files", "test_loading_image_saved_with_DM_stack.tif"
+    )
     s = hs.load(fname, lazy=lazy)
     assert s.data.shape == (2, 68, 68)
-    assert s.axes_manager[0].units == 's'
-    assert s.axes_manager[1].units == 'µm'
-    assert s.axes_manager[2].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 2.5, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[2].scale, 1.68674, atol=1E-5)
+    assert s.axes_manager[0].units == "s"
+    assert s.axes_manager[1].units == "µm"
+    assert s.axes_manager[2].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 2.5, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.68674, atol=1e-5)
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname2 = os.path.join(
-            tmpdir, 'test_loading_image_saved_with_DM_stack2.tif')
+        fname2 = os.path.join(tmpdir, "test_loading_image_saved_with_DM_stack2.tif")
         s.save(fname2, overwrite=True)
         s2 = hs.load(fname2)
         _compare_signal_shape_data(s, s2)
         assert s2.axes_manager[0].units == s.axes_manager[0].units
-        assert s2.axes_manager[1].units == 'µm'
-        assert s2.axes_manager[2].units == 'µm'
+        assert s2.axes_manager[1].units == "µm"
+        assert s2.axes_manager[2].units == "µm"
         np.testing.assert_allclose(
-            s2.axes_manager[0].scale, s.axes_manager[0].scale, atol=1E-5)
+            s2.axes_manager[0].scale, s.axes_manager[0].scale, atol=1e-5
+        )
         np.testing.assert_allclose(
-            s2.axes_manager[1].scale, s.axes_manager[1].scale, atol=1E-5)
+            s2.axes_manager[1].scale, s.axes_manager[1].scale, atol=1e-5
+        )
         np.testing.assert_allclose(
-            s2.axes_manager[2].scale, s.axes_manager[2].scale, atol=1E-5)
+            s2.axes_manager[2].scale, s.axes_manager[2].scale, atol=1e-5
+        )
         np.testing.assert_allclose(
-            s2.axes_manager[0].offset, s.axes_manager[0].offset, atol=1E-5)
+            s2.axes_manager[0].offset, s.axes_manager[0].offset, atol=1e-5
+        )
         np.testing.assert_allclose(
-            s2.axes_manager[1].offset, s.axes_manager[1].offset, atol=1E-5)
+            s2.axes_manager[1].offset, s.axes_manager[1].offset, atol=1e-5
+        )
         np.testing.assert_allclose(
-            s2.axes_manager[2].offset, s.axes_manager[2].offset, atol=1E-5)
+            s2.axes_manager[2].offset, s.axes_manager[2].offset, atol=1e-5
+        )
 
 
 def test_read_unit_from_imagej_stack_no_scale():
-    fname = os.path.join(MY_PATH, 'tiff_files',
-                         'test_loading_image_saved_with_imageJ_stack_no_scale.tif')
+    fname = os.path.join(
+        MY_PATH, "tiff_files", "test_loading_image_saved_with_imageJ_stack_no_scale.tif"
+    )
     s = hs.load(fname)
     assert s.data.shape == (2, 68, 68)
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
     assert s.axes_manager[2].units == t.Undefined
-    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[2].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.0, atol=1e-5)
 
 
 def test_read_unit_from_imagej_no_scale():
-    fname = os.path.join(MY_PATH, 'tiff_files',
-                         'test_loading_image_saved_with_imageJ_no_scale.tif')
+    fname = os.path.join(
+        MY_PATH, "tiff_files", "test_loading_image_saved_with_imageJ_no_scale.tif"
+    )
     s = hs.load(fname)
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
-    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1e-5)
 
 
 def test_write_read_unit_imagej():
-    fname = os.path.join(MY_PATH, 'tiff_files',
-                         'test_loading_image_saved_with_imageJ.tif')
+    fname = os.path.join(
+        MY_PATH, "tiff_files", "test_loading_image_saved_with_imageJ.tif"
+    )
     s = hs.load(fname, convert_units=True)
-    s.axes_manager[0].units = 'µm'
-    s.axes_manager[1].units = 'µm'
+    s.axes_manager[0].units = "µm"
+    s.axes_manager[1].units = "µm"
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname2 = os.path.join(
-            tmpdir, 'test_loading_image_saved_with_imageJ2.tif')
+        fname2 = os.path.join(tmpdir, "test_loading_image_saved_with_imageJ2.tif")
         s.save(fname2, export_scale=True, overwrite=True)
         s2 = hs.load(fname2)
-        assert s2.axes_manager[0].units == 'µm'
-        assert s2.axes_manager[1].units == 'µm'
+        assert s2.axes_manager[0].units == "µm"
+        assert s2.axes_manager[1].units == "µm"
         assert s.data.shape == s.data.shape
 
 
 def test_write_read_unit_imagej_with_description():
-    fname = os.path.join(MY_PATH, 'tiff_files',
-                         'test_loading_image_saved_with_imageJ.tif')
+    fname = os.path.join(
+        MY_PATH, "tiff_files", "test_loading_image_saved_with_imageJ.tif"
+    )
     s = hs.load(fname)
-    s.axes_manager[0].units = 'µm'
-    s.axes_manager[1].units = 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    s.axes_manager[0].units = "µm"
+    s.axes_manager[1].units = "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1e-5)
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname2 = os.path.join(tmpdir, 'description.tif')
-        s.save(fname2, export_scale=False, overwrite=True, description='test')
+        fname2 = os.path.join(tmpdir, "description.tif")
+        s.save(fname2, export_scale=False, overwrite=True, description="test")
         s2 = hs.load(fname2)
         assert s2.axes_manager[0].units == t.Undefined
         assert s2.axes_manager[1].units == t.Undefined
-        np.testing.assert_allclose(s2.axes_manager[0].scale, 1.0, atol=1E-5)
-        np.testing.assert_allclose(s2.axes_manager[1].scale, 1.0, atol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[0].scale, 1.0, atol=1e-5)
+        np.testing.assert_allclose(s2.axes_manager[1].scale, 1.0, atol=1e-5)
 
-        fname3 = os.path.join(tmpdir, 'description2.tif')
-        s.save(fname3, export_scale=True, overwrite=True, description='test')
+        fname3 = os.path.join(tmpdir, "description2.tif")
+        s.save(fname3, export_scale=True, overwrite=True, description="test")
         s3 = hs.load(fname3, convert_units=True)
-        assert s3.axes_manager[0].units == 'µm'
-        assert s3.axes_manager[1].units == 'µm'
-        np.testing.assert_allclose(s3.axes_manager[0].scale, 0.16867, atol=1E-5)
-        np.testing.assert_allclose(s3.axes_manager[1].scale, 0.16867, atol=1E-5)
+        assert s3.axes_manager[0].units == "µm"
+        assert s3.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s3.axes_manager[0].scale, 0.16867, atol=1e-5)
+        np.testing.assert_allclose(s3.axes_manager[1].scale, 0.16867, atol=1e-5)
 
 
 def test_saving_with_custom_tag():
-    s = hs.signals.Signal2D(
-        np.arange(
-            10 * 15,
-            dtype=np.uint8).reshape(
-            (10,
-             15)))
+    s = hs.signals.Signal2D(np.arange(10 * 15, dtype=np.uint8).reshape((10, 15)))
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test_saving_with_custom_tag.tif')
-        extratag = [(65000, 's', 1, "Random metadata", False)]
+        fname = os.path.join(tmpdir, "test_saving_with_custom_tag.tif")
+        extratag = [(65000, "s", 1, "Random metadata", False)]
         s.save(fname, extratags=extratag, overwrite=True)
         s2 = hs.load(fname)
-        assert (s2.original_metadata['Number_65000'] ==
-                "Random metadata")
+        assert s2.original_metadata["Number_65000"] == "Random metadata"
 
 
 def _test_read_unit_from_dm():
-    fname = os.path.join(MY_PATH2, 'test_loading_image_saved_with_DM.tif')
+    fname = os.path.join(MY_PATH2, "test_loading_image_saved_with_DM.tif")
     s = hs.load(fname)
-    assert s.axes_manager[0].units == 'µm'
-    assert s.axes_manager[1].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[0].offset, 139.66264, atol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].offset, 128.19276, atol=1E-5)
+    assert s.axes_manager[0].units == "µm"
+    assert s.axes_manager[1].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 139.66264, atol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 128.19276, atol=1e-5)
     with tempfile.TemporaryDirectory() as tmpdir:
         fname2 = os.path.join(tmpdir, "DM2.tif")
         s.save(fname2, overwrite=True)
         s2 = hs.load(fname2)
         _compare_signal_shape_data(s, s2)
-        assert s2.axes_manager[0].units == 'micron'
-        assert s2.axes_manager[1].units == 'micron'
-        np.testing.assert_allclose(s2.axes_manager[0].scale, s.axes_manager[0].scale,
-                        atol=1E-5)
-        np.testing.assert_allclose(s2.axes_manager[1].scale, s.axes_manager[1].scale,
-                        atol=1E-5)
-        np.testing.assert_allclose(s2.axes_manager[0].offset, s.axes_manager[0].offset,
-                        atol=1E-5)
-        np.testing.assert_allclose(s2.axes_manager[1].offset, s.axes_manager[1].offset,
-                        atol=1E-5)
+        assert s2.axes_manager[0].units == "micron"
+        assert s2.axes_manager[1].units == "micron"
+        np.testing.assert_allclose(
+            s2.axes_manager[0].scale, s.axes_manager[0].scale, atol=1e-5
+        )
+        np.testing.assert_allclose(
+            s2.axes_manager[1].scale, s.axes_manager[1].scale, atol=1e-5
+        )
+        np.testing.assert_allclose(
+            s2.axes_manager[0].offset, s.axes_manager[0].offset, atol=1e-5
+        )
+        np.testing.assert_allclose(
+            s2.axes_manager[1].offset, s.axes_manager[1].offset, atol=1e-5
+        )
 
 
 def test_write_scale_unit():
@@ -260,121 +269,90 @@ def test_write_scale_unit_no_export_scale():
 
 
 def _test_write_scale_unit(export_scale=True):
-    """ Lazy test, still need to open the files in ImageJ or DM to check if the
-        scale and unit are correct """
-    s = hs.signals.Signal2D(
-        np.arange(
-            10 * 15,
-            dtype=np.uint8).reshape(
-            (10,
-             15)))
-    s.axes_manager[0].name = 'x'
-    s.axes_manager[1].name = 'y'
-    s.axes_manager['x'].scale = 0.25
-    s.axes_manager['y'].scale = 0.25
-    s.axes_manager['x'].units = 'nm'
-    s.axes_manager['y'].units = 'nm'
+    """Lazy test, still need to open the files in ImageJ or DM to check if the
+    scale and unit are correct"""
+    s = hs.signals.Signal2D(np.arange(10 * 15, dtype=np.uint8).reshape((10, 15)))
+    s.axes_manager[0].name = "x"
+    s.axes_manager[1].name = "y"
+    s.axes_manager["x"].scale = 0.25
+    s.axes_manager["y"].scale = 0.25
+    s.axes_manager["x"].units = "nm"
+    s.axes_manager["y"].units = "nm"
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(
-            tmpdir, 'test_export_scale_unit_%s.tif' % export_scale)
+        fname = os.path.join(tmpdir, "test_export_scale_unit_%s.tif" % export_scale)
         s.save(fname, overwrite=True, export_scale=export_scale)
 
 
 def test_write_scale_unit_not_square_pixel():
-    """ Lazy test, still need to open the files in ImageJ or DM to check if the
-        scale and unit are correct """
-    s = hs.signals.Signal2D(
-        np.arange(
-            10 * 15,
-            dtype=np.uint8).reshape(
-            (10,
-             15)))
+    """Lazy test, still need to open the files in ImageJ or DM to check if the
+    scale and unit are correct"""
+    s = hs.signals.Signal2D(np.arange(10 * 15, dtype=np.uint8).reshape((10, 15)))
     s.change_dtype(np.uint8)
-    s.axes_manager[0].name = 'x'
-    s.axes_manager[1].name = 'y'
-    s.axes_manager['x'].scale = 0.25
-    s.axes_manager['y'].scale = 0.5
-    s.axes_manager['x'].units = 'nm'
-    s.axes_manager['y'].units = 'µm'
+    s.axes_manager[0].name = "x"
+    s.axes_manager[1].name = "y"
+    s.axes_manager["x"].scale = 0.25
+    s.axes_manager["y"].scale = 0.5
+    s.axes_manager["x"].units = "nm"
+    s.axes_manager["y"].units = "µm"
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(
-            tmpdir, 'test_export_scale_unit_not_square_pixel.tif')
+        fname = os.path.join(tmpdir, "test_export_scale_unit_not_square_pixel.tif")
         s.save(fname, overwrite=True, export_scale=True)
 
 
 def test_write_scale_with_undefined_unit():
-    """ Lazy test, still need to open the files in ImageJ or DM to check if the
-        scale and unit are correct """
-    s = hs.signals.Signal2D(
-        np.arange(
-            10 * 15,
-            dtype=np.uint8).reshape(
-            (10,
-             15)))
-    s.axes_manager[0].name = 'x'
-    s.axes_manager[1].name = 'y'
-    s.axes_manager['x'].scale = 0.25
-    s.axes_manager['y'].scale = 0.25
+    """Lazy test, still need to open the files in ImageJ or DM to check if the
+    scale and unit are correct"""
+    s = hs.signals.Signal2D(np.arange(10 * 15, dtype=np.uint8).reshape((10, 15)))
+    s.axes_manager[0].name = "x"
+    s.axes_manager[1].name = "y"
+    s.axes_manager["x"].scale = 0.25
+    s.axes_manager["y"].scale = 0.25
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(
-            tmpdir, 'test_export_scale_undefined_unit.tif')
+        fname = os.path.join(tmpdir, "test_export_scale_undefined_unit.tif")
         s.save(fname, overwrite=True, export_scale=True)
 
 
 def test_write_scale_with_undefined_scale():
-    """ Lazy test, still need to open the files in ImageJ or DM to check if the
-        scale and unit are correct """
-    s = hs.signals.Signal2D(
-        np.arange(
-            10 * 15,
-            dtype=np.uint8).reshape(
-            (10,
-             15)))
+    """Lazy test, still need to open the files in ImageJ or DM to check if the
+    scale and unit are correct"""
+    s = hs.signals.Signal2D(np.arange(10 * 15, dtype=np.uint8).reshape((10, 15)))
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(
-            tmpdir, 'test_export_scale_undefined_scale.tif')
+        fname = os.path.join(tmpdir, "test_export_scale_undefined_scale.tif")
         s.save(fname, overwrite=True, export_scale=True)
         s1 = hs.load(fname)
         _compare_signal_shape_data(s, s1)
 
 
 def test_write_scale_with_um_unit():
-    """ Lazy test, still need to open the files in ImageJ or DM to check if the
-        scale and unit are correct """
-    s = hs.load(os.path.join(MY_PATH, 'tiff_files',
-                             'test_dm_image_um_unit.dm3'))
+    """Lazy test, still need to open the files in ImageJ or DM to check if the
+    scale and unit are correct"""
+    s = hs.load(os.path.join(MY_PATH, "tiff_files", "test_dm_image_um_unit.dm3"))
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test_export_um_unit.tif')
+        fname = os.path.join(tmpdir, "test_export_um_unit.tif")
         s.save(fname, overwrite=True, export_scale=True)
         s1 = hs.load(fname)
         _compare_signal_shape_data(s, s1)
 
 
 def test_write_scale_unit_image_stack():
-    """ Lazy test, still need to open the files in ImageJ or DM to check if the
-        scale and unit are correct """
-    s = hs.signals.Signal2D(
-        np.arange(
-            5 * 10 * 15,
-            dtype=np.uint8).reshape(
-            (5,
-             10,
-             15)))
+    """Lazy test, still need to open the files in ImageJ or DM to check if the
+    scale and unit are correct"""
+    s = hs.signals.Signal2D(np.arange(5 * 10 * 15, dtype=np.uint8).reshape((5, 10, 15)))
     s.axes_manager[0].scale = 0.25
     s.axes_manager[1].scale = 0.5
     s.axes_manager[2].scale = 1.5
-    s.axes_manager[0].units = 'nm'
-    s.axes_manager[1].units = 'µm'
-    s.axes_manager[2].units = 'µm'
+    s.axes_manager[0].units = "nm"
+    s.axes_manager[1].units = "µm"
+    s.axes_manager[2].units = "µm"
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test_export_scale_unit_stack2.tif')
+        fname = os.path.join(tmpdir, "test_export_scale_unit_stack2.tif")
         s.save(fname, overwrite=True, export_scale=True)
         s1 = hs.load(fname, convert_units=True)
         _compare_signal_shape_data(s, s1)
-        assert s1.axes_manager[0].units == 'pm'
+        assert s1.axes_manager[0].units == "pm"
         # only one unit can be read
-        assert s1.axes_manager[1].units == 'µm'
-        assert s1.axes_manager[2].units == 'µm'
+        assert s1.axes_manager[1].units == "µm"
+        assert s1.axes_manager[2].units == "µm"
         np.testing.assert_allclose(s1.axes_manager[0].scale, 250.0)
         np.testing.assert_allclose(s1.axes_manager[1].scale, s.axes_manager[1].scale)
         np.testing.assert_allclose(s1.axes_manager[2].scale, s.axes_manager[2].scale)
@@ -382,356 +360,442 @@ def test_write_scale_unit_image_stack():
 
 def test_saving_loading_stack_no_scale():
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test_export_scale_unit_stack2.tif')
+        fname = os.path.join(tmpdir, "test_export_scale_unit_stack2.tif")
         s0 = hs.signals.Signal2D(np.zeros((10, 20, 30)))
         s0.save(fname, overwrite=True)
         s1 = hs.load(fname)
         _compare_signal_shape_data(s0, s1)
 
 
-FEI_Helios_metadata = {'Acquisition_instrument': {'SEM': {'Stage': {'rotation': -2.3611,
-                                                                    'tilt': 6.54498e-06,
-                                                                    'x': 2.576e-05,
-                                                                    'y': -0.000194177,
-                                                                    'z': 0.007965},
-                                                          'beam_current': 0.00625,
-                                                          'beam_energy': 5.0,
-                                                          'dwell_time': 1e-05,
-                                                          'microscope': 'Helios NanoLab" 660',
-                                                          'working_distance': 4.03466}},
-                       'General': {'original_filename': 'FEI-Helios-Ebeam-8bits.tif',
-                                   'title': '',
-                                   'authors': 'supervisor',
-                                   'date': '2016-06-13',
-                                   'time': '17:06:40',
-                                   'FileIO': {'0': {
-                                       'operation': 'load',
-                                       'hyperspy_version': hs_version,
-                                       'io_plugin': 'rsciio.tiff.api'
-                                   }}
-                                   },
-                       'Signal': {'signal_type': ''},
-                       '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                                 'original_shape': None,
-                                                 'signal_unfolded': False,
-                                                 'unfolded': False}}}
+FEI_Helios_metadata = {
+    "Acquisition_instrument": {
+        "SEM": {
+            "Stage": {
+                "rotation": -2.3611,
+                "tilt": 6.54498e-06,
+                "x": 2.576e-05,
+                "y": -0.000194177,
+                "z": 0.007965,
+            },
+            "beam_current": 0.00625,
+            "beam_energy": 5.0,
+            "dwell_time": 1e-05,
+            "microscope": 'Helios NanoLab" 660',
+            "working_distance": 4.03466,
+        }
+    },
+    "General": {
+        "original_filename": "FEI-Helios-Ebeam-8bits.tif",
+        "title": "",
+        "authors": "supervisor",
+        "date": "2016-06-13",
+        "time": "17:06:40",
+        "FileIO": {
+            "0": {
+                "operation": "load",
+                "hyperspy_version": hs_version,
+                "io_plugin": "rsciio.tiff.api",
+            }
+        },
+    },
+    "Signal": {"signal_type": ""},
+    "_HyperSpy": {
+        "Folding": {
+            "original_axes_manager": None,
+            "original_shape": None,
+            "signal_unfolded": False,
+            "unfolded": False,
+        }
+    },
+}
 
 FEI_navcam_metadata = {
-    '_HyperSpy': {'Folding': {'unfolded': False, 'signal_unfolded': False,
-                              'original_shape': None, 'original_axes_manager': None}},
-    'General': {'original_filename': 'FEI-Helios-navcam-with-no-IRBeam.tif',
-                'title': '', 'date': '2022-05-17', 'time': '09:07:08', 'authors': 'user',
-                'FileIO': {'0': {'operation': 'load', 'io_plugin': 'rsciio.tiff.api'}}},
-    'Signal': {'signal_type': ''},
-    'Acquisition_instrument': {'SEM': {'Stage': {'x': 0.0699197, 'y': 0.000811186, 'z': 0,
-                                                 'rotation': 1.07874, 'tilt': 6.54498e-06},
-                                       'working_distance': -0.012, 'microscope': 'Helios NanoLab" 660'}}}
+    "_HyperSpy": {
+        "Folding": {
+            "unfolded": False,
+            "signal_unfolded": False,
+            "original_shape": None,
+            "original_axes_manager": None,
+        }
+    },
+    "General": {
+        "original_filename": "FEI-Helios-navcam-with-no-IRBeam.tif",
+        "title": "",
+        "date": "2022-05-17",
+        "time": "09:07:08",
+        "authors": "user",
+        "FileIO": {"0": {"operation": "load", "io_plugin": "rsciio.tiff.api"}},
+    },
+    "Signal": {"signal_type": ""},
+    "Acquisition_instrument": {
+        "SEM": {
+            "Stage": {
+                "x": 0.0699197,
+                "y": 0.000811186,
+                "z": 0,
+                "rotation": 1.07874,
+                "tilt": 6.54498e-06,
+            },
+            "working_distance": -0.012,
+            "microscope": 'Helios NanoLab" 660',
+        }
+    },
+}
 
 
 class TestReadFEIHelios:
-    
+
     path = Path(TMP_DIR.name)
-    
+
     @classmethod
     def setup_class(cls):
         zipf = os.path.join(MY_PATH2, "tiff_FEI_Helios.zip")
-        with zipfile.ZipFile(zipf, 'r') as zipped:
+        with zipfile.ZipFile(zipf, "r") as zipped:
             zipped.extractall(cls.path)
 
     def test_read_FEI_SEM_scale_metadata_8bits(self):
-        fname = self.path / 'FEI-Helios-Ebeam-8bits.tif'
+        fname = self.path / "FEI-Helios-Ebeam-8bits.tif"
         s = hs.load(fname, convert_units=True)
-        assert s.axes_manager[0].units == 'µm'
-        assert s.axes_manager[1].units == 'µm'
-        np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
-        np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
-        assert s.data.dtype == 'uint8'
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1e-5)
+        np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1e-5)
+        assert s.data.dtype == "uint8"
         # delete timestamp from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
-        FEI_Helios_metadata['General'][
-            'original_filename'] = 'FEI-Helios-Ebeam-8bits.tif'
+        FEI_Helios_metadata["General"][
+            "original_filename"
+        ] = "FEI-Helios-Ebeam-8bits.tif"
         assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
-    
+
     def test_read_FEI_SEM_scale_metadata_16bits(self):
-        fname = self.path / 'FEI-Helios-Ebeam-16bits.tif'
+        fname = self.path / "FEI-Helios-Ebeam-16bits.tif"
         s = hs.load(fname, convert_units=True)
-        assert s.axes_manager[0].units == 'µm'
-        assert s.axes_manager[1].units == 'µm'
-        np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
-        np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
-        assert s.data.dtype == 'uint16'
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1e-5)
+        np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1e-5)
+        assert s.data.dtype == "uint16"
         # delete timestamp from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
-        FEI_Helios_metadata['General'][
-            'original_filename'] = 'FEI-Helios-Ebeam-16bits.tif'
+        FEI_Helios_metadata["General"][
+            "original_filename"
+        ] = "FEI-Helios-Ebeam-16bits.tif"
         assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
 
     def test_read_FEI_navcam_metadata(self):
-        fname = self.path / 'FEI-Helios-navcam.tif'
+        fname = self.path / "FEI-Helios-navcam.tif"
         s = hs.load(fname, convert_units=True)
-        assert s.axes_manager[0].units == 'mm'
-        assert s.axes_manager[1].units == 'mm'
-        np.testing.assert_allclose(s.axes_manager[0].scale, 0.2640, rtol=.0001)
-        np.testing.assert_allclose(s.axes_manager[1].scale, 0.2640, rtol=.0001)
-        assert s.data.dtype == 'uint8'
+        assert s.axes_manager[0].units == "mm"
+        assert s.axes_manager[1].units == "mm"
+        np.testing.assert_allclose(s.axes_manager[0].scale, 0.2640, rtol=0.0001)
+        np.testing.assert_allclose(s.axes_manager[1].scale, 0.2640, rtol=0.0001)
+        assert s.data.dtype == "uint8"
         # delete timestamp and version from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
         del s.metadata.General.FileIO.Number_0.hyperspy_version
-        FEI_navcam_metadata['General']['original_filename'] = 'FEI-Helios-navcam.tif'
+        FEI_navcam_metadata["General"]["original_filename"] = "FEI-Helios-navcam.tif"
         assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_navcam_metadata)
 
-
     def test_read_FEI_navcam_no_IRBeam_metadata(self):
-        fname = self.path / 'FEI-Helios-navcam-with-no-IRBeam.tif'
+        fname = self.path / "FEI-Helios-navcam-with-no-IRBeam.tif"
         s = hs.load(fname, convert_units=True)
         assert s.axes_manager[0].units == t.Undefined
         assert s.axes_manager[1].units == t.Undefined
         np.testing.assert_allclose(s.axes_manager[0].scale, 1, rtol=0)
         np.testing.assert_allclose(s.axes_manager[1].scale, 1, rtol=0)
-        assert s.data.dtype == 'uint8'
+        assert s.data.dtype == "uint8"
         # delete timestamp and version from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
         del s.metadata.General.FileIO.Number_0.hyperspy_version
-        FEI_navcam_metadata['General']['original_filename'] = 'FEI-Helios-navcam-with-no-IRBeam.tif'
+        FEI_navcam_metadata["General"][
+            "original_filename"
+        ] = "FEI-Helios-navcam-with-no-IRBeam.tif"
         assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_navcam_metadata)
 
-
     def test_read_FEI_navcam_no_IRBeam_bad_floats_metadata(self):
-        fname = self.path / 'FEI-Helios-navcam-with-no-IRBeam-bad-floats.tif'
+        fname = self.path / "FEI-Helios-navcam-with-no-IRBeam-bad-floats.tif"
         s = hs.load(fname, convert_units=True)
 
         # delete timestamp and version from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
         del s.metadata.General.FileIO.Number_0.hyperspy_version
-        FEI_navcam_metadata['General']['original_filename'] = 'FEI-Helios-navcam-with-no-IRBeam-bad-floats.tif'
+        FEI_navcam_metadata["General"][
+            "original_filename"
+        ] = "FEI-Helios-navcam-with-no-IRBeam-bad-floats.tif"
 
         # working distance in the file was a bogus value, so it shouldn't be in the resulting metadata
-        del FEI_navcam_metadata['Acquisition_instrument']['SEM']['working_distance']
+        del FEI_navcam_metadata["Acquisition_instrument"]["SEM"]["working_distance"]
         assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_navcam_metadata)
 
 
 class TestReadZeissSEM:
-    
+
     path = Path(TMP_DIR.name)
-    
+
     @classmethod
     def setup_class(cls):
         zipf = os.path.join(MY_PATH2, "tiff_Zeiss_SEM.zip")
-        with zipfile.ZipFile(zipf, 'r') as zipped:
+        with zipfile.ZipFile(zipf, "r") as zipped:
             zipped.extractall(cls.path)
 
     def test_read_Zeiss_SEM_scale_metadata_1k_image(self):
-        md = {'Acquisition_instrument': {'SEM': {'Stage': {'rotation': 10.2,
-                                                           'tilt': -0.0,
-                                                           'x': 75.6442,
-                                                           'y': 60.4901,
-                                                           'z': 25.193},
-                                                 'Detector':{'detector_type':
-                                                     'HE-SE2'},
-                                                 'beam_current': 1.0,
-                                                 'beam_energy': 25.0,
-                                                 'dwell_time': 5e-08,
-                                                 'magnification': 105.0,
-                                                 'microscope': 'Merlin-61-08',
-                                                 'working_distance': 14.808}},
-              'General': {'authors': 'LIM',
-                          'date': '2015-12-23',
-                          'original_filename': 'test_tiff_Zeiss_SEM_1k.tif',
-                          'time': '09:40:32',
-                          'title': '',
-                          'FileIO': {'0': {
-                              'operation': 'load',
-                              'hyperspy_version': hs_version,
-                              'io_plugin': 'rsciio.tiff.api'
-                          }}
-                          },
-              'Signal': {'signal_type': ''},
-              '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                        'original_shape': None,
-                                        'signal_unfolded': False,
-                                        'unfolded': False}}}
-        
-        fname = self.path / 'test_tiff_Zeiss_SEM_1k.tif'
+        md = {
+            "Acquisition_instrument": {
+                "SEM": {
+                    "Stage": {
+                        "rotation": 10.2,
+                        "tilt": -0.0,
+                        "x": 75.6442,
+                        "y": 60.4901,
+                        "z": 25.193,
+                    },
+                    "Detector": {"detector_type": "HE-SE2"},
+                    "beam_current": 1.0,
+                    "beam_energy": 25.0,
+                    "dwell_time": 5e-08,
+                    "magnification": 105.0,
+                    "microscope": "Merlin-61-08",
+                    "working_distance": 14.808,
+                }
+            },
+            "General": {
+                "authors": "LIM",
+                "date": "2015-12-23",
+                "original_filename": "test_tiff_Zeiss_SEM_1k.tif",
+                "time": "09:40:32",
+                "title": "",
+                "FileIO": {
+                    "0": {
+                        "operation": "load",
+                        "hyperspy_version": hs_version,
+                        "io_plugin": "rsciio.tiff.api",
+                    }
+                },
+            },
+            "Signal": {"signal_type": ""},
+            "_HyperSpy": {
+                "Folding": {
+                    "original_axes_manager": None,
+                    "original_shape": None,
+                    "signal_unfolded": False,
+                    "unfolded": False,
+                }
+            },
+        }
+
+        fname = self.path / "test_tiff_Zeiss_SEM_1k.tif"
         s = hs.load(fname, convert_units=True)
-    
-        assert s.axes_manager[0].units == 'µm'
-        assert s.axes_manager[1].units == 'µm'
-        np.testing.assert_allclose(s.axes_manager[0].scale, 2.614514, rtol=1E-6)
-        np.testing.assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1E-6)
-        assert s.data.dtype == 'uint8'
+
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s.axes_manager[0].scale, 2.614514, rtol=1e-6)
+        np.testing.assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1e-6)
+        assert s.data.dtype == "uint8"
         # delete timestamp from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
     def test_read_Zeiss_SEM_scale_metadata_512_image(self):
-        md = {'Acquisition_instrument': {'SEM': {'Stage': {'rotation': 245.8,
-                                                           'tilt': 0.0,
-                                                           'x': 62.9961,
-                                                           'y': 65.3168,
-                                                           'z': 44.678},
-                                                 'beam_energy': 5.0,
-                                                 'magnification': '50.00 K X',
-                                                 'microscope': 'ULTRA 55-36-06',
-                                                 'working_distance': 3.9}},
-              'General': {'authors': 'LIBERATO',
-                          'date': '2018-09-25',
-                          'original_filename': 'test_tiff_Zeiss_SEM_512pix.tif',
-                          'time': '08:20:42',
-                          'title': '',
-                          'FileIO': {'0': {
-                              'operation': 'load',
-                              'hyperspy_version': hs_version,
-                              'io_plugin': 'rsciio.tiff.api'
-                          }}
-                          },
-              'Signal': {'signal_type': ''},
-              '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                        'original_shape': None,
-                                        'signal_unfolded': False,
-                                        'unfolded': False}}}
-    
-        fname = self.path / 'test_tiff_Zeiss_SEM_512pix.tif'
+        md = {
+            "Acquisition_instrument": {
+                "SEM": {
+                    "Stage": {
+                        "rotation": 245.8,
+                        "tilt": 0.0,
+                        "x": 62.9961,
+                        "y": 65.3168,
+                        "z": 44.678,
+                    },
+                    "beam_energy": 5.0,
+                    "magnification": "50.00 K X",
+                    "microscope": "ULTRA 55-36-06",
+                    "working_distance": 3.9,
+                }
+            },
+            "General": {
+                "authors": "LIBERATO",
+                "date": "2018-09-25",
+                "original_filename": "test_tiff_Zeiss_SEM_512pix.tif",
+                "time": "08:20:42",
+                "title": "",
+                "FileIO": {
+                    "0": {
+                        "operation": "load",
+                        "hyperspy_version": hs_version,
+                        "io_plugin": "rsciio.tiff.api",
+                    }
+                },
+            },
+            "Signal": {"signal_type": ""},
+            "_HyperSpy": {
+                "Folding": {
+                    "original_axes_manager": None,
+                    "original_shape": None,
+                    "signal_unfolded": False,
+                    "unfolded": False,
+                }
+            },
+        }
+
+        fname = self.path / "test_tiff_Zeiss_SEM_512pix.tif"
         s = hs.load(fname, convert_units=True)
-        assert s.axes_manager[0].units == 'µm'
-        assert s.axes_manager[1].units == 'µm'
-        np.testing.assert_allclose(s.axes_manager[0].scale, 0.011649976, rtol=1E-6)
-        np.testing.assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1E-6)
-        assert s.data.dtype == 'uint8'
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s.axes_manager[0].scale, 0.011649976, rtol=1e-6)
+        np.testing.assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1e-6)
+        assert s.data.dtype == "uint8"
         # delete timestamp from metadata since it's runtime dependent
         del s.metadata.General.FileIO.Number_0.timestamp
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
 def test_read_RGB_Zeiss_optical_scale_metadata():
-    fname = os.path.join(MY_PATH2, 'optical_Zeiss_AxioVision_RGB.tif')
-    s = hs.load(fname, )
-    dtype = np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1')])
+    fname = os.path.join(MY_PATH2, "optical_Zeiss_AxioVision_RGB.tif")
+    s = hs.load(
+        fname,
+    )
+    dtype = np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1")])
     assert s.data.dtype == dtype
     assert s.data.shape == (10, 13)
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
-    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
-    assert s.metadata.General.date == '2016-06-13'
-    assert s.metadata.General.time == '15:59:52'
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1e-5)
+    assert s.metadata.General.date == "2016-06-13"
+    assert s.metadata.General.time == "15:59:52"
     assert s.metadata.General.FileIO.Number_0.hyperspy_version == hs_version
-    assert s.metadata.General.FileIO.Number_0.io_plugin == 'rsciio.tiff.api'
+    assert s.metadata.General.FileIO.Number_0.io_plugin == "rsciio.tiff.api"
 
 
 def test_read_BW_Zeiss_optical_scale_metadata():
-    fname = os.path.join(MY_PATH2, 'optical_Zeiss_AxioVision_BW.tif')
+    fname = os.path.join(MY_PATH2, "optical_Zeiss_AxioVision_BW.tif")
     s = hs.load(fname, force_read_resolution=True, convert_units=True)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (10, 13)
-    assert s.axes_manager[0].units == 'µm'
-    assert s.axes_manager[1].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
-    assert s.metadata.General.date == '2016-06-13'
-    assert s.metadata.General.time == '16:08:49'
+    assert s.axes_manager[0].units == "µm"
+    assert s.axes_manager[1].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1e-5)
+    assert s.metadata.General.date == "2016-06-13"
+    assert s.metadata.General.time == "16:08:49"
 
 
 def test_read_BW_Zeiss_optical_scale_metadata_convert_units_false():
-    fname = os.path.join(MY_PATH2, 'optical_Zeiss_AxioVision_BW.tif')
+    fname = os.path.join(MY_PATH2, "optical_Zeiss_AxioVision_BW.tif")
     s = hs.load(fname, force_read_resolution=True, convert_units=False)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (10, 13)
-    assert s.axes_manager[0].units == 'µm'
-    assert s.axes_manager[1].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
+    assert s.axes_manager[0].units == "µm"
+    assert s.axes_manager[1].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1e-5)
 
 
 def test_read_BW_Zeiss_optical_scale_metadata2():
-    fname = os.path.join(MY_PATH2, 'optical_Zeiss_AxioVision_BW.tif')
+    fname = os.path.join(MY_PATH2, "optical_Zeiss_AxioVision_BW.tif")
     s = hs.load(fname, force_read_resolution=True, convert_units=True)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (10, 13)
-    assert s.axes_manager[0].units == 'µm'
-    assert s.axes_manager[1].units == 'µm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
-    assert s.metadata.General.date == '2016-06-13'
-    assert s.metadata.General.time == '16:08:49'
+    assert s.axes_manager[0].units == "µm"
+    assert s.axes_manager[1].units == "µm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1e-5)
+    assert s.metadata.General.date == "2016-06-13"
+    assert s.metadata.General.time == "16:08:49"
 
 
 def test_read_BW_Zeiss_optical_scale_metadata3():
-    fname = os.path.join(MY_PATH2, 'optical_Zeiss_AxioVision_BW.tif')
+    fname = os.path.join(MY_PATH2, "optical_Zeiss_AxioVision_BW.tif")
     s = hs.load(fname, force_read_resolution=False)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (10, 13)
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
-    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
-    assert s.metadata.General.date == '2016-06-13'
-    assert s.metadata.General.time == '16:08:49'
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1e-5)
+    assert s.metadata.General.date == "2016-06-13"
+    assert s.metadata.General.time == "16:08:49"
 
 
 def test_read_TVIPS_metadata():
-    md = {'Acquisition_instrument': {'TEM': {'Detector': {'Camera': {'exposure': 0.4,
-                                                                     'name': 'F416'}},
-                                             'Stage': {'tilt_alpha': -0.0070000002,
-                                                       'tilt_beta': -0.055,
-                                                       'x': 0.0,
-                                                       'y': -9.2000000506686774e-05,
-                                                       'z': 7.0000001350933871e-06},
-                                             'beam_energy': 99.0,
-                                             'magnification': 32000.0}},
-          'General': {'original_filename': 'TVIPS_bin4.tif',
-                      'time': '9:01:17',
-                      'title': '',
-                      'FileIO': {'0': {
-                          'operation': 'load',
-                          'hyperspy_version': hs_version,
-                          'io_plugin': 'rsciio.tiff.api'
-                      }}
-                      },
-          'Signal': {'signal_type': ''},
-          '_HyperSpy': {'Folding': {'original_axes_manager': None,
-                                    'original_shape': None,
-                                    'signal_unfolded': False,
-                                    'unfolded': False}}}
-    
+    md = {
+        "Acquisition_instrument": {
+            "TEM": {
+                "Detector": {"Camera": {"exposure": 0.4, "name": "F416"}},
+                "Stage": {
+                    "tilt_alpha": -0.0070000002,
+                    "tilt_beta": -0.055,
+                    "x": 0.0,
+                    "y": -9.2000000506686774e-05,
+                    "z": 7.0000001350933871e-06,
+                },
+                "beam_energy": 99.0,
+                "magnification": 32000.0,
+            }
+        },
+        "General": {
+            "original_filename": "TVIPS_bin4.tif",
+            "time": "9:01:17",
+            "title": "",
+            "FileIO": {
+                "0": {
+                    "operation": "load",
+                    "hyperspy_version": hs_version,
+                    "io_plugin": "rsciio.tiff.api",
+                }
+            },
+        },
+        "Signal": {"signal_type": ""},
+        "_HyperSpy": {
+            "Folding": {
+                "original_axes_manager": None,
+                "original_shape": None,
+                "signal_unfolded": False,
+                "unfolded": False,
+            }
+        },
+    }
+
     zipf = os.path.join(MY_PATH2, "TVIPS_bin4.zip")
     path = Path(TMP_DIR.name)
-    with zipfile.ZipFile(zipf, 'r') as zipped:
+    with zipfile.ZipFile(zipf, "r") as zipped:
         zipped.extractall(path)
-        s = hs.load(path / 'TVIPS_bin4.tif', convert_units=True)
-        
+        s = hs.load(path / "TVIPS_bin4.tif", convert_units=True)
+
     assert s.data.dtype == np.uint8
     assert s.data.shape == (1024, 1024)
-    assert s.axes_manager[0].units == 'nm'
-    assert s.axes_manager[1].units == 'nm'
-    np.testing.assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1E-5)
-    np.testing.assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1E-5)
+    assert s.axes_manager[0].units == "nm"
+    assert s.axes_manager[1].units == "nm"
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1e-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1e-5)
     # delete timestamp from metadata since it's runtime dependent
     del s.metadata.General.FileIO.Number_0.timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
 def test_axes_metadata():
-    data = np.arange(2*5*10).reshape((2, 5, 10))
+    data = np.arange(2 * 5 * 10).reshape((2, 5, 10))
     s = hs.signals.Signal2D(data)
-    nav_unit = 's'
+    nav_unit = "s"
     s.axes_manager.navigation_axes[0].units = nav_unit
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'axes_metadata_default.tif')
+        fname = os.path.join(tmpdir, "axes_metadata_default.tif")
         s.save(fname)
         s2 = hs.load(fname)
-        assert s2.axes_manager.navigation_axes[0].name == 'image series'
+        assert s2.axes_manager.navigation_axes[0].name == "image series"
         assert s2.axes_manager.navigation_axes[0].units == nav_unit
         assert s2.axes_manager.navigation_axes[0].is_binned == False
 
-        fname2 = os.path.join(tmpdir, 'axes_metadata_IYX.tif')
-        s.save(fname2, metadata={'axes':'IYX'})
+        fname2 = os.path.join(tmpdir, "axes_metadata_IYX.tif")
+        s.save(fname2, metadata={"axes": "IYX"})
         s3 = hs.load(fname2)
-        assert s3.axes_manager.navigation_axes[0].name == 'image series'
+        assert s3.axes_manager.navigation_axes[0].name == "image series"
         assert s3.axes_manager.navigation_axes[0].units == nav_unit
         assert s3.axes_manager.navigation_axes[0].is_binned == False
 
-        fname2 = os.path.join(tmpdir, 'axes_metadata_ZYX.tif')
-        s.save(fname2, metadata={'axes':'ZYX'})
+        fname2 = os.path.join(tmpdir, "axes_metadata_ZYX.tif")
+        s.save(fname2, metadata={"axes": "ZYX"})
         s3 = hs.load(fname2)
         assert s3.axes_manager.navigation_axes[0].units == nav_unit
         assert s3.axes_manager.navigation_axes[0].is_binned == False
@@ -739,7 +803,7 @@ def test_axes_metadata():
 
 def test_olympus_SIS():
     pytest.importorskip("imagecodecs", reason="imagecodecs is required")
-    fname = os.path.join(MY_PATH2, 'olympus_SIS.tif')
+    fname = os.path.join(MY_PATH2, "olympus_SIS.tif")
     s = hs.load(fname)
     # This olympus SIS contains two images:
     # - the first one is a RGB 8-bits (used for preview purposes)
@@ -748,25 +812,25 @@ def test_olympus_SIS():
     assert len(s) == 2
     am = s[1].axes_manager
     for axis in am._axes:
-        assert axis.units == 'm'
+        assert axis.units == "m"
         np.testing.assert_allclose(axis.scale, 2.3928e-11)
         np.testing.assert_allclose(axis.offset, 0.0)
 
     for ima in s:
         assert ima.data.shape == (101, 112)
 
-    assert s[1].data.dtype is np.dtype('uint16')
+    assert s[1].data.dtype is np.dtype("uint16")
 
 
 def test_save_angstrom_units():
-    s = hs.signals.Signal2D(np.arange(200*200, dtype='float32').reshape((200, 200)))
+    s = hs.signals.Signal2D(np.arange(200 * 200, dtype="float32").reshape((200, 200)))
     for axis in s.axes_manager.signal_axes:
-        axis.units = 'Å'
+        axis.units = "Å"
         axis.scale = 0.1
         axis.offset = 10
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'save_angstrom_units.tif')
+        fname = os.path.join(tmpdir, "save_angstrom_units.tif")
         s.save(fname)
         s2 = hs.load(fname)
         if Version(tifffile.__version__) >= Version("2020.7.17"):
@@ -777,139 +841,143 @@ def test_save_angstrom_units():
 
 
 def test_JEOL_SightX():
-    files = [ ("JEOL-SightX-Ronchigram-dummy.tif.gz", 1.0, t.Undefined),
-              ("JEOL-SightX-SAED-dummy.tif.gz", 0.2723, "1 / nm"),
-              ("JEOL-SightX-TEM-mag-dummy.tif.gz", 1.8208, "nm") ]
+    files = [
+        ("JEOL-SightX-Ronchigram-dummy.tif.gz", 1.0, t.Undefined),
+        ("JEOL-SightX-SAED-dummy.tif.gz", 0.2723, "1 / nm"),
+        ("JEOL-SightX-TEM-mag-dummy.tif.gz", 1.8208, "nm"),
+    ]
     for file in files:
         fname = file[0]
-        if fname[-3:]==".gz":
+        if fname[-3:] == ".gz":
             import tempfile
             import gzip
+
             with tempfile.TemporaryDirectory() as tmp_dir:
-                with gzip.open(os.path.join(MY_PATH2,fname),'rb') as f:
+                with gzip.open(os.path.join(MY_PATH2, fname), "rb") as f:
                     content = f.read()
                 fname = os.path.join(tmp_dir, fname[:-3])
-                with open(fname,"wb") as f2:
+                with open(fname, "wb") as f2:
                     f2.write(content)
                 s = hs.load(fname)
         else:
             fname = os.path.join(MY_PATH2, file[0])
             s = hs.load(fname)
-        for i in range(2): # x, y
+        for i in range(2):  # x, y
             assert s.axes_manager[i].size == 556
-            np.testing.assert_allclose(s.axes_manager[i].scale, file[1], rtol=1E-3)
+            np.testing.assert_allclose(s.axes_manager[i].scale, file[1], rtol=1e-3)
             assert s.axes_manager[i].units == file[2]
 
 
 class TestReadHamamatsu:
-    
+
     path = Path(TMP_DIR.name)
-    
+
     @classmethod
     def setup_class(cls):
         zipf = os.path.join(MY_PATH2, "tiff_hamamatsu.zip")
-        with zipfile.ZipFile(zipf, 'r') as zipped:
+        with zipfile.ZipFile(zipf, "r") as zipped:
             zipped.extractall(cls.path)
 
-
     def test_hamamatsu_streak_loadwarnings(self):
-        file = 'test_hamamatsu_streak_SCAN.tif'
+        file = "test_hamamatsu_streak_SCAN.tif"
         fname = os.path.join(self.path, file)
-    
+
         # No hamamatsu_streak_axis_type argument should :
         # - raise warning
         # - Initialise uniform data axis
         with pytest.warns(UserWarning):
             s = hs.load(fname)
             assert s.axes_manager.all_uniform
-    
-        #Invalid hamamatsu_streak_axis_type argument should:
+
+        # Invalid hamamatsu_streak_axis_type argument should:
         # - raise warning
         # - Initialise uniform data axis
         with pytest.warns(UserWarning):
-            s = hs.load(fname,hamamatsu_streak_axis_type='xxx')
+            s = hs.load(fname, hamamatsu_streak_axis_type="xxx")
             assert s.axes_manager.all_uniform
-    
-        #Explicitly calling hamamatsu_streak_axis_type='uniform'
+
+        # Explicitly calling hamamatsu_streak_axis_type='uniform'
         # should NOT raise a warning
         with warnings.catch_warnings():
-            warnings.simplefilter('error')
-            s = hs.load(fname, hamamatsu_streak_axis_type='uniform')
+            warnings.simplefilter("error")
+            s = hs.load(fname, hamamatsu_streak_axis_type="uniform")
             assert s.axes_manager.all_uniform
 
     def test_hamamatsu_streak_scanfile(self):
-        file = 'test_hamamatsu_streak_SCAN.tif'
+        file = "test_hamamatsu_streak_SCAN.tif"
         fname = os.path.join(self.path, file)
-    
+
         with pytest.warns(UserWarning):
             s = hs.load(fname)
-    
+
         assert s.data.shape == (508, 672)
-        assert s.axes_manager[1].units == 'ps'
-        np.testing.assert_allclose(s.axes_manager[1].scale, 2.3081, rtol=1E-3)
-        np.testing.assert_allclose(s.axes_manager[1].offset, 652.3756, rtol=1E-3)
-        np.testing.assert_allclose(s.axes_manager[0].scale, 0.01714, rtol=1E-3)
-        np.testing.assert_allclose(s.axes_manager[0].offset, 231.0909, rtol=1E-3)
-    
+        assert s.axes_manager[1].units == "ps"
+        np.testing.assert_allclose(s.axes_manager[1].scale, 2.3081, rtol=1e-3)
+        np.testing.assert_allclose(s.axes_manager[1].offset, 652.3756, rtol=1e-3)
+        np.testing.assert_allclose(s.axes_manager[0].scale, 0.01714, rtol=1e-3)
+        np.testing.assert_allclose(s.axes_manager[0].offset, 231.0909, rtol=1e-3)
+
     def test_hamamatsu_streak_focusfile(self):
-        file = 'test_hamamatsu_streak_FOCUS.tif'
+        file = "test_hamamatsu_streak_FOCUS.tif"
         fname = os.path.join(self.path, file)
-    
+
         with pytest.warns(UserWarning):
             s = hs.load(fname)
-    
+
         assert s.data.shape == (508, 672)
-        assert s.axes_manager[1].units == ''
-        np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-3)
-        np.testing.assert_allclose(s.axes_manager[1].offset, 0.0, rtol=1E-3, atol=1e-5)
-        np.testing.assert_allclose(s.axes_manager[0].scale, 0.01714, rtol=1E-3)
-        np.testing.assert_allclose(s.axes_manager[0].offset, 231.0909, rtol=1E-3)
-    
+        assert s.axes_manager[1].units == ""
+        np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1e-3)
+        np.testing.assert_allclose(s.axes_manager[1].offset, 0.0, rtol=1e-3, atol=1e-5)
+        np.testing.assert_allclose(s.axes_manager[0].scale, 0.01714, rtol=1e-3)
+        np.testing.assert_allclose(s.axes_manager[0].offset, 231.0909, rtol=1e-3)
+
     def test_hamamatsu_streak_non_uniform_load(self):
-        file = 'test_hamamatsu_streak_SCAN.tif'
+        file = "test_hamamatsu_streak_SCAN.tif"
         fname = os.path.join(self.path, file)
-    
-        s = hs.load(fname, hamamatsu_streak_axis_type='data')
-    
+
+        s = hs.load(fname, hamamatsu_streak_axis_type="data")
+
         np.testing.assert_allclose(
             s.original_metadata.ImageDescriptionParsed.Scaling.ScalingYaxis,
-            s.axes_manager[1].axis, rtol=1e-5
-            )
-    
-        s = hs.load(fname, hamamatsu_streak_axis_type='functional')
-    
+            s.axes_manager[1].axis,
+            rtol=1e-5,
+        )
+
+        s = hs.load(fname, hamamatsu_streak_axis_type="functional")
+
         np.testing.assert_allclose(
             s.original_metadata.ImageDescriptionParsed.Scaling.ScalingYaxis,
-            s.axes_manager[1].axis, rtol=1e-5
-            )
-    
+            s.axes_manager[1].axis,
+            rtol=1e-5,
+        )
+
     def test_is_hamamatsu_streak(self):
-        file = 'test_hamamatsu_streak_SCAN.tif'
+        file = "test_hamamatsu_streak_SCAN.tif"
         fname = os.path.join(self.path, file)
-    
+
         with pytest.warns(UserWarning):
             s = hs.load(fname)
-    
+
         omd = s.original_metadata.as_dictionary()
-    
-        omd['Artist'] = "TAPTAP"
-    
+
+        omd["Artist"] = "TAPTAP"
+
         assert not rsciio.tiff.api._is_streak_hamamatsu(omd)
-    
-        _ = omd.pop('Artist')
-    
+
+        _ = omd.pop("Artist")
+
         assert not rsciio.tiff.api._is_streak_hamamatsu(omd)
-    
-        omd.update({'Artist': "Copyright Hamamatsu GmbH, 2018"})
-    
-        omd['Software'] = "TAPTAPTAP"
-    
+
+        omd.update({"Artist": "Copyright Hamamatsu GmbH, 2018"})
+
+        omd["Software"] = "TAPTAPTAP"
+
         assert not rsciio.tiff.api._is_streak_hamamatsu(omd)
-    
-        _ = omd.pop('Software')
-    
+
+        _ = omd.pop("Software")
+
         assert not rsciio.tiff.api._is_streak_hamamatsu(omd)
-    
-        omd.update({'Software': "HPD-TA 9.5 pf4"})
-    
+
+        omd.update({"Software": "HPD-TA 9.5 pf4"})
+
         assert rsciio.tiff.api._is_streak_hamamatsu(omd)

--- a/rsciio/tests/test_tvips.py
+++ b/rsciio/tests/test_tvips.py
@@ -57,7 +57,7 @@ DIRPATH = os.path.join(os.path.dirname(__file__), "tvips_files")
 def fake_metadata_diffraction():
     metadata = {
         "Acquisition_instrument": {
-            "TEM" : {
+            "TEM": {
                 "beam_current": 23,
                 "beam_energy": 200,
                 "camera_length": 80,
@@ -67,7 +67,7 @@ def fake_metadata_diffraction():
             "date": "1993-06-18",
             "time": "12:34:56",
             "time_zone": "CET",
-        }
+        },
     }
     return DictionaryTreeBrowser(metadata)
 
@@ -76,7 +76,7 @@ def fake_metadata_diffraction():
 def fake_metadata_imaging():
     metadata = {
         "Acquisition_instrument": {
-            "TEM" : {
+            "TEM": {
                 "beam_current": 23,
                 "beam_energy": 200,
                 "magnification": 3000,
@@ -86,7 +86,7 @@ def fake_metadata_imaging():
             "date": "1993-06-18",
             "time": "12:34:56",
             "time_zone": "CET",
-        }
+        },
     }
     return DictionaryTreeBrowser(metadata)
 
@@ -95,7 +95,7 @@ def fake_metadata_imaging():
 def fake_metadata_confused():
     metadata = {
         "Acquisition_instrument": {
-            "TEM" : {
+            "TEM": {
                 "beam_current": 23,
                 "beam_energy": 200,
                 "camera_length": 80,
@@ -106,17 +106,20 @@ def fake_metadata_confused():
             "date": "1993-06-18",
             "time": "12:34:56",
             "time_zone": "CET",
-        }
+        },
     }
     return DictionaryTreeBrowser(metadata)
 
 
 @pytest.fixture()
-def fake_metadatas(fake_metadata_diffraction, fake_metadata_imaging, fake_metadata_confused):
-    return {"diffraction": fake_metadata_diffraction,
-            "imaging": fake_metadata_imaging,
-            "confused": fake_metadata_confused,
-            }
+def fake_metadatas(
+    fake_metadata_diffraction, fake_metadata_imaging, fake_metadata_confused
+):
+    return {
+        "diffraction": fake_metadata_diffraction,
+        "imaging": fake_metadata_imaging,
+        "confused": fake_metadata_confused,
+    }
 
 
 @pytest.fixture()
@@ -172,12 +175,9 @@ def fake_signals(fake_signal_3D, fake_signal_4D, fake_signal_5D):
         ("foo", None),
         ("", None),
         ("s", None),
-    ]
+    ],
 )
-@pytest.mark.parametrize(
-    "sig",
-    ["fake_signal_3D", "fake_signal_4D", "fake_signal_5D"]
-)
+@pytest.mark.parametrize("sig", ["fake_signal_3D", "fake_signal_4D", "fake_signal_5D"])
 def test_guess_image_mode(unit, expected_mode, sig, fake_signals):
     signal = fake_signals[sig]
     signal.axes_manager[-1].units = unit
@@ -191,18 +191,20 @@ def test_guess_image_mode(unit, expected_mode, sig, fake_signals):
         ("1/pm", 1e3, 2, 0),
         ("um", 1e3, 1, 60),
         ("foo", 1, 2, 12),
-    ]
+    ],
 )
-@pytest.mark.parametrize(
-    "sig",
-    ["fake_signal_3D", "fake_signal_4D", "fake_signal_5D"]
-)
-@pytest.mark.parametrize(
-    "metadata",
-    ["diffraction", "imaging", "confused", None]
-)
-def test_main_header_from_signal(unit, expected_scale_factor, version, fheb,
-                                 sig, fake_signals, metadata, fake_metadatas):
+@pytest.mark.parametrize("sig", ["fake_signal_3D", "fake_signal_4D", "fake_signal_5D"])
+@pytest.mark.parametrize("metadata", ["diffraction", "imaging", "confused", None])
+def test_main_header_from_signal(
+    unit,
+    expected_scale_factor,
+    version,
+    fheb,
+    sig,
+    fake_signals,
+    metadata,
+    fake_metadatas,
+):
     signal = fake_signals[sig]
     if metadata is not None:
         signal._metadata = fake_metadatas[metadata]
@@ -222,11 +224,20 @@ def test_main_header_from_signal(unit, expected_scale_factor, version, fheb,
     assert header["offsetx"] == 0
     assert header["offsety"] == 0
     assert header["pixelsize"] == original_scale_x * expected_scale_factor
-    assert header["frameheaderbytes"] == np.dtype(TVIPS_RECORDER_FRAME_HEADER).itemsize + fheb
+    assert (
+        header["frameheaderbytes"]
+        == np.dtype(TVIPS_RECORDER_FRAME_HEADER).itemsize + fheb
+    )
     if metadata == "diffraction" and unit == "1/pm":
-        assert header["magtotal"] == signal.metadata.Acquisition_instrument.TEM.camera_length
+        assert (
+            header["magtotal"]
+            == signal.metadata.Acquisition_instrument.TEM.camera_length
+        )
     elif metadata == "imaging" and unit == "um":
-        assert header["magtotal"] == signal.metadata.Acquisition_instrument.TEM.magnification
+        assert (
+            header["magtotal"]
+            == signal.metadata.Acquisition_instrument.TEM.magnification
+        )
     else:
         assert header["magtotal"] == 0
     if metadata is None:
@@ -235,20 +246,20 @@ def test_main_header_from_signal(unit, expected_scale_factor, version, fheb,
         assert header["ht"] == signal.metadata.Acquisition_instrument.TEM.beam_energy
 
 
-@pytest.mark.parametrize(
-    "extra_bytes",
-    [0, 20]
-)
-@pytest.mark.parametrize(
-    "sig",
-    ["fake_signal_3D", "fake_signal_4D", "fake_signal_5D"]
-)
+@pytest.mark.parametrize("extra_bytes", [0, 20])
+@pytest.mark.parametrize("sig", ["fake_signal_3D", "fake_signal_4D", "fake_signal_5D"])
 def test_get_frame_record_dtype(sig, fake_signals, extra_bytes):
     signal = fake_signals[sig]
-    dt_fh = _get_frame_record_dtype_from_signal(signal._to_dictionary(), extra_bytes=extra_bytes)
+    dt_fh = _get_frame_record_dtype_from_signal(
+        signal._to_dictionary(), extra_bytes=extra_bytes
+    )
     dimx = signal.axes_manager[-2].size
     dimy = signal.axes_manager[-1].size
-    total_size = np.dtype(TVIPS_RECORDER_FRAME_HEADER).itemsize + extra_bytes + dimx * dimy * signal.data.itemsize
+    total_size = (
+        np.dtype(TVIPS_RECORDER_FRAME_HEADER).itemsize
+        + extra_bytes
+        + dimx * dimy * signal.data.itemsize
+    )
     assert dt_fh.itemsize == total_size
 
 
@@ -261,7 +272,7 @@ def test_get_frame_record_dtype(sig, fake_signals, extra_bytes):
         pytest.param("foo_0000.TVIPS", marks=pytest.mark.xfail(raises=ValueError)),
         ("foo_000.tvips"),
         ("foo_000.TVIPS"),
-    ]
+    ],
 )
 def test_valid_tvips_file(filename):
     isvalid = _is_valid_first_tvips_file(filename)
@@ -278,7 +289,7 @@ def test_valid_tvips_file(filename):
         (np.array([0, 0, 1, 1, 3, 3, 4, 0]), (2, 6)),
         (np.array([1, 2, 3, 4, 5]), (0, 4)),
         (np.array([0, 0, 0, 0]), (None, None)),
-    ]
+    ],
 )
 def test_auto_scan_start_stop(rotators, expected):
     start, stop = _find_auto_scan_start_stop(rotators)
@@ -289,19 +300,19 @@ def test_auto_scan_start_stop(rotators, expected):
 @pytest.mark.parametrize(
     "rotators, startstop, expected",
     [
-        (np.array([0, 0, 1, 2, 3, 4, 5, 6, 0, 0]),
+        (np.array([0, 0, 1, 2, 3, 4, 5, 6, 0, 0]), None, np.array([2, 3, 4, 5, 6, 7])),
+        (np.array([0, 1, 2, 3, 4, 5, 6, 0, 0]), (2, 5), np.array([2, 2, 3, 4, 5])),
+        (
+            np.array([1, 3, 3, 4, 5, 5, 9, 0, 0]),
             None,
-            np.array([2, 3, 4, 5, 6, 7])),
-        (np.array([0, 1, 2, 3, 4, 5, 6, 0, 0]),
-            (2, 5),
-            np.array([2, 2, 3, 4, 5])),
-        (np.array([1, 3, 3, 4, 5, 5, 9, 0, 0]),
+            np.array([0, 0, 1, 3, 4, 5, 5, 5, 6]),
+        ),
+        (
+            np.array([0, 0, 1, 3, 3, 4, 5, 5, 9, 0, 0]),
             None,
-            np.array([0, 0, 1, 3, 4, 5, 5, 5, 6])),
-        (np.array([0, 0, 1, 3, 3, 4, 5, 5, 9, 0, 0]),
-            None,
-            np.array([2, 2, 3, 5, 6, 7, 7, 7, 8])),
-    ]
+            np.array([2, 2, 3, 5, 6, 7, 7, 7, 8]),
+        ),
+    ],
 )
 def test_guess_scan_index_grid(rotators, startstop, expected):
     if startstop is None:
@@ -329,7 +340,7 @@ def _dask_supports_assignment():
                 "scan_start_frame": 20,
                 "hysteresis": 1,
                 "rechunking": False,
-            }
+            },
         ),
         (
             os.path.join(DIRPATH, "test_tvips_2345_000.tvips"),
@@ -338,7 +349,7 @@ def _dask_supports_assignment():
                 "scan_start_frame": 0,
                 "hysteresis": 0,
                 "rechunking": "auto",
-            }
+            },
         ),
         (
             os.path.join(DIRPATH, "test_tvips_2345_split_000.tvips"),
@@ -347,9 +358,9 @@ def _dask_supports_assignment():
                 "scan_start_frame": 2,
                 "hysteresis": -1,
                 "rechunking": {0: 1, 1: 1, 2: None, 3: None},
-            }
+            },
         ),
-    ]
+    ],
 )
 @pytest.mark.parametrize("wsa", ["x", "y", None])
 @pytest.mark.parametrize("lazy", [True, False])
@@ -370,29 +381,37 @@ def test_tvips_file_reader(filename, lazy, kwargs, wsa):
         signal_test.compute()
         signal_test.data = signal_test.data.copy()
     if wsa == "x":
-        signal_test.data[..., ::2, :, :, :] = signal_test.data[..., ::2, :, :, :][..., :, ::-1, :, :]
-        signal_test.data[..., ::2, :, :, :] = np.roll(signal_test.data[..., ::2, :, :, :], hyst, axis=-3)
+        signal_test.data[..., ::2, :, :, :] = signal_test.data[..., ::2, :, :, :][
+            ..., :, ::-1, :, :
+        ]
+        signal_test.data[..., ::2, :, :, :] = np.roll(
+            signal_test.data[..., ::2, :, :, :], hyst, axis=-3
+        )
     elif wsa == "y":
-        signal_test.data[..., ::2, :, :] = signal_test.data[..., ::2, :, :][..., ::-1, :, :, :]
-        signal_test.data[..., ::2, :, :] = np.roll(signal_test.data[..., ::2, :, :], hyst, axis=-4)
+        signal_test.data[..., ::2, :, :] = signal_test.data[..., ::2, :, :][
+            ..., ::-1, :, :, :
+        ]
+        signal_test.data[..., ::2, :, :] = np.roll(
+            signal_test.data[..., ::2, :, :], hyst, axis=-4
+        )
     assert np.allclose(signal_test.data, signal.data)
 
 
 @pytest.mark.xfail(raises=ValueError)
 def test_read_fail_version():
-    file = os.path.join(DIRPATH, "test_tvips_2345_split_000.tvips"),
+    file = (os.path.join(DIRPATH, "test_tvips_2345_split_000.tvips"),)
     hs.load(file, scan_shape="auto")
 
 
 @pytest.mark.xfail(raises=ValueError)
 def test_read_fail_wind_axis():
-    file = os.path.join(DIRPATH, "test_tvips_2345_split_000.tvips"),
+    file = (os.path.join(DIRPATH, "test_tvips_2345_split_000.tvips"),)
     hs.load(file, scan_shape=(2, 3), winding_scan_axis="z")
 
 
 @pytest.mark.xfail(raises=ValueError)
 def test_read_fail_scan_shape():
-    file = os.path.join(DIRPATH, "test_tvips_2345_split_000.tvips"),
+    file = (os.path.join(DIRPATH, "test_tvips_2345_split_000.tvips"),)
     hs.load(file, scan_shape=(3, 3))
 
 
@@ -413,10 +432,12 @@ def test_write_fail_signal_type():
         ("fake_signal_4D", "diffraction", 100, 0),
         ("fake_signal_5D", "imaging", 100, 20),
         ("fake_signal_5D", None, 700, 10),
-    ]
+    ],
 )
 @pytest.mark.parametrize("lazy", [True, False])
-def test_file_writer(sig, meta, max_file_size, fheb, fake_signals, fake_metadatas, lazy):
+def test_file_writer(
+    sig, meta, max_file_size, fheb, fake_signals, fake_metadatas, lazy
+):
     signal = fake_signals[sig]
     if lazy:
         signal = signal.as_lazy()
@@ -427,20 +448,31 @@ def test_file_writer(sig, meta, max_file_size, fheb, fake_signals, fake_metadata
     with tempfile.TemporaryDirectory() as tmp:
         filepath = os.path.join(tmp, "test_tvips_save_000.tvips")
         scan_shape = signal.axes_manager.navigation_shape
-        file_writer(filepath, signal._to_dictionary(), max_file_size=max_file_size, frame_header_extra_bytes=fheb)
+        file_writer(
+            filepath,
+            signal._to_dictionary(),
+            max_file_size=max_file_size,
+            frame_header_extra_bytes=fheb,
+        )
         if max_file_size is None:
             assert len(os.listdir(tmp)) == 1
         else:
             assert len(os.listdir(tmp)) >= 1
         filepath_load = os.path.join(tmp, "test_tvips_save_000.tvips")
         dtc = file_reader(filepath_load, scan_shape=scan_shape[::-1], lazy=False)[0]
-        np.testing.assert_allclose(signal.data, dtc['data'])
-        assert signal.data.dtype == dtc['data'].dtype
+        np.testing.assert_allclose(signal.data, dtc["data"])
+        assert signal.data.dtype == dtc["data"].dtype
         if metadata and meta is not None:
             assert dtc["metadata"]["General"]["date"] == metadata.General.date
             assert dtc["metadata"]["General"]["time"] == metadata.General.time
-            assert dtc["metadata"]["Acquisition_instrument"]["TEM"]['beam_energy'] == metadata.Acquisition_instrument.TEM.beam_energy
-            assert dtc["metadata"]["Acquisition_instrument"]["TEM"]['beam_current'] == metadata.Acquisition_instrument.TEM.beam_current
+            assert (
+                dtc["metadata"]["Acquisition_instrument"]["TEM"]["beam_energy"]
+                == metadata.Acquisition_instrument.TEM.beam_energy
+            )
+            assert (
+                dtc["metadata"]["Acquisition_instrument"]["TEM"]["beam_current"]
+                == metadata.Acquisition_instrument.TEM.beam_current
+            )
         gc.collect()
 
 

--- a/rsciio/tests/test_usid.py
+++ b/rsciio/tests/test_usid.py
@@ -13,33 +13,40 @@ sidpy = pytest.importorskip("sidpy", reason="sidpy not installed")
 
 # ##################### HELPER FUNCTIONS ######################################
 
+
 def _array_translator_basic_checks(h5_f):
     assert len(h5_f.items()) == 1
-    assert 'Measurement_000' in h5_f.keys()
-    h5_meas_grp = h5_f['Measurement_000']
+    assert "Measurement_000" in h5_f.keys()
+    h5_meas_grp = h5_f["Measurement_000"]
     assert isinstance(h5_meas_grp, h5py.Group)
 
     # Again, this group should only have one group - Channel_000
     assert len(h5_meas_grp.items()) == 1
-    assert 'Channel_000' in h5_meas_grp.keys()
-    h5_chan_grp = h5_meas_grp['Channel_000']
+    assert "Channel_000" in h5_meas_grp.keys()
+    h5_chan_grp = h5_meas_grp["Channel_000"]
     assert isinstance(h5_chan_grp, h5py.Group)
 
     # This channel group will contain the main dataset
     assert len(h5_chan_grp.items()) == 5
-    for dset_name in ['Raw_Data', 'Position_Indices', 'Position_Values',
-                      'Spectroscopic_Indices', 'Spectroscopic_Values']:
+    for dset_name in [
+        "Raw_Data",
+        "Position_Indices",
+        "Position_Values",
+        "Spectroscopic_Indices",
+        "Spectroscopic_Values",
+    ]:
         assert dset_name in h5_chan_grp.keys()
         h5_dset = h5_chan_grp[dset_name]
         assert isinstance(h5_dset, h5py.Dataset)
 
     assert len(usid.hdf_utils.get_all_main(h5_f)) == 1
 
-    assert usid.hdf_utils.check_if_main(h5_chan_grp['Raw_Data'])
+    assert usid.hdf_utils.check_if_main(h5_chan_grp["Raw_Data"])
 
 
-def _compare_axes(hs_axes, dim_descriptors, usid_val_func, axes_defined=True,
-                  invalid_axes=False):
+def _compare_axes(
+    hs_axes, dim_descriptors, usid_val_func, axes_defined=True, invalid_axes=False
+):
     usid_descriptors = [_split_descriptor(_) for _ in dim_descriptors]
     for dim_ind, axis in enumerate(hs_axes):
         # Remember that the signal axes are actually reversed!
@@ -49,9 +56,9 @@ def _compare_axes(hs_axes, dim_descriptors, usid_val_func, axes_defined=True,
             assert axis.units == usid_descriptors[real_dim_ind][1]
 
         if not invalid_axes:
-            axis_vals = np.arange(axis.offset,
-                                  axis.offset + axis.size * axis.scale,
-                                  axis.scale)
+            axis_vals = np.arange(
+                axis.offset, axis.offset + axis.size * axis.scale, axis.scale
+            )
             usid_vals = usid_val_func(usid_descriptors[real_dim_ind][0])
             np.testing.assert_allclose(axis_vals, usid_vals)
 
@@ -65,51 +72,52 @@ def _assert_empty_dims(hs_axes, usid_labels, usid_val_func):
 
 def _split_descriptor(desc):
     desc = desc.strip()
-    ind = desc.rfind('(')
+    ind = desc.rfind("(")
     if ind < 0:
-        ind = desc.rfind('[')
+        ind = desc.rfind("[")
         if ind < 0:
-            return desc, ''
+            return desc, ""
 
     quant = desc[:ind].strip()
     units = desc[ind:]
-    for item in '()[]':
-        units = units.replace(item, '')
+    for item in "()[]":
+        units = units.replace(item, "")
     return quant, units
 
 
 def _validate_metadata_from_h5dset(sig, h5_dset, compound_comp_name=None):
     if compound_comp_name is None:
-        quant = usid.hdf_utils.get_attr(h5_dset, 'quantity')
-        units = usid.hdf_utils.get_attr(h5_dset, 'units')
+        quant = usid.hdf_utils.get_attr(h5_dset, "quantity")
+        units = usid.hdf_utils.get_attr(h5_dset, "units")
     else:
         quant, units = _split_descriptor(compound_comp_name)
     assert sig.original_metadata.quantity == quant
     assert sig.original_metadata.units == units
     assert sig.metadata.General.original_filename == h5_dset.file.filename
-    assert sig.metadata.General.title == h5_dset.name.split('/')[-1]
+    assert sig.metadata.General.title == h5_dset.name.split("/")[-1]
     assert sig.original_metadata.dataset_path == h5_dset.name
-    assert sig.original_metadata.original_file_type == 'USID HDF5'
+    assert sig.original_metadata.original_file_type == "USID HDF5"
     assert sig.original_metadata.pyUSID_version == usid.__version__
 
     h5_chan_grp = h5_dset.parent
     usid_grp_parms = dict()
-    if 'Channel' in h5_chan_grp.name.split('/')[-1]:
+    if "Channel" in h5_chan_grp.name.split("/")[-1]:
         usid_grp_parms = sidpy.hdf.hdf_utils.get_attributes(h5_chan_grp)
         h5_meas_grp = h5_chan_grp.parent
-        if 'Measurement' in h5_meas_grp.name.split('/')[-1]:
+        if "Measurement" in h5_meas_grp.name.split("/")[-1]:
             temp = sidpy.hdf.hdf_utils.get_attributes(h5_meas_grp)
             usid_grp_parms.update(temp)
     # Remove timestamp key since there is 1s difference occasionally
-    usid_grp_parms.pop('timestamp', None)
+    usid_grp_parms.pop("timestamp", None)
     om_dict = sig.original_metadata.parameters.as_dictionary()
-    om_dict.pop('timestamp', None)
+    om_dict.pop("timestamp", None)
     assert om_dict == usid_grp_parms
 
 
-def compare_usid_from_signal(sig, h5_path, empty_pos=False, empty_spec=False,
-                             dataset_path=None, **kwargs):
-    with h5py.File(h5_path, mode='r') as h5_f:
+def compare_usid_from_signal(
+    sig, h5_path, empty_pos=False, empty_spec=False, dataset_path=None, **kwargs
+):
+    with h5py.File(h5_path, mode="r") as h5_f:
         # 1. Validate that what has been written is a USID Main dataset
         if dataset_path is None:
             _array_translator_basic_checks(h5_f)
@@ -122,28 +130,47 @@ def compare_usid_from_signal(sig, h5_path, empty_pos=False, empty_spec=False,
         np.testing.assert_allclose(sig.data, usid_data)
         # 3. Validate that axes / dimensions have been translated correctly:
         if empty_pos:
-            _assert_empty_dims(sig.axes_manager.navigation_axes,
-                               h5_main.pos_dim_labels, h5_main.get_pos_values,
-                               **kwargs)
+            _assert_empty_dims(
+                sig.axes_manager.navigation_axes,
+                h5_main.pos_dim_labels,
+                h5_main.get_pos_values,
+                **kwargs
+            )
         else:
-            _compare_axes(sig.axes_manager.navigation_axes,
-                          h5_main.pos_dim_descriptors, h5_main.get_pos_values,
-                          **kwargs)
+            _compare_axes(
+                sig.axes_manager.navigation_axes,
+                h5_main.pos_dim_descriptors,
+                h5_main.get_pos_values,
+                **kwargs
+            )
         # 4. Check to make sure that there is only one spectroscopic dimension
         # of size 1
         if empty_spec:
-            _assert_empty_dims(sig.axes_manager.signal_axes,
-                               h5_main.spec_dim_labels,
-                               h5_main.get_spec_values, **kwargs)
+            _assert_empty_dims(
+                sig.axes_manager.signal_axes,
+                h5_main.spec_dim_labels,
+                h5_main.get_spec_values,
+                **kwargs
+            )
         else:
-            _compare_axes(sig.axes_manager.signal_axes,
-                          h5_main.spec_dim_descriptors,
-                          h5_main.get_spec_values, **kwargs)
+            _compare_axes(
+                sig.axes_manager.signal_axes,
+                h5_main.spec_dim_descriptors,
+                h5_main.get_spec_values,
+                **kwargs
+            )
 
 
-def compare_signal_from_usid(file_path, ndata, new_sig, axes_to_spec=[],
-                             sig_type=hs.signals.BaseSignal, dataset_path=None,
-                             compound_comp_name=None, **kwargs):
+def compare_signal_from_usid(
+    file_path,
+    ndata,
+    new_sig,
+    axes_to_spec=[],
+    sig_type=hs.signals.BaseSignal,
+    dataset_path=None,
+    compound_comp_name=None,
+    **kwargs
+):
     # 1. Validate object type
     assert isinstance(new_sig, sig_type)
     if len(axes_to_spec) > 0:
@@ -151,39 +178,53 @@ def compare_signal_from_usid(file_path, ndata, new_sig, axes_to_spec=[],
 
     # 2. Validate that data has been read in correctly:
     np.testing.assert_allclose(new_sig.data, ndata)
-    with h5py.File(file_path, mode='r') as h5_f:
+    with h5py.File(file_path, mode="r") as h5_f:
         if dataset_path is None:
             h5_main = usid.hdf_utils.get_all_main(h5_f)[0]
         else:
             h5_main = usid.USIDataset(h5_f[dataset_path])
         # 3. Validate that all axes / dimensions have been translated correctly
         if len(axes_to_spec) > 0:
-            _compare_axes(new_sig.axes_manager.navigation_axes,
-                          h5_main.pos_dim_descriptors, h5_main.get_pos_values,
-                          **kwargs)
+            _compare_axes(
+                new_sig.axes_manager.navigation_axes,
+                h5_main.pos_dim_descriptors,
+                h5_main.get_pos_values,
+                **kwargs
+            )
         else:
             assert new_sig.axes_manager.navigation_dimension == 0
         # 3. Validate that all spectroscopic axes / dimensions have been
         # translated correctly:
         if h5_main.shape[1] == 1:
-            _compare_axes(new_sig.axes_manager.signal_axes,
-                          h5_main.pos_dim_descriptors, h5_main.get_pos_values,
-                          **kwargs)
+            _compare_axes(
+                new_sig.axes_manager.signal_axes,
+                h5_main.pos_dim_descriptors,
+                h5_main.get_pos_values,
+                **kwargs
+            )
         else:
-            _compare_axes(new_sig.axes_manager.signal_axes,
-                          h5_main.spec_dim_descriptors,
-                          h5_main.get_spec_values, **kwargs)
+            _compare_axes(
+                new_sig.axes_manager.signal_axes,
+                h5_main.spec_dim_descriptors,
+                h5_main.get_spec_values,
+                **kwargs
+            )
 
         # 5. Validate that metadata has been read in correctly:
-        _validate_metadata_from_h5dset(new_sig, h5_main,
-                                       compound_comp_name=compound_comp_name)
+        _validate_metadata_from_h5dset(
+            new_sig, h5_main, compound_comp_name=compound_comp_name
+        )
 
 
 def gen_2pos_2spec(s2f_aux=True, mode=None):
-    pos_dims = [usid.Dimension('X', 'nm', [-250, 750]),
-                usid.Dimension('Y', 'um', np.linspace(0, 60, num=7))]
-    spec_dims = [usid.Dimension('Frequency', 'kHz', [300, 350, 400]),
-                 usid.Dimension('Bias', 'V', np.linspace(-4, 4, num=5))]
+    pos_dims = [
+        usid.Dimension("X", "nm", [-250, 750]),
+        usid.Dimension("Y", "um", np.linspace(0, 60, num=7)),
+    ]
+    spec_dims = [
+        usid.Dimension("Frequency", "kHz", [300, 350, 400]),
+        usid.Dimension("Bias", "V", np.linspace(-4, 4, num=5)),
+    ]
     if s2f_aux:
         pos_dims = pos_dims[::-1]
         spec_dims = spec_dims[::-1]
@@ -192,406 +233,543 @@ def gen_2pos_2spec(s2f_aux=True, mode=None):
     if mode is None:
         # Typcial floating point dataset
         ndata = np.random.rand(*ndim_shape)
-    elif mode == 'complex':
+    elif mode == "complex":
         ndata = np.random.rand(*ndim_shape) + 1j * np.random.rand(*ndim_shape)
-    elif mode == 'compound':
-        struc_dtype = np.dtype({'names': ['amp', 'phas'],
-                                'formats': [np.float16, np.float32]})
+    elif mode == "compound":
+        struc_dtype = np.dtype(
+            {"names": ["amp", "phas"], "formats": [np.float16, np.float32]}
+        )
         ndata = np.zeros(shape=ndim_shape, dtype=struc_dtype)
-        ndata['amp'] = np.random.random(size=ndim_shape)
-        ndata['phas'] = np.random.random(size=ndim_shape)
+        ndata["amp"] = np.random.random(size=ndim_shape)
+        ndata["phas"] = np.random.random(size=ndim_shape)
 
-    data_2d = ndata.reshape(np.prod(ndata.shape[:2]),
-                              np.prod(ndata.shape[2:]))
+    data_2d = ndata.reshape(np.prod(ndata.shape[:2]), np.prod(ndata.shape[2:]))
     return pos_dims, spec_dims, ndata, data_2d
 
 
 def gen_2dim(all_pos=False, s2f_aux=True):
     ndata = np.random.rand(3, 2)
     if all_pos:
-        pos_dims = [usid.Dimension('X', 'nm', [-250, 750]),
-                    usid.Dimension('Y', 'um', [-2, 0, 2])]
-        spec_dims = [usid.Dimension('arb', 'a.u.', 1)]
+        pos_dims = [
+            usid.Dimension("X", "nm", [-250, 750]),
+            usid.Dimension("Y", "um", [-2, 0, 2]),
+        ]
+        spec_dims = [usid.Dimension("arb", "a.u.", 1)]
         data_2d = ndata.reshape(-1, 1)
     else:
-        pos_dims = [usid.Dimension('arb', 'a.u.', 1)]
-        spec_dims = [usid.Dimension('Frequency', 'kHz', [0, 100]),
-                     usid.Dimension('Bias', 'V', [-5, 0, 5])]
+        pos_dims = [usid.Dimension("arb", "a.u.", 1)]
+        spec_dims = [
+            usid.Dimension("Frequency", "kHz", [0, 100]),
+            usid.Dimension("Bias", "V", [-5, 0, 5]),
+        ]
         data_2d = ndata.reshape(1, -1)
     if s2f_aux:
         pos_dims = pos_dims[::-1]
         spec_dims = spec_dims[::-1]
     return pos_dims, spec_dims, ndata, data_2d
 
+
 # ################ HyperSpy Signal to h5USID ##################################
 
 
-@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:This dataset does not have an N-dimensional form:UserWarning"
+)
 class TestHS2USIDallKnown:
-
     def test_n_pos_0_spec(self):
-        sig = hs.signals.BaseSignal(np.random.randint(0, high=100,
-                                                      size=(2, 3)),
-                                    axes=[{'size': 2, 'name': 'X',
-                                           'units': 'nm', 'scale': 0.2,
-                                           'offset': 1},
-                                          {'size': 3, 'name': 'Y',
-                                           'units': 'um', 'scale': 0.1,
-                                           'offset': 2}])
+        sig = hs.signals.BaseSignal(
+            np.random.randint(0, high=100, size=(2, 3)),
+            axes=[
+                {"size": 2, "name": "X", "units": "nm", "scale": 0.2, "offset": 1},
+                {"size": 3, "name": "Y", "units": "um", "scale": 0.1, "offset": 2},
+            ],
+        )
         sig = sig.transpose()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_0_spec_real.h5'
+            file_path = tmp_dir + "usid_n_pos_0_spec_real.h5"
         sig.save(file_path)
 
-        compare_usid_from_signal(sig, file_path, empty_pos=False,
-                                 empty_spec=True)
+        compare_usid_from_signal(sig, file_path, empty_pos=False, empty_spec=True)
 
     def test_0_pos_n_spec(self):
-        sig = hs.signals.BaseSignal(np.random.randint(0, high=100,
-                                                      size=(2, 3)),
-                                    axes=[{'size': 2, 'name': 'Freq',
-                                           'units': 'Hz', 'scale': 30,
-                                           'offset': 300},
-                                          {'size': 3, 'name': 'Bias',
-                                           'units': 'V', 'scale': 0.25,
-                                           'offset': -0.25}])
+        sig = hs.signals.BaseSignal(
+            np.random.randint(0, high=100, size=(2, 3)),
+            axes=[
+                {"size": 2, "name": "Freq", "units": "Hz", "scale": 30, "offset": 300},
+                {
+                    "size": 3,
+                    "name": "Bias",
+                    "units": "V",
+                    "scale": 0.25,
+                    "offset": -0.25,
+                },
+            ],
+        )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_0_pos_n_spec_real.h5'
+            file_path = tmp_dir + "usid_0_pos_n_spec_real.h5"
         sig.save(file_path)
 
-        compare_usid_from_signal(sig, file_path, empty_pos=True,
-                                 empty_spec=False)
+        compare_usid_from_signal(sig, file_path, empty_pos=True, empty_spec=False)
 
     def test_n_pos_m_spec(self):
-        sig = hs.signals.Signal2D(np.random.randint(0, high=100,
-                                                    size=(2, 3, 5, 7)),
-                                  axes=[{'size': 2, 'name': 'X', 'units': 'nm',
-                                         'scale': 0.2, 'offset': 1},
-                                        {'size': 3, 'name': 'Y', 'units': 'um',
-                                         'scale': 0.1, 'offset': 2},
-                                        {'size': 5, 'name': 'Freq',
-                                         'units': 'Hz', 'scale': 30,
-                                         'offset': 300},
-                                        {'size': 7, 'name': 'Bias',
-                                         'units': 'V', 'scale': 0.25,
-                                         'offset': -0.25}])
+        sig = hs.signals.Signal2D(
+            np.random.randint(0, high=100, size=(2, 3, 5, 7)),
+            axes=[
+                {"size": 2, "name": "X", "units": "nm", "scale": 0.2, "offset": 1},
+                {"size": 3, "name": "Y", "units": "um", "scale": 0.1, "offset": 2},
+                {"size": 5, "name": "Freq", "units": "Hz", "scale": 30, "offset": 300},
+                {
+                    "size": 7,
+                    "name": "Bias",
+                    "units": "V",
+                    "scale": 0.25,
+                    "offset": -0.25,
+                },
+            ],
+        )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_real.h5'
+            file_path = tmp_dir + "usid_n_pos_n_spec_real.h5"
         sig.save(file_path)
 
-        compare_usid_from_signal(sig, file_path, empty_pos=False,
-                                 empty_spec=False)
+        compare_usid_from_signal(sig, file_path, empty_pos=False, empty_spec=False)
 
     def test_append_to_existing_file(self):
-        sig = hs.signals.BaseSignal(np.random.randint(0, high=100,
-                                                      size=(2, 3)),
-                                    axes=[{'size': 2, 'name': 'X',
-                                           'units': 'nm', 'scale': 0.2,
-                                           'offset': 1},
-                                          {'size': 3, 'name': 'Y',
-                                           'units': 'um', 'scale': 0.1,
-                                           'offset': 2}])
+        sig = hs.signals.BaseSignal(
+            np.random.randint(0, high=100, size=(2, 3)),
+            axes=[
+                {"size": 2, "name": "X", "units": "nm", "scale": 0.2, "offset": 1},
+                {"size": 3, "name": "Y", "units": "um", "scale": 0.1, "offset": 2},
+            ],
+        )
         sig = sig.transpose()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_0_spec_real.h5'
+            file_path = tmp_dir + "usid_n_pos_0_spec_real.h5"
         sig.save(file_path)
 
-        compare_usid_from_signal(sig, file_path, empty_pos=False,
-                                 empty_spec=True)
+        compare_usid_from_signal(sig, file_path, empty_pos=False, empty_spec=True)
 
-        sig = hs.signals.BaseSignal(np.random.randint(0, high=100,
-                                                      size=(2, 3)),
-                                    axes=[{'size': 2, 'name': 'Freq',
-                                           'units': 'Hz', 'scale': 30,
-                                           'offset': 300},
-                                          {'size': 3, 'name': 'Bias',
-                                           'units': 'V', 'scale': 0.25,
-                                           'offset': -0.25}])
+        sig = hs.signals.BaseSignal(
+            np.random.randint(0, high=100, size=(2, 3)),
+            axes=[
+                {"size": 2, "name": "Freq", "units": "Hz", "scale": 30, "offset": 300},
+                {
+                    "size": 3,
+                    "name": "Bias",
+                    "units": "V",
+                    "scale": 0.25,
+                    "offset": -0.25,
+                },
+            ],
+        )
 
         sig.save(file_path, overwrite=True)
 
-        new_dataset_path = '/Measurement_001/Channel_000/Raw_Data'
+        new_dataset_path = "/Measurement_001/Channel_000/Raw_Data"
 
-        compare_usid_from_signal(sig, file_path, empty_pos=True,
-                                 empty_spec=False, dataset_path=new_dataset_path)
+        compare_usid_from_signal(
+            sig,
+            file_path,
+            empty_pos=True,
+            empty_spec=False,
+            dataset_path=new_dataset_path,
+        )
 
 
-@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:This dataset does not have an N-dimensional form:UserWarning"
+)
 class TestHS2USIDlazy:
-
     def test_base_nd(self):
-        sig = hs.signals.Signal2D(da.random.randint(0, high=100,
-                                                    size=(2, 3, 5, 7),
-                                                    chunks='auto')).as_lazy()
+        sig = hs.signals.Signal2D(
+            da.random.randint(0, high=100, size=(2, 3, 5, 7), chunks="auto")
+        ).as_lazy()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_dask.h5'
+            file_path = tmp_dir + "usid_n_pos_n_spec_dask.h5"
         sig.save(file_path)
 
-        compare_usid_from_signal(sig, file_path, empty_pos=False,
-                                 empty_spec=False, axes_defined=False)
+        compare_usid_from_signal(
+            sig, file_path, empty_pos=False, empty_spec=False, axes_defined=False
+        )
 
 
-@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:This dataset does not have an N-dimensional form:UserWarning"
+)
 class TestHS2USIDedgeAxes:
-
     def test_no_axes(self):
-        sig = hs.signals.Signal2D(np.random.randint(0, high=100,
-                                                    size=(2, 3, 5, 7)))
+        sig = hs.signals.Signal2D(np.random.randint(0, high=100, size=(2, 3, 5, 7)))
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_no_axes.h5'
+            file_path = tmp_dir + "usid_n_pos_n_spec_no_axes.h5"
         sig.save(file_path)
 
-        compare_usid_from_signal(sig, file_path, empty_pos=False,
-                                 empty_spec=False, axes_defined=False)
+        compare_usid_from_signal(
+            sig, file_path, empty_pos=False, empty_spec=False, axes_defined=False
+        )
 
     def test_incorrect_axes(self):
-        sig = hs.signals.Signal2D(np.random.randint(0, high=100,
-                                                    size=(2, 3, 5, 7)),
-                                  axes=[{'size': 1259, 'name': 'X',
-                                         'units': 'nm', 'scale': 0.2,
-                                         'offset': 1},
-                                        {'size': 245, 'name': 'Y',
-                                         'units': 'um', 'scale': 0.1,
-                                         'offset': 2},
-                                        {'size': 205, 'name': 'Freq',
-                                         'units': 'Hz', 'scale': 30,
-                                         'offset': 300},
-                                        {'size': 1005, 'name': 'Bias',
-                                         'units': 'V', 'scale': 0.25,
-                                         'offset': -0.25}])
+        sig = hs.signals.Signal2D(
+            np.random.randint(0, high=100, size=(2, 3, 5, 7)),
+            axes=[
+                {"size": 1259, "name": "X", "units": "nm", "scale": 0.2, "offset": 1},
+                {"size": 245, "name": "Y", "units": "um", "scale": 0.1, "offset": 2},
+                {
+                    "size": 205,
+                    "name": "Freq",
+                    "units": "Hz",
+                    "scale": 30,
+                    "offset": 300,
+                },
+                {
+                    "size": 1005,
+                    "name": "Bias",
+                    "units": "V",
+                    "scale": 0.25,
+                    "offset": -0.25,
+                },
+            ],
+        )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_incorrect_axes.h5'
+            file_path = tmp_dir + "usid_n_pos_n_spec_incorrect_axes.h5"
         sig.save(file_path)
 
-        compare_usid_from_signal(sig, file_path, empty_pos=False,
-                                 empty_spec=False, invalid_axes=True)
+        compare_usid_from_signal(
+            sig, file_path, empty_pos=False, empty_spec=False, invalid_axes=True
+        )
 
     def test_too_many_axes(self):
 
-        sig = hs.signals.Signal2D(np.random.randint(0, high=100,
-                                                    size=(2, 3, 5, 7)),
-                                  axes=[{'size': 2, 'name': 'X', 'units': 'nm',
-                                         'scale': 0.2, 'offset': 1},
-                                        {'size': 3, 'name': 'Y', 'units': 'um',
-                                         'scale': 0.1, 'offset': 2},
-                                        {'size': 5, 'name': 'Freq',
-                                         'units': 'Hz', 'scale': 30,
-                                         'offset': 300},
-                                        {'size': 7, 'name': 'Bias',
-                                         'units': 'V', 'scale': 0.25,
-                                         'offset': -0.25},
-                                        {'size': 27, 'name': 'Does not exist',
-                                         'units': 'V', 'scale': 0.25,
-                                         'offset': -0.25}])
+        sig = hs.signals.Signal2D(
+            np.random.randint(0, high=100, size=(2, 3, 5, 7)),
+            axes=[
+                {"size": 2, "name": "X", "units": "nm", "scale": 0.2, "offset": 1},
+                {"size": 3, "name": "Y", "units": "um", "scale": 0.1, "offset": 2},
+                {"size": 5, "name": "Freq", "units": "Hz", "scale": 30, "offset": 300},
+                {
+                    "size": 7,
+                    "name": "Bias",
+                    "units": "V",
+                    "scale": 0.25,
+                    "offset": -0.25,
+                },
+                {
+                    "size": 27,
+                    "name": "Does not exist",
+                    "units": "V",
+                    "scale": 0.25,
+                    "offset": -0.25,
+                },
+            ],
+        )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_too_many_axes.h5'
+            file_path = tmp_dir + "usid_n_pos_n_spec_too_many_axes.h5"
         with pytest.raises(ValueError):
             sig.save(file_path)
 
+
 # ################## h5USID to HyperSpy Signal(s)  ############################
 
-@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
-class TestUSID2HSbase:
 
+@pytest.mark.filterwarnings(
+    "ignore:This dataset does not have an N-dimensional form:UserWarning"
+)
+class TestUSID2HSbase:
     def test_n_pos_0_spec(self):
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
         slow_to_fast = True
-        pos_dims, spec_dims, ndata, data_2d = gen_2dim(all_pos=True,
-                                                       s2f_aux=slow_to_fast)
+        pos_dims, spec_dims, ndata, data_2d = gen_2dim(
+            all_pos=True, s2f_aux=slow_to_fast
+        )
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_0_spec.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims, slow_to_fast=slow_to_fast)
+            file_path = tmp_dir + "usid_n_pos_0_spec.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=slow_to_fast,
+        )
 
         new_sig = hs.load(file_path)
-        compare_signal_from_usid(file_path, ndata, new_sig,
-                                 sig_type=hs.signals.BaseSignal,
-                                 axes_to_spec=[])
+        compare_signal_from_usid(
+            file_path, ndata, new_sig, sig_type=hs.signals.BaseSignal, axes_to_spec=[]
+        )
 
     def test_0_pos_n_spec(self):
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
         slow_to_fast = True
-        pos_dims, spec_dims, ndata, data_2d = gen_2dim(all_pos=False,
-                                                       s2f_aux=slow_to_fast)
+        pos_dims, spec_dims, ndata, data_2d = gen_2dim(
+            all_pos=False, s2f_aux=slow_to_fast
+        )
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_0_pos_n_spec.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims, slow_to_fast=slow_to_fast)
+            file_path = tmp_dir + "usid_0_pos_n_spec.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=slow_to_fast,
+        )
 
         new_sig = hs.load(file_path)
-        compare_signal_from_usid(file_path, ndata, new_sig,
-                                 sig_type=hs.signals.BaseSignal,
-                                 axes_to_spec=[])
+        compare_signal_from_usid(
+            file_path, ndata, new_sig, sig_type=hs.signals.BaseSignal, axes_to_spec=[]
+        )
 
-    @pytest.mark.parametrize('lazy', [True, False])
+    @pytest.mark.parametrize("lazy", [True, False])
     def test_base_n_pos_m_spec(self, lazy, slow_to_fast=True):
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
         ret_vals = gen_2pos_2spec(s2f_aux=slow_to_fast)
         pos_dims, spec_dims, ndata, data_2d = ret_vals
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims, slow_to_fast=slow_to_fast)
+            file_path = tmp_dir + "usid_n_pos_n_spec.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=slow_to_fast,
+        )
 
         new_sig = hs.load(file_path, lazy=lazy)
-        compare_signal_from_usid(file_path, ndata, new_sig,
-                                 sig_type=hs.signals.BaseSignal,
-                                 axes_to_spec=['Frequency', 'Bias'])
+        compare_signal_from_usid(
+            file_path,
+            ndata,
+            new_sig,
+            sig_type=hs.signals.BaseSignal,
+            axes_to_spec=["Frequency", "Bias"],
+        )
 
 
-@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:This dataset does not have an N-dimensional form:UserWarning"
+)
 class TestUSID2HSdtype:
-
     def test_complex(self):
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
         slow_to_fast = True
-        ret_vals = gen_2pos_2spec(s2f_aux=slow_to_fast, mode='complex')
+        ret_vals = gen_2pos_2spec(s2f_aux=slow_to_fast, mode="complex")
         pos_dims, spec_dims, ndata, data_2d = ret_vals
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_complex.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims, slow_to_fast=slow_to_fast)
+            file_path = tmp_dir + "usid_n_pos_n_spec_complex.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=slow_to_fast,
+        )
 
         new_sig = hs.load(file_path)
-        compare_signal_from_usid(file_path, ndata, new_sig,
-                                 sig_type=hs.signals.ComplexSignal,
-                                 axes_to_spec=['Frequency', 'Bias'])
+        compare_signal_from_usid(
+            file_path,
+            ndata,
+            new_sig,
+            sig_type=hs.signals.ComplexSignal,
+            axes_to_spec=["Frequency", "Bias"],
+        )
 
     def test_compound(self):
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
         slow_to_fast = True
-        ret_vals = gen_2pos_2spec(s2f_aux=slow_to_fast, mode='compound')
+        ret_vals = gen_2pos_2spec(s2f_aux=slow_to_fast, mode="compound")
         pos_dims, spec_dims, ndata, data_2d = ret_vals
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_compound.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims, slow_to_fast=slow_to_fast)
+            file_path = tmp_dir + "usid_n_pos_n_spec_compound.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=slow_to_fast,
+        )
 
         objects = hs.load(file_path)
         assert isinstance(objects, list)
         assert len(objects) == 2
 
         # 1. Validate object type
-        for new_sig, comp_name in zip(objects, ['amp', 'phas']):
-            compare_signal_from_usid(file_path, ndata[comp_name], new_sig,
-                                     sig_type=hs.signals.BaseSignal,
-                                     axes_to_spec=['Frequency', 'Bias'],
-                                     compound_comp_name=comp_name)
+        for new_sig, comp_name in zip(objects, ["amp", "phas"]):
+            compare_signal_from_usid(
+                file_path,
+                ndata[comp_name],
+                new_sig,
+                sig_type=hs.signals.BaseSignal,
+                axes_to_spec=["Frequency", "Bias"],
+                compound_comp_name=comp_name,
+            )
 
     def test_non_uniform_dimension(self):
-        pos_dims = [usid.Dimension('Y', 'um', np.linspace(0, 60, num=5)),
-                    usid.Dimension('X', 'nm', [-250, 750])]
-        spec_dims = [usid.Dimension('Bias', 'V',
-                                    np.sin(np.linspace(0, 2 * np.pi, num=7))),
-                     usid.Dimension('Frequency', 'kHz', [300, 350, 400])]
+        pos_dims = [
+            usid.Dimension("Y", "um", np.linspace(0, 60, num=5)),
+            usid.Dimension("X", "nm", [-250, 750]),
+        ]
+        spec_dims = [
+            usid.Dimension("Bias", "V", np.sin(np.linspace(0, 2 * np.pi, num=7))),
+            usid.Dimension("Frequency", "kHz", [300, 350, 400]),
+        ]
         ndata = np.random.rand(5, 2, 7, 3)
-        phy_quant = 'Current'
-        phy_unit = 'nA'
-        data_2d = ndata.reshape(np.prod(ndata.shape[:2]),
-                                np.prod(ndata.shape[2:]))
+        phy_quant = "Current"
+        phy_unit = "nA"
+        data_2d = ndata.reshape(np.prod(ndata.shape[:2]), np.prod(ndata.shape[2:]))
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec_non_lin_dim.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims,
-                           slow_to_fast=True)
+            file_path = tmp_dir + "usid_n_pos_n_spec_non_lin_dim.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=True,
+        )
 
         with pytest.raises(ValueError):
             _ = hs.load(file_path, ignore_non_uniform_dims=False)
 
         with pytest.warns(UserWarning) as _:
             new_sig = hs.load(file_path)
-        compare_signal_from_usid(file_path, ndata, new_sig,
-                                 axes_to_spec=['Frequency', 'Bias'],
-                                 invalid_axes=True)
+        compare_signal_from_usid(
+            file_path,
+            ndata,
+            new_sig,
+            axes_to_spec=["Frequency", "Bias"],
+            invalid_axes=True,
+        )
 
 
-@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:This dataset does not have an N-dimensional form:UserWarning"
+)
 class TestUSID2HSmultiDsets:
-
     def test_pick_specific(self):
         slow_to_fast = True
         ret_vals = gen_2pos_2spec(s2f_aux=slow_to_fast)
         pos_dims, spec_dims, ndata, data_2d = ret_vals
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_n_pos_n_spec.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims, slow_to_fast=slow_to_fast)
+            file_path = tmp_dir + "usid_n_pos_n_spec.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=slow_to_fast,
+        )
 
         ret_vals = gen_2dim(all_pos=True, s2f_aux=slow_to_fast)
         pos_dims, spec_dims, ndata_2, data_2d_2 = ret_vals
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
 
-        with h5py.File(file_path, mode='r+') as h5_f:
-            h5_meas_grp = h5_f.create_group('Measurement_001')
-            h5_chan_grp = h5_meas_grp.create_group('Channel_000')
-            _ = usid.hdf_utils.write_main_dataset(h5_chan_grp, data_2d_2,
-                                                  'Raw_Data', phy_quant,
-                                                  phy_unit, pos_dims,
-                                                  spec_dims,
-                                                  slow_to_fast=slow_to_fast)
+        with h5py.File(file_path, mode="r+") as h5_f:
+            h5_meas_grp = h5_f.create_group("Measurement_001")
+            h5_chan_grp = h5_meas_grp.create_group("Channel_000")
+            _ = usid.hdf_utils.write_main_dataset(
+                h5_chan_grp,
+                data_2d_2,
+                "Raw_Data",
+                phy_quant,
+                phy_unit,
+                pos_dims,
+                spec_dims,
+                slow_to_fast=slow_to_fast,
+            )
 
-        dataset_path = '/Measurement_001/Channel_000/Raw_Data'
+        dataset_path = "/Measurement_001/Channel_000/Raw_Data"
         new_sig = hs.load(file_path, dataset_path=dataset_path)
-        compare_signal_from_usid(file_path, ndata_2, new_sig,
-                                 dataset_path=dataset_path)
+        compare_signal_from_usid(file_path, ndata_2, new_sig, dataset_path=dataset_path)
 
     def test_read_all_by_default(self):
         slow_to_fast = True
-        pos_dims, spec_dims, ndata, data_2d = gen_2dim(all_pos=False,
-                                                       s2f_aux=slow_to_fast)
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        pos_dims, spec_dims, ndata, data_2d = gen_2dim(
+            all_pos=False, s2f_aux=slow_to_fast
+        )
+        phy_quant = "Current"
+        phy_unit = "nA"
         tran = usid.ArrayTranslator()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            file_path = tmp_dir + 'usid_0_pos_n_spec.h5'
-        _ = tran.translate(file_path, 'Blah', data_2d, phy_quant, phy_unit,
-                           pos_dims, spec_dims, slow_to_fast=slow_to_fast)
+            file_path = tmp_dir + "usid_0_pos_n_spec.h5"
+        _ = tran.translate(
+            file_path,
+            "Blah",
+            data_2d,
+            phy_quant,
+            phy_unit,
+            pos_dims,
+            spec_dims,
+            slow_to_fast=slow_to_fast,
+        )
 
         ret_vals = gen_2dim(all_pos=True, s2f_aux=slow_to_fast)
         pos_dims, spec_dims, ndata_2, data_2d_2 = ret_vals
-        phy_quant = 'Current'
-        phy_unit = 'nA'
+        phy_quant = "Current"
+        phy_unit = "nA"
 
-        with h5py.File(file_path, mode='r+') as h5_f:
-            h5_meas_grp = h5_f.create_group('Measurement_001')
-            _ = usid.hdf_utils.write_main_dataset(h5_meas_grp, data_2d_2,
-                                                  'Spat_Map', phy_quant,
-                                                  phy_unit, pos_dims,
-                                                  spec_dims,
-                                                  slow_to_fast=slow_to_fast)
+        with h5py.File(file_path, mode="r+") as h5_f:
+            h5_meas_grp = h5_f.create_group("Measurement_001")
+            _ = usid.hdf_utils.write_main_dataset(
+                h5_meas_grp,
+                data_2d_2,
+                "Spat_Map",
+                phy_quant,
+                phy_unit,
+                pos_dims,
+                spec_dims,
+                slow_to_fast=slow_to_fast,
+            )
 
         objects = hs.load(file_path)
         assert isinstance(objects, list)
         assert len(objects) == 2
 
-        dset_names = ['/Measurement_000/Channel_000/Raw_Data',
-                      'Measurement_001/Spat_Map']
+        dset_names = [
+            "/Measurement_000/Channel_000/Raw_Data",
+            "Measurement_001/Spat_Map",
+        ]
 
         # 1. Validate object type
-        for new_sig, ndim_data, dataset_path in zip(objects,
-                                                    [ndata, ndata_2],
-                                                    dset_names):
-            compare_signal_from_usid(file_path, ndim_data, new_sig,
-                                     dataset_path=dataset_path)
+        for new_sig, ndim_data, dataset_path in zip(
+            objects, [ndata, ndata_2], dset_names
+        ):
+            compare_signal_from_usid(
+                file_path, ndim_data, new_sig, dataset_path=dataset_path
+            )

--- a/rsciio/tests/test_zspy.py
+++ b/rsciio/tests/test_zspy.py
@@ -30,16 +30,15 @@ zarr = pytest.importorskip("zarr", reason="zarr not installed")
 
 
 class TestZspy:
-
     @pytest.fixture
     def signal(self):
-        data = np.ones((10,10,10,10))
+        data = np.ones((10, 10, 10, 10))
         s = Signal1D(data)
         return s
 
-    @pytest.mark.parametrize('store_class', [zarr.N5Store, zarr.ZipStore])
+    @pytest.mark.parametrize("store_class", [zarr.N5Store, zarr.ZipStore])
     def test_save_store(self, signal, tmp_path, store_class):
-        filename = tmp_path / 'testmodels.zspy'
+        filename = tmp_path / "testmodels.zspy"
         store = store_class(path=filename)
         signal.save(store)
 
@@ -54,7 +53,7 @@ class TestZspy:
         np.testing.assert_array_equal(signal2.data, signal.data)
 
     def test_save_ZipStore_close_file(self, signal, tmp_path):
-        filename = tmp_path / 'testmodels.zspy'
+        filename = tmp_path / "testmodels.zspy"
         store = zarr.ZipStore(path=filename)
         signal.save(store, close_file=False)
 
@@ -66,7 +65,7 @@ class TestZspy:
         np.testing.assert_array_equal(s2.data, signal.data)
 
     def test_save_wrong_store(self, signal, tmp_path, caplog):
-        filename = tmp_path / 'testmodels.zspy'
+        filename = tmp_path / "testmodels.zspy"
         store = zarr.N5Store(path=filename)
         signal.save(store)
 
@@ -79,46 +78,48 @@ class TestZspy:
             with caplog.at_level(logging.ERROR):
                 _ = load(store2)
 
-    @pytest.mark.parametrize("overwrite",[None, True, False])
+    @pytest.mark.parametrize("overwrite", [None, True, False])
     def test_overwrite(self, signal, overwrite, tmp_path):
-        filename = tmp_path / 'testmodels.zspy'
+        filename = tmp_path / "testmodels.zspy"
         signal.save(filename=filename)
-        signal2 = signal*2
+        signal2 = signal * 2
         signal2.save(filename=filename, overwrite=overwrite)
         if overwrite is None:
-            np.testing.assert_array_equal(signal.data,load(filename).data)
+            np.testing.assert_array_equal(signal.data, load(filename).data)
         elif overwrite:
-            np.testing.assert_array_equal(signal2.data,load(filename).data)
+            np.testing.assert_array_equal(signal2.data, load(filename).data)
         else:
-            np.testing.assert_array_equal(signal.data,load(filename).data)
+            np.testing.assert_array_equal(signal.data, load(filename).data)
 
     def test_compression_opts(self, tmp_path):
-        self.filename = tmp_path / 'testfile.zspy'
+        self.filename = tmp_path / "testfile.zspy"
         from numcodecs import Blosc
-        comp = Blosc(cname='zstd', clevel=1, shuffle=Blosc.SHUFFLE)
+
+        comp = Blosc(cname="zstd", clevel=1, shuffle=Blosc.SHUFFLE)
         BaseSignal([1, 2, 3]).save(self.filename, compressor=comp)
-        f = zarr.open(self.filename.__str__(), mode='r+')
-        d = f['Experiments/__unnamed__/data']
-        assert (d.compressor == comp)\
+        f = zarr.open(self.filename.__str__(), mode="r+")
+        d = f["Experiments/__unnamed__/data"]
+        assert d.compressor == comp
 
     @pytest.mark.parametrize("compressor", (None, "default", "blosc"))
     def test_compression(self, compressor, tmp_path):
         if compressor == "blosc":
             from numcodecs import Blosc
-            compressor = Blosc(cname='zstd', clevel=3, shuffle=Blosc.BITSHUFFLE)
+
+            compressor = Blosc(cname="zstd", clevel=3, shuffle=Blosc.BITSHUFFLE)
         s = Signal1D(np.ones((3, 3)))
-        s.save(tmp_path / 'test_compression.zspy',
-               overwrite=True,
-               compressor=compressor)
-        load(tmp_path / 'test_compression.zspy')
+        s.save(
+            tmp_path / "test_compression.zspy", overwrite=True, compressor=compressor
+        )
+        load(tmp_path / "test_compression.zspy")
 
 
 def test_non_valid_zspy(tmp_path, caplog):
-    filename = tmp_path / 'testfile.zspy'
+    filename = tmp_path / "testfile.zspy"
     data = np.arange(10)
 
     f = zarr.group(filename)
-    f.create_dataset('dataset', data=data)
+    f.create_dataset("dataset", data=data)
 
     with pytest.raises(IOError):
         with caplog.at_level(logging.ERROR):

--- a/rsciio/tests/utils/test_rgbtools.py
+++ b/rsciio/tests/utils/test_rgbtools.py
@@ -23,64 +23,62 @@ import rsciio.utils.rgb_tools as rt
 
 
 class TestRGBTools:
-
     def setup_method(self, method):
-        self.data_c = np.ones((2, 2, 3), dtype=np.uint8, order='C')
-        self.data_f = np.ones((2, 2, 3), dtype=np.uint8, order='F')
+        self.data_c = np.ones((2, 2, 3), dtype=np.uint8, order="C")
+        self.data_f = np.ones((2, 2, 3), dtype=np.uint8, order="F")
         mask = [[[0, 1, 1], [1, 0, 1]], [[1, 1, 0], [0, 0, 1]]]
-        self.data_masked = np.ma.masked_array(self.data_c, mask,
-                                              hard_mask=True)
+        self.data_masked = np.ma.masked_array(self.data_c, mask, hard_mask=True)
 
     def test_rgbx2regular_array_corder_from_c(self):
         d = rt.rgbx2regular_array(self.data_c)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_rgbx2regular_array_corder_from_f(self):
         d = rt.rgbx2regular_array(self.data_f)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_rgbx2regular_array_corder_from_c_slices(self):
         d = rt.rgbx2regular_array(self.data_c[0:1, ...])
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
         d = rt.rgbx2regular_array(self.data_c[:, 0:1, :])
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_rgbx2regular_array_cordermask_from_cmasked(self):
         d = rt.rgbx2regular_array(self.data_masked)
         assert isinstance(d, np.ma.MaskedArray)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_rgbx2regular_array_cordermask_from_cmasked_slices(self):
         d = rt.rgbx2regular_array(self.data_masked[0:1, ...])
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
         assert isinstance(d, np.ma.MaskedArray)
         d = rt.rgbx2regular_array(self.data_masked[:, 0:1, :])
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
         assert isinstance(d, np.ma.MaskedArray)
 
     def test_regular_array2rgbx_corder_from_c(self):
         d = rt.regular_array2rgbx(self.data_c)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_regular_array2rgbx_corder_from_f(self):
         d = rt.regular_array2rgbx(self.data_f)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_regular_array2rgbx_corder_from_c_slices(self):
         d = rt.regular_array2rgbx(self.data_c[0:1, ...])
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
         d = rt.regular_array2rgbx(self.data_c[:, 0:1, :])
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_regular_array2rgbx_cordermask_from_cmasked(self):
         d = rt.regular_array2rgbx(self.data_masked)
         assert isinstance(d, np.ma.MaskedArray)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
 
     def test_regular_array2rgbx_cordermask_from_cmasked_slices(self):
         d = rt.regular_array2rgbx(self.data_masked[0:1, ...])
         assert isinstance(d, np.ma.MaskedArray)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]
         d = rt.regular_array2rgbx(self.data_masked[:, 0:1, :])
         assert isinstance(d, np.ma.MaskedArray)
-        assert d.flags['C_CONTIGUOUS']
+        assert d.flags["C_CONTIGUOUS"]

--- a/rsciio/tests/utils/test_utils.py
+++ b/rsciio/tests/utils/test_utils.py
@@ -194,53 +194,60 @@ def test_datetime_to_serial_date():
 
 
 def _get_example(date, time, time_zone=None):
-    md = {'General': {'date': date, 'time': time}}
+    md = {"General": {"date": date, "time": time}}
     if time_zone:
-        md['General']['time_zone'] = time_zone
-        dt = parser.parse(f'{date}T{time}')
+        md["General"]["time_zone"] = time_zone
+        dt = parser.parse(f"{date}T{time}")
         dt = dt.replace(tzinfo=tz.gettz(time_zone))
         iso = dt.isoformat()
     else:
-        iso = f'{date}T{time}'
+        iso = f"{date}T{time}"
         dt = parser.parse(iso)
     return md, dt, iso
 
 
-md1, dt1, iso1 = _get_example('2014-12-27', '00:00:00', 'UTC')
+md1, dt1, iso1 = _get_example("2014-12-27", "00:00:00", "UTC")
 serial1 = 42000.00
 
-md2, dt2, iso2 = _get_example('2124-03-25', '10:04:48', 'EST')
+md2, dt2, iso2 = _get_example("2124-03-25", "10:04:48", "EST")
 serial2 = 81900.62833333334
 
-md3, dt3, iso3 = _get_example('2016-07-12', '22:57:32')
+md3, dt3, iso3 = _get_example("2016-07-12", "22:57:32")
 serial3 = 42563.95662037037
 
 
 def test_get_date_time_from_metadata():
-    assert (dtt.get_date_time_from_metadata(md1) ==
-            '2014-12-27T00:00:00+00:00')
-    assert (dtt.get_date_time_from_metadata(md1, formatting='ISO') ==
-            '2014-12-27T00:00:00+00:00')
-    assert (dtt.get_date_time_from_metadata(md1, formatting='datetime64') ==
-            np.datetime64('2014-12-27T00:00:00.000000'))
-    assert (dtt.get_date_time_from_metadata(md1, formatting='datetime') ==
-            dt1)
+    assert dtt.get_date_time_from_metadata(md1) == "2014-12-27T00:00:00+00:00"
+    assert (
+        dtt.get_date_time_from_metadata(md1, formatting="ISO")
+        == "2014-12-27T00:00:00+00:00"
+    )
+    assert dtt.get_date_time_from_metadata(
+        md1, formatting="datetime64"
+    ) == np.datetime64("2014-12-27T00:00:00.000000")
+    assert dtt.get_date_time_from_metadata(md1, formatting="datetime") == dt1
 
-    assert (dtt.get_date_time_from_metadata(md2) ==
-            '2124-03-25T10:04:48-05:00')
-    assert (dtt.get_date_time_from_metadata(md2, formatting='datetime') ==
-            dt2)
-    assert (dtt.get_date_time_from_metadata(md2, formatting='datetime64') ==
-            np.datetime64('2124-03-25T10:04:48'))
+    assert dtt.get_date_time_from_metadata(md2) == "2124-03-25T10:04:48-05:00"
+    assert dtt.get_date_time_from_metadata(md2, formatting="datetime") == dt2
+    assert dtt.get_date_time_from_metadata(
+        md2, formatting="datetime64"
+    ) == np.datetime64("2124-03-25T10:04:48")
 
-    assert (dtt.get_date_time_from_metadata(md3) ==
-            '2016-07-12T22:57:32')
-    assert (dtt.get_date_time_from_metadata(md3, formatting='datetime') ==
-            dt3)
-    assert (dtt.get_date_time_from_metadata(md3, formatting='datetime64') ==
-            np.datetime64('2016-07-12T22:57:32.000000'))
+    assert dtt.get_date_time_from_metadata(md3) == "2016-07-12T22:57:32"
+    assert dtt.get_date_time_from_metadata(md3, formatting="datetime") == dt3
+    assert dtt.get_date_time_from_metadata(
+        md3, formatting="datetime64"
+    ) == np.datetime64("2016-07-12T22:57:32.000000")
 
-    assert dtt.get_date_time_from_metadata({'General': {}}) is None
-    assert dtt.get_date_time_from_metadata({'General': {'date': '2016-07-12'}}) == '2016-07-12'
-    assert dtt.get_date_time_from_metadata({'General': {'time': '12:00'}}) == '12:00:00'
-    assert dtt.get_date_time_from_metadata({'General': {'time': '12:00', 'time_zone': 'CET'}}) == '12:00:00'
+    assert dtt.get_date_time_from_metadata({"General": {}}) is None
+    assert (
+        dtt.get_date_time_from_metadata({"General": {"date": "2016-07-12"}})
+        == "2016-07-12"
+    )
+    assert dtt.get_date_time_from_metadata({"General": {"time": "12:00"}}) == "12:00:00"
+    assert (
+        dtt.get_date_time_from_metadata(
+            {"General": {"time": "12:00", "time_zone": "CET"}}
+        )
+        == "12:00:00"
+    )

--- a/rsciio/tiff/api.py
+++ b/rsciio/tiff/api.py
@@ -37,23 +37,24 @@ _logger = logging.getLogger(__name__)
 
 
 axes_label_codes = {
-    'X': "width",
-    'Y': "height",
-    'S': "sample",
-    'P': "plane",
-    'I': "image series",
-    'Z': "depth",
-    'C': "color|em-wavelength|channel",
-    'E': "ex-wavelength|lambda",
-    'T': "time",
-    'R': "region|tile",
-    'A': "angle",
-    'F': "phase",
-    'H': "lifetime",
-    'L': "exposure",
-    'V': "event",
-    'Q': None,
-    '_': None}
+    "X": "width",
+    "Y": "height",
+    "S": "sample",
+    "P": "plane",
+    "I": "image series",
+    "Z": "depth",
+    "C": "color|em-wavelength|channel",
+    "E": "ex-wavelength|lambda",
+    "T": "time",
+    "R": "region|tile",
+    "A": "angle",
+    "F": "phase",
+    "H": "lifetime",
+    "L": "exposure",
+    "V": "event",
+    "Q": None,
+    "_": None,
+}
 
 
 def file_writer(filename, signal, export_scale=True, extratags=[], **kwds):
@@ -69,41 +70,37 @@ def file_writer(filename, signal, export_scale=True, extratags=[], **kwds):
         appropriate tags.
     """
 
-    data = signal['data']
+    data = signal["data"]
     photometric = "MINISBLACK"
     # HyperSpy uses struct arrays to store RGBA data
     from rsciio.utils import rgb_tools
+
     if rgb_tools.is_rgbx(data):
         data = rgb_tools.rgbx2regular_array(data)
         photometric = "RGB"
 
-    if 'description' in kwds.keys() and export_scale:
-        kwds.pop('description')
+    if "description" in kwds.keys() and export_scale:
+        kwds.pop("description")
         _logger.warning(
             "Description and export scale cannot be used at the same time, "
-            "because it is incompability with the 'ImageJ' tiff format")
+            "because it is incompability with the 'ImageJ' tiff format"
+        )
     if export_scale:
         kwds.update(_get_tags_dict(signal, extratags=extratags))
         _logger.debug(f"kwargs passed to tifffile.py imsave: {kwds}")
 
-        if 'metadata' not in kwds.keys():
+        if "metadata" not in kwds.keys():
             # Because we write the calibration to the ImageDescription tag
             # for imageJ, we need to disable tiffile from also writing JSON
             # metadata if not explicitely requested
             # (https://github.com/cgohlke/tifffile/issues/21)
-            kwds['metadata'] = None
+            kwds["metadata"] = None
 
-    if signal['metadata']['General'].get('date'):
-        dt = get_date_time_from_metadata(
-            signal['metadata'], formatting='datetime'
-            )
-        kwds['datetime'] = dt
+    if signal["metadata"]["General"].get("date"):
+        dt = get_date_time_from_metadata(signal["metadata"], formatting="datetime")
+        kwds["datetime"] = dt
 
-    imwrite(filename,
-            data,
-            software="hyperspy",
-            photometric=photometric,
-            **kwds)
+    imwrite(filename, data, software="hyperspy", photometric=photometric, **kwds)
 
 
 def file_reader(filename, force_read_resolution=False, lazy=False, **kwds):
@@ -126,14 +123,15 @@ def file_reader(filename, force_read_resolution=False, lazy=False, **kwds):
         Load the data lazily. Default is False
     **kwds, optional
     """
-    tmp = kwds.pop('hamamatsu_streak_axis_type', None)
-
+    tmp = kwds.pop("hamamatsu_streak_axis_type", None)
 
     with TiffFile(filename, **kwds) as tiff:
         if tmp is not None:
-            kwds.update({'hamamatsu_streak_axis_type': tmp})
-        dict_list = [_read_serie(tiff, serie, filename, force_read_resolution,
-                                 lazy=lazy, **kwds) for serie in tiff.series]
+            kwds.update({"hamamatsu_streak_axis_type": tmp})
+        dict_list = [
+            _read_serie(tiff, serie, filename, force_read_resolution, lazy=lazy, **kwds)
+            for serie in tiff.series
+        ]
 
     return dict_list
 
@@ -144,23 +142,22 @@ def _order_axes_by_name(names: list, scales: dict, offsets: dict, units: dict):
     offsets_new = [0.0] * len(names)
     units_new = [None] * len(names)
     for i, name in enumerate(names):
-        if name == 'height':
-            scales_new[i] = scales['x']
-            offsets_new[i] = offsets['x']
-            units_new[i] = units['x']
-        elif name == 'width':
-            scales_new[i] = scales['y']
-            offsets_new[i] = offsets['y']
-            units_new[i] = units['y']
-        elif name in ['depth', 'image series', 'time']:
-            scales_new[i] = scales['z']
-            offsets_new[i] = offsets['z']
-            units_new[i] = units['z']
+        if name == "height":
+            scales_new[i] = scales["x"]
+            offsets_new[i] = offsets["x"]
+            units_new[i] = units["x"]
+        elif name == "width":
+            scales_new[i] = scales["y"]
+            offsets_new[i] = offsets["y"]
+            units_new[i] = units["y"]
+        elif name in ["depth", "image series", "time"]:
+            scales_new[i] = scales["z"]
+            offsets_new[i] = offsets["z"]
+            units_new[i] = units["z"]
     return scales_new, offsets_new, units_new
 
 
-def _build_axes_dictionaries(shape, names=None, scales=None, offsets=None,
-                             units=None):
+def _build_axes_dictionaries(shape, names=None, scales=None, offsets=None, units=None):
     """Build axes dictionaries from a set of lists"""
     if names is None:
         names = [""] * len(shape)
@@ -171,31 +168,45 @@ def _build_axes_dictionaries(shape, names=None, scales=None, offsets=None,
     if units is None:
         scales = [None] * len(shape)
 
-    axes = [{'size': size, 'name': str(name), 'scale': scale, 'offset': offset, 'units': unit}
-            for size, name, scale, offset, unit in zip(shape, names, scales, offsets, units)]
+    axes = [
+        {
+            "size": size,
+            "name": str(name),
+            "scale": scale,
+            "offset": offset,
+            "units": unit,
+        }
+        for size, name, scale, offset, unit in zip(shape, names, scales, offsets, units)
+    ]
     return axes
 
 
-def _read_serie(tiff, serie, filename, force_read_resolution=False,
-                lazy=False, memmap=None, RGB_as_structured_array=True,
-                **kwds):
+def _read_serie(
+    tiff,
+    serie,
+    filename,
+    force_read_resolution=False,
+    lazy=False,
+    memmap=None,
+    RGB_as_structured_array=True,
+    **kwds,
+):
     axes = serie.axes
     page = serie.pages[0]
-    if hasattr(serie, 'shape'):
+    if hasattr(serie, "shape"):
         shape = serie.shape
         dtype = serie.dtype
     else:
-        shape = serie['shape']
-        dtype = serie['dtype']
+        shape = serie["shape"]
+        dtype = serie["dtype"]
 
     is_rgb = page.photometric == TIFF.PHOTOMETRIC.RGB and RGB_as_structured_array
     _logger.debug("Is RGB: %s" % is_rgb)
     if is_rgb:
         axes = axes[:-1]
-        names = ['R', 'G', 'B', 'A']
+        names = ["R", "G", "B", "A"]
         lastshape = shape[-1]
-        dtype = np.dtype({'names': names[:lastshape],
-                          'formats': [dtype] * lastshape})
+        dtype = np.dtype({"names": names[:lastshape], "formats": [dtype] * lastshape})
         shape = shape[:-1]
 
     if Version(tiffversion) >= Version("2020.2.16"):
@@ -205,59 +216,66 @@ def _read_serie(tiff, serie, filename, force_read_resolution=False,
 
     names = [axes_label_codes[axis] for axis in axes]
 
-    _logger.debug('Tiff tags list: %s' % op)
-    _logger.debug("Photometric: %s" % op['PhotometricInterpretation'])
-    _logger.debug('is_imagej: {}'.format(page.is_imagej))
+    _logger.debug("Tiff tags list: %s" % op)
+    _logger.debug("Photometric: %s" % op["PhotometricInterpretation"])
+    _logger.debug("is_imagej: {}".format(page.is_imagej))
 
     try:
-        axes = _parse_scale_unit(tiff, page, op, shape, force_read_resolution, names, **kwds)
+        axes = _parse_scale_unit(
+            tiff, page, op, shape, force_read_resolution, names, **kwds
+        )
     except BaseException:
         _logger.info("Scale and units could not be imported")
         axes = _build_axes_dictionaries(shape, names)
 
-    md = {'General': {'original_filename': os.path.split(filename)[1]},
-           'Signal': {'signal_type': "", 'record_by': "image" }}
+    md = {
+        "General": {"original_filename": os.path.split(filename)[1]},
+        "Signal": {"signal_type": "", "record_by": "image"},
+    }
 
-    if 'DateTime' in op:
+    if "DateTime" in op:
         dt = None
         try:
-            dt = datetime.strptime(op['DateTime'], "%Y:%m:%d %H:%M:%S")
+            dt = datetime.strptime(op["DateTime"], "%Y:%m:%d %H:%M:%S")
         except:
             try:
-                if 'ImageDescription' in op:
+                if "ImageDescription" in op:
                     # JEOL SightX.
-                    _dt = op['ImageDescription']['DateTime']
-                    md['General']['date'] = _dt[0:10]
+                    _dt = op["ImageDescription"]["DateTime"]
+                    md["General"]["date"] = _dt[0:10]
                     # 1 extra digit for millisec should be removed
-                    md['General']['time'] = _dt[11:26]
-                    md['General']['time_zone'] = _dt[-6:]
+                    md["General"]["time"] = _dt[11:26]
+                    md["General"]["time_zone"] = _dt[-6:]
                     dt = None
                 else:
-                    dt = datetime.strptime(op['DateTime'], "%Y/%m/%d %H:%M")
+                    dt = datetime.strptime(op["DateTime"], "%Y/%m/%d %H:%M")
             except:
-                _logger.info("Date/Time is invalid : " + op['DateTime'])
+                _logger.info("Date/Time is invalid : " + op["DateTime"])
         if dt is not None:
-            md['General']['date'] = dt.date().isoformat()
-            md['General']['time'] = dt.time().isoformat()
+            md["General"]["date"] = dt.date().isoformat()
+            md["General"]["time"] = dt.time().isoformat()
 
-    #Get the digital micrograph intensity axis
+    # Get the digital micrograph intensity axis
     if _is_digital_micrograph(op):
         intensity_axis = _intensity_axis_digital_micrograph(op)
     else:
         intensity_axis = {}
 
-    if 'units' in intensity_axis:
-        md['Signal']['quantity'] = intensity_axis['units']
-    if 'scale' in intensity_axis and 'offset' in intensity_axis:
-        dic = {'gain_factor': intensity_axis['scale'],
-               'gain_offset': intensity_axis['offset']}
-        md['Signal']['Noise_properties'] = {'Variance_linear_model': dic}
+    if "units" in intensity_axis:
+        md["Signal"]["quantity"] = intensity_axis["units"]
+    if "scale" in intensity_axis and "offset" in intensity_axis:
+        dic = {
+            "gain_factor": intensity_axis["scale"],
+            "gain_offset": intensity_axis["offset"],
+        }
+        md["Signal"]["Noise_properties"] = {"Variance_linear_model": dic}
 
     data_args = serie, is_rgb
     if lazy:
         from dask import delayed
         from dask.array import from_delayed
-        memmap = 'memmap'
+
+        memmap = "memmap"
         val = delayed(_load_data, pure=True)(*data_args, memmap=memmap, **kwds)
         dc = from_delayed(val, dtype=dtype, shape=shape)
         # TODO: maybe just pass the memmap from tiffile?
@@ -265,17 +283,20 @@ def _read_serie(tiff, serie, filename, force_read_resolution=False,
         dc = _load_data(*data_args, memmap=memmap, **kwds)
 
     if _is_streak_hamamatsu(op):
-        op.update({'ImageDescriptionParsed': _get_hamamatsu_streak_description(tiff, op)})
+        op.update(
+            {"ImageDescriptionParsed": _get_hamamatsu_streak_description(tiff, op)}
+        )
 
     metadata_mapping = get_metadata_mapping(page, op)
-    if 'SightX_Notes' in op:
-        md['General']['title'] = op['SightX_Notes']
-    return {'data': dc,
-            'original_metadata': op,
-            'axes': axes,
-            'metadata': md,
-            'mapping': metadata_mapping,
-            }
+    if "SightX_Notes" in op:
+        md["General"]["title"] = op["SightX_Notes"]
+    return {
+        "data": dc,
+        "original_metadata": op,
+        "axes": axes,
+        "metadata": md,
+        "mapping": metadata_mapping,
+    }
 
 
 def _load_data(serie, is_rgb, sl=None, memmap=None, **kwds):
@@ -283,6 +304,7 @@ def _load_data(serie, is_rgb, sl=None, memmap=None, **kwds):
     _logger.debug("data shape: {0}".format(dc.shape))
     if is_rgb:
         from rsciio.utils import rgb_tools
+
         dc = rgb_tools.regular_array2rgbx(dc)
 
     if sl is not None:
@@ -292,7 +314,7 @@ def _load_data(serie, is_rgb, sl=None, memmap=None, **kwds):
 
 def _axes_defaults():
     """Get default axes dictionaries, with offsets and scales"""
-    axes_labels = ['x', 'y', 'z']
+    axes_labels = ["x", "y", "z"]
     scales = {axis: 1.0 for axis in axes_labels}
     offsets = {axis: 0.0 for axis in axes_labels}
     units = {axis: None for axis in axes_labels}
@@ -301,23 +323,23 @@ def _axes_defaults():
 
 
 def _is_force_readable(op, force_read_resolution) -> bool:
-    return force_read_resolution and 'ResolutionUnit' in op and 'XResolution' in op
+    return force_read_resolution and "ResolutionUnit" in op and "XResolution" in op
 
 
 def _axes_force_read(op, shape, names):
     scales, offsets, units = _axes_defaults()
-    res_unit_tag = op['ResolutionUnit']
+    res_unit_tag = op["ResolutionUnit"]
     if res_unit_tag != TIFF.RESUNIT.NONE:
         _logger.debug("Resolution unit: %s" % res_unit_tag)
-        scales['x'], scales['y'] = _get_scales_from_x_y_resolution(op)
+        scales["x"], scales["y"] = _get_scales_from_x_y_resolution(op)
         # conversion to µm:
         if res_unit_tag == TIFF.RESUNIT.INCH:
-            for key in ['x', 'y']:
-                units[key] = 'µm'
+            for key in ["x", "y"]:
+                units[key] = "µm"
                 scales[key] = scales[key] * 25400
         elif res_unit_tag == TIFF.RESUNIT.CENTIMETER:
-            for key in ['x', 'y']:
-                units[key] = 'µm'
+            for key in ["x", "y"]:
+                units[key] = "µm"
                 scales[key] = scales[key] * 10000
 
     scales, offsets, units = _order_axes_by_name(names, scales, offsets, units)
@@ -328,7 +350,7 @@ def _axes_force_read(op, shape, names):
 
 
 def _is_fei(tiff) -> bool:
-    return 'fei' in tiff.flags
+    return "fei" in tiff.flags
 
 
 def _axes_fei(tiff, op, shape, names):
@@ -336,24 +358,32 @@ def _axes_fei(tiff, op, shape, names):
 
     scales, offsets, units = _axes_defaults()
 
-    op['fei_metadata'] = tiff.fei_metadata
+    op["fei_metadata"] = tiff.fei_metadata
     try:
-        del op['FEI_HELIOS']
+        del op["FEI_HELIOS"]
     except KeyError:
-        del op['FEI_SFEG']
+        del op["FEI_SFEG"]
     try:
-        scales['x'] = float(op['fei_metadata']['Scan']['PixelWidth'])
-        scales['y'] = float(op['fei_metadata']['Scan']['PixelHeight'])
-        units.update({'x': 'm', 'y': 'm'})
+        scales["x"] = float(op["fei_metadata"]["Scan"]["PixelWidth"])
+        scales["y"] = float(op["fei_metadata"]["Scan"]["PixelHeight"])
+        units.update({"x": "m", "y": "m"})
     except KeyError:
-        _logger.debug("No 'Scan' information found in FEI metadata; attempting to get pixel size "
-                        "from 'IRBeam' metadata")
+        _logger.debug(
+            "No 'Scan' information found in FEI metadata; attempting to get pixel size "
+            "from 'IRBeam' metadata"
+        )
         try:
-            scales['x'] = float(op['fei_metadata']['IRBeam']['HFW']) / float(op['fei_metadata']['Image']['ResolutionX'])
-            scales['y'] = float(op['fei_metadata']['IRBeam']['VFW']) / float(op['fei_metadata']['Image']['ResolutionY'])
-            units.update({'x': 'm', 'y': 'm'})
+            scales["x"] = float(op["fei_metadata"]["IRBeam"]["HFW"]) / float(
+                op["fei_metadata"]["Image"]["ResolutionX"]
+            )
+            scales["y"] = float(op["fei_metadata"]["IRBeam"]["VFW"]) / float(
+                op["fei_metadata"]["Image"]["ResolutionY"]
+            )
+            units.update({"x": "m", "y": "m"})
         except KeyError:
-            _logger.warning("Could not determine pixel size; resulting Signal will not be calibrated")
+            _logger.warning(
+                "Could not determine pixel size; resulting Signal will not be calibrated"
+            )
 
     scales, offsets, units = _order_axes_by_name(names, scales, offsets, units)
 
@@ -363,7 +393,7 @@ def _axes_fei(tiff, op, shape, names):
 
 
 def _is_zeiss(tiff) -> bool:
-    return 'sem' in tiff.flags
+    return "sem" in tiff.flags
 
 
 def _axes_zeiss(tiff, op, shape, names):
@@ -379,9 +409,9 @@ def _axes_zeiss(tiff, op, shape, names):
     # in the described tags as 'ap_image_pixel_size' and/or
     # 'ap_pixel_size', which depending from ZEISS software version
     # can be absent and thus is not used here.
-    scale_in_m = op['CZ_SEM'][''][3] * 1024 / tiff.pages[0].shape[1]
-    scales.update({'x': scale_in_m, 'y': scale_in_m})
-    units.update({'x': 'm', 'y': 'm'})
+    scale_in_m = op["CZ_SEM"][""][3] * 1024 / tiff.pages[0].shape[1]
+    scales.update({"x": scale_in_m, "y": scale_in_m})
+    units.update({"x": "m", "y": "m"})
 
     scales, offsets, units = _order_axes_by_name(names, scales, offsets, units)
 
@@ -392,7 +422,7 @@ def _axes_zeiss(tiff, op, shape, names):
 
 
 def _is_tvips(tiff) -> bool:
-    return 'tvips' in tiff.flags
+    return "tvips" in tiff.flags
 
 
 def _axes_tvips(tiff, op, shape, names):
@@ -400,16 +430,15 @@ def _axes_tvips(tiff, op, shape, names):
 
     scales, offsets, units = _axes_defaults()
 
-    if 'PixelSizeX' in op['TVIPS'] and 'PixelSizeY' in op['TVIPS']:
+    if "PixelSizeX" in op["TVIPS"] and "PixelSizeY" in op["TVIPS"]:
         _logger.debug("getting TVIPS scale from PixelSizeX")
-        scales['x'] = op['TVIPS']['PixelSizeX']
-        scales['y'] = op['TVIPS']['PixelSizeY']
-        units.update({'x': 'nm', 'y': 'nm'})
+        scales["x"] = op["TVIPS"]["PixelSizeX"]
+        scales["y"] = op["TVIPS"]["PixelSizeY"]
+        units.update({"x": "nm", "y": "nm"})
     else:
         _logger.debug("getting TVIPS scale from XYResolution")
-        scales['x'], scales['y'] = _get_scales_from_x_y_resolution(
-            op, factor=1e-2)
-        units.update({'x': 'm', 'y': 'm'})
+        scales["x"], scales["y"] = _get_scales_from_x_y_resolution(op, factor=1e-2)
+        units.update({"x": "m", "y": "m"})
 
     scales, offsets, units = _order_axes_by_name(names, scales, offsets, units)
 
@@ -432,10 +461,10 @@ def _axes_olympus_sis(page, tiff, op, shape, names):
             sis_metadata = page.tags[tag_number].value
         except Exception:
             pass
-    op['Olympus_SIS_metadata'] = sis_metadata
-    scales['x'] = round(float(sis_metadata['pixelsizex']), 15)
-    scales['y'] = round(float(sis_metadata['pixelsizey']), 15)
-    units.update({'x': 'm', 'y': 'm'})
+    op["Olympus_SIS_metadata"] = sis_metadata
+    scales["x"] = round(float(sis_metadata["pixelsizex"]), 15)
+    scales["y"] = round(float(sis_metadata["pixelsizey"]), 15)
+    units.update({"x": "m", "y": "m"})
 
     scales, offsets, units = _order_axes_by_name(names, scales, offsets, units)
 
@@ -445,7 +474,7 @@ def _axes_olympus_sis(page, tiff, op, shape, names):
 
 
 def _is_jeol_sightx(op) -> bool:
-    return op.get('Make', None) == "JEOL Ltd."
+    return op.get("Make", None) == "JEOL Ltd."
 
 
 def _axes_jeol_sightx(tiff, op, shape, names):
@@ -453,10 +482,13 @@ def _axes_jeol_sightx(tiff, op, shape, names):
     # convert_xml_to_dict need to remove white spaces before decoding XML
     scales, offsets, units = _axes_defaults()
 
-    jeol_xml = ''.join([line.strip(" \r\n\t\x01\x00") for line in op['ImageDescription'].split('\n')])
+    jeol_xml = "".join(
+        [line.strip(" \r\n\t\x01\x00") for line in op["ImageDescription"].split("\n")]
+    )
     from rsciio.utils.tools import convert_xml_to_dict
+
     jeol_dict = convert_xml_to_dict(jeol_xml)
-    op['ImageDescription'] = jeol_dict['TemReporter']
+    op["ImageDescription"] = jeol_dict["TemReporter"]
     eos = op["ImageDescription"]["Eos"]["EosMode"]
     illumi = op["ImageDescription"]["IlluminationSystem"]
     imaging = op["ImageDescription"]["ImageFormingSystem"]
@@ -473,7 +505,7 @@ def _axes_jeol_sightx(tiff, op, shape, names):
     mode_strs.append(imaging["SelectorString"])  # Mag / Camera Length
     op["SightX_Notes"] = ", ".join(mode_strs)
 
-    res_unit_tag = op['ResolutionUnit']
+    res_unit_tag = op["ResolutionUnit"]
     if res_unit_tag == TIFF.RESUNIT.INCH:
         scale = 0.0254  # inch/m
     else:
@@ -481,14 +513,28 @@ def _axes_jeol_sightx(tiff, op, shape, names):
     # TEM - MAG
     if (eos == "eosTEM") and (imaging["ModeString"] == "MAG"):
         mag = float(imaging["SelectorValue"])
-        scales['x'], scales['y'] = _get_scales_from_x_y_resolution(op, factor=scale / mag * 1e9)
+        scales["x"], scales["y"] = _get_scales_from_x_y_resolution(
+            op, factor=scale / mag * 1e9
+        )
         units = {"x": "nm", "y": "nm", "z": "nm"}
     # TEM - DIFF
     elif (eos == "eosTEM") and (imaging["ModeString"] == "DIFF"):
+
         def wave_len(ht):
             import scipy.constants as constants
-            momentum = 2 * constants.m_e * constants.elementary_charge * ht * \
-                (1 + constants.elementary_charge * ht / (2 * constants.m_e * constants.c ** 2))
+
+            momentum = (
+                2
+                * constants.m_e
+                * constants.elementary_charge
+                * ht
+                * (
+                    1
+                    + constants.elementary_charge
+                    * ht
+                    / (2 * constants.m_e * constants.c**2)
+                )
+            )
             return constants.h / np.sqrt(momentum)
 
         camera_len = float(imaging["SelectorValue"])
@@ -498,7 +544,7 @@ def _axes_jeol_sightx(tiff, op, shape, names):
         elif imaging["SelectorUnitString"] == "cm":  # convert to "m"
             camera_len /= 100
         scale /= camera_len * wave_len(ht) * 1e9  # in nm
-        scales['x'], scales['y'] = _get_scales_from_x_y_resolution(op, factor=scale)
+        scales["x"], scales["y"] = _get_scales_from_x_y_resolution(op, factor=scale)
         units = {"x": "1 / nm", "y": "1 / nm", "z": None}
 
     scales, offsets, units = _order_axes_by_name(names, scales, offsets, units)
@@ -515,22 +561,22 @@ def _is_streak_hamamatsu(op) -> bool:
     is_hamatif = True
 
     # Check that the original op has an "Artist" field with "Copyright Hamamatsu"
-    if 'Artist' not in op:
+    if "Artist" not in op:
         is_hamatif = False
         return is_hamatif
     else:
-        artist = op['Artist']
+        artist = op["Artist"]
         if not artist.startswith("Copyright Hamamatsu"):
             is_hamatif = False
             return is_hamatif
 
     # Check that the original op has a "Software" corresponding to "HPD-TA"
-    if 'Software' not in op:
+    if "Software" not in op:
         is_hamatif = False
         return is_hamatif
     else:
-        software = op['Software']
-        if not software.startswith('HPD-TA'):
+        software = op["Software"]
+        if not software.startswith("HPD-TA"):
             is_hamatif = False
 
     return is_hamatif
@@ -540,45 +586,45 @@ def _get_hamamatsu_streak_description(tiff, op):
     """Extract a dictionary recursively from the ImageDescription
     Metadata field in a Hamamatsu Streak .tiff file"""
 
-    desc = op['ImageDescription']
+    desc = op["ImageDescription"]
     dict_meta = {}
-    reader = csv.reader(desc.splitlines(), delimiter=',', quotechar='"')
+    reader = csv.reader(desc.splitlines(), delimiter=",", quotechar='"')
     for row in reader:
         key = row[0].strip(" []")
         key_dict = {}
         for element in row[1:]:
-            spl = element.split('=')
+            spl = element.split("=")
             if len(spl) == 2:
                 key_dict[spl[0]] = spl[1].strip('"')
         dict_meta[key] = key_dict
 
     # Scaling entry
-    scaling = dict_meta['Scaling']
+    scaling = dict_meta["Scaling"]
 
     # Address in file where the X axis is saved
-    x_scale_address = int(re.findall(r'\d+', scaling['ScalingXScalingFile'])[0])
-    xlen = op['ImageWidth']
+    x_scale_address = int(re.findall(r"\d+", scaling["ScalingXScalingFile"])[0])
+    xlen = op["ImageWidth"]
 
     # If focus mode is used there is no Y axis
-    if scaling['ScalingYScalingFile'].startswith('Focus mode'):
+    if scaling["ScalingYScalingFile"].startswith("Focus mode"):
         y_scale_address = None
     else:
-        y_scale_address = int(re.findall(r'\d+', scaling['ScalingYScalingFile'])[0])
-    ylen = op['ImageLength']
+        y_scale_address = int(re.findall(r"\d+", scaling["ScalingYScalingFile"])[0])
+    ylen = op["ImageLength"]
 
     # Accessing the file as a binary
     fh = tiff.filehandle
     # Reading the x axis
     fh.seek(x_scale_address, 0)
-    xax = np.fromfile(fh, dtype='f', count=xlen)
+    xax = np.fromfile(fh, dtype="f", count=xlen)
     if y_scale_address is None:
         yax = np.arange(ylen)
     else:
         fh.seek(y_scale_address, 0)
-        yax = np.fromfile(fh, dtype='f', count=ylen)
+        yax = np.fromfile(fh, dtype="f", count=ylen)
 
-    dict_meta['Scaling']['ScalingXaxis'] = xax
-    dict_meta['Scaling']['ScalingYaxis'] = yax
+    dict_meta["Scaling"]["ScalingXaxis"] = xax
+    dict_meta["Scaling"]["ScalingYaxis"] = yax
 
     return dict_meta
 
@@ -586,122 +632,152 @@ def _get_hamamatsu_streak_description(tiff, op):
 def _axes_hamamatsu_streak(tiff, op, shape, names, **kwds):
     _logger.debug("Reading Hamamatsu Streak Map tif metadata")
 
-    if 'hamamatsu_streak_axis_type' in kwds:
-        hamamatsu_streak_axis_type = kwds['hamamatsu_streak_axis_type']
+    if "hamamatsu_streak_axis_type" in kwds:
+        hamamatsu_streak_axis_type = kwds["hamamatsu_streak_axis_type"]
     else:
-        hamamatsu_streak_axis_type = 'uniform'
-        warnings.warn(f"{tiff} contain a non linear axis. By default, "
-                      f"a linearized version is initialised, which can "
-                      f"induce errors. Use the `hamamatsu_streak_axis_type` keyword to load "
-                      f"either a parabolic functional axis using `hamamatsu_streak_axis_type='functional'`, "
-                      f"a data axis using `hamamatsu_streak_axis_type='data'`, or use `hamamatsu_streak_axis_type='uniform'`to "
-                      f"linearize the axis and make this warning disappear", UserWarning)
+        hamamatsu_streak_axis_type = "uniform"
+        warnings.warn(
+            f"{tiff} contain a non linear axis. By default, "
+            f"a linearized version is initialised, which can "
+            f"induce errors. Use the `hamamatsu_streak_axis_type` keyword to load "
+            f"either a parabolic functional axis using `hamamatsu_streak_axis_type='functional'`, "
+            f"a data axis using `hamamatsu_streak_axis_type='data'`, or use `hamamatsu_streak_axis_type='uniform'`to "
+            f"linearize the axis and make this warning disappear",
+            UserWarning,
+        )
 
-    if hamamatsu_streak_axis_type not in ['functional', 'data', 'uniform']:
-        hamamatsu_streak_axis_type = 'uniform'
-        warnings.warn("The `hamamatsu_streak_axis_type`  argument only admits "
-                         "the values `'data'`, `'functional'` and `'uniform'`", UserWarning)
+    if hamamatsu_streak_axis_type not in ["functional", "data", "uniform"]:
+        hamamatsu_streak_axis_type = "uniform"
+        warnings.warn(
+            "The `hamamatsu_streak_axis_type`  argument only admits "
+            "the values `'data'`, `'functional'` and `'uniform'`",
+            UserWarning,
+        )
 
     # Parsing the Metadata
     desc = _get_hamamatsu_streak_description(tiff, op)
-    #Getting the raw axes
-    xax = desc['Scaling']['ScalingXaxis']
-    yax = desc['Scaling']['ScalingYaxis']
+    # Getting the raw axes
+    xax = desc["Scaling"]["ScalingXaxis"]
+    yax = desc["Scaling"]["ScalingYaxis"]
 
-    #Axes are initialised as a list of empty dictionaries
-    axes = [{}]*len(names)
+    # Axes are initialised as a list of empty dictionaries
+    axes = [{}] * len(names)
 
-    #The width axis is always linear
+    # The width axis is always linear
     [xsc, xof] = np.polyfit(np.arange(len(xax)), xax, 1)
 
-    i = names.index('width')
-    axes[i] = {'size': shape[i],
-               'name': 'width',
-               'units': desc['Scaling']['ScalingXUnit'],
-               'scale': xsc,
-               'offset': xof}
+    i = names.index("width")
+    axes[i] = {
+        "size": shape[i],
+        "name": "width",
+        "units": desc["Scaling"]["ScalingXUnit"],
+        "scale": xsc,
+        "offset": xof,
+    }
 
-    #The height axis is changing
-    i = names.index('height')
-    axes[i] = {'name': 'height',
-               'units': desc['Scaling']['ScalingYUnit']}
-    if hamamatsu_streak_axis_type == 'uniform':
-        #Uniform axis initialisation
+    # The height axis is changing
+    i = names.index("height")
+    axes[i] = {"name": "height", "units": desc["Scaling"]["ScalingYUnit"]}
+    if hamamatsu_streak_axis_type == "uniform":
+        # Uniform axis initialisation
         [ysc, yof] = np.polyfit(np.arange(len(yax)), yax, 1)
-        axes[i].update({'scale': ysc,
-                        'offset': yof,
-                        'size': shape[i],
-                        })
-    elif hamamatsu_streak_axis_type == 'data':
-        #Data axis initialisation
-        axes[i].update({'axis': yax})
-    elif hamamatsu_streak_axis_type == 'functional':
-        #Functional axis initialisation
-        xaxis = {'scale': 1, 'offset': 0, 'size': len(yax)}
+        axes[i].update(
+            {
+                "scale": ysc,
+                "offset": yof,
+                "size": shape[i],
+            }
+        )
+    elif hamamatsu_streak_axis_type == "data":
+        # Data axis initialisation
+        axes[i].update({"axis": yax})
+    elif hamamatsu_streak_axis_type == "functional":
+        # Functional axis initialisation
+        xaxis = {"scale": 1, "offset": 0, "size": len(yax)}
         poly = np.polyfit(np.arange(len(yax)), yax, 3)
-        axes[i].update({'size': len(yax), 'x': xaxis,
-                   'expression': "a*x**3+b*x**2+c*x+d",
-                   'a': poly[0], 'b': poly[1], 'c': poly[2], 'd': poly[3]})
+        axes[i].update(
+            {
+                "size": len(yax),
+                "x": xaxis,
+                "expression": "a*x**3+b*x**2+c*x+d",
+                "a": poly[0],
+                "b": poly[1],
+                "c": poly[2],
+                "d": poly[3],
+            }
+        )
 
     return axes
 
 
 def _is_imagej(tiff) -> bool:
-    return 'imagej' in tiff.flags
+    return "imagej" in tiff.flags
 
 
-def _add_axes_imagej(tiff, op, scales, offsets, units ):
+def _add_axes_imagej(tiff, op, scales, offsets, units):
     imagej_metadata = tiff.imagej_metadata
-    if 'ImageJ' in imagej_metadata:
+    if "ImageJ" in imagej_metadata:
         _logger.debug("Reading ImageJ tif metadata")
         # ImageJ write the unit in the image description
-        if 'unit' in imagej_metadata:
-            if imagej_metadata['unit'] == 'micron':
-                units.update({'x': 'µm', 'y': 'µm'})
-            scales['x'], scales['y'] = _get_scales_from_x_y_resolution(op)
-        if 'spacing' in imagej_metadata:
-            scales['z'] = imagej_metadata['spacing']
+        if "unit" in imagej_metadata:
+            if imagej_metadata["unit"] == "micron":
+                units.update({"x": "µm", "y": "µm"})
+            scales["x"], scales["y"] = _get_scales_from_x_y_resolution(op)
+        if "spacing" in imagej_metadata:
+            scales["z"] = imagej_metadata["spacing"]
     return scales, offsets, units
 
 
 def _is_digital_micrograph(op) -> bool:
     # for files containing DM metadata
-    tags = ['65003', '65004', '65005', '65009', '65010', '65011',
-            '65006', '65007', '65008', '65022', '65024', '65025']
+    tags = [
+        "65003",
+        "65004",
+        "65005",
+        "65009",
+        "65010",
+        "65011",
+        "65006",
+        "65007",
+        "65008",
+        "65022",
+        "65024",
+        "65025",
+    ]
     search_result = [tag in op for tag in tags]
     return any(search_result)
 
 
-def _intensity_axis_digital_micrograph(op, intensity_axis = {}):
-    if '65022' in op:
-        intensity_axis['units'] = op['65022']  # intensity units
-    if '65024' in op:
-        intensity_axis['offset'] = op['65024']  # intensity offset
-    if '65025' in op:
-        intensity_axis['scale'] = op['65025']  # intensity scale
+def _intensity_axis_digital_micrograph(op, intensity_axis={}):
+    if "65022" in op:
+        intensity_axis["units"] = op["65022"]  # intensity units
+    if "65024" in op:
+        intensity_axis["offset"] = op["65024"]  # intensity offset
+    if "65025" in op:
+        intensity_axis["scale"] = op["65025"]  # intensity scale
     return intensity_axis
 
 
 def _add_axes_digital_micrograph(op, scales, offsets, units):
-    if '65003' in op:
+    if "65003" in op:
         _logger.debug("Reading Gatan DigitalMicrograph tif metadata")
-        units['y'] = op['65003']  # x units
-    if '65004' in op:
-        units['x'] = op['65004']  # y units
-    if '65005' in op:
-        units['z'] = op['65005']  # z units
-    if '65009' in op:
-        scales['y'] = op['65009']  # x scales
-    if '65010' in op:
-        scales['x'] = op['65010']  # y scales
-    if '65011' in op:
-        scales['z'] = op['65011']  # z scales
-    if '65006' in op:
-        offsets['y'] = op['65006']  # x offset
-    if '65007' in op:
-        offsets['x'] = op['65007']  # y offset
-    if '65008' in op:
-        offsets['z'] = op['65008']  # z offset
+        units["y"] = op["65003"]  # x units
+    if "65004" in op:
+        units["x"] = op["65004"]  # y units
+    if "65005" in op:
+        units["z"] = op["65005"]  # z units
+    if "65009" in op:
+        scales["y"] = op["65009"]  # x scales
+    if "65010" in op:
+        scales["x"] = op["65010"]  # y scales
+    if "65011" in op:
+        scales["z"] = op["65011"]  # z scales
+    if "65006" in op:
+        offsets["y"] = op["65006"]  # x offset
+    if "65007" in op:
+        offsets["x"] = op["65007"]  # y offset
+    if "65008" in op:
+        offsets["z"] = op["65008"]  # z offset
 
     return scales, offsets, units
 
@@ -735,7 +811,9 @@ def _parse_scale_unit(tiff, page, op, shape, force_read_resolution, names, **kwd
         scales, offsets, units = _axes_defaults()
         # Axes descriptors can be additionally parsed from digital micrograph or imagej-style files
         if _is_digital_micrograph(op):
-            scales, offsets, units = _add_axes_digital_micrograph(op, scales, offsets, units)
+            scales, offsets, units = _add_axes_digital_micrograph(
+                op, scales, offsets, units
+            )
         if _is_imagej(tiff):
             scales, offsets, units = _add_axes_imagej(tiff, op, scales, offsets, units)
 
@@ -747,82 +825,98 @@ def _parse_scale_unit(tiff, page, op, shape, force_read_resolution, names, **kwd
 
 
 def _get_scales_from_x_y_resolution(op, factor=1.0):
-    scales = (op["YResolution"][1] / op["YResolution"][0] * factor,
-              op["XResolution"][1] / op["XResolution"][0] * factor)
+    scales = (
+        op["YResolution"][1] / op["YResolution"][0] * factor,
+        op["XResolution"][1] / op["XResolution"][0] * factor,
+    )
     return scales
 
 
-def _get_tags_dict(signal, extratags=[], factor=int(1E8)):
+def _get_tags_dict(signal, extratags=[], factor=int(1e8)):
     """
     Get the tags to export the scale and the unit to be used in Digital
     Micrograph and ImageJ.
     """
-    axes = signal['axes']
-    nav_dim = len([ax for ax in axes if ax['navigate']])
+    axes = signal["axes"]
+    nav_dim = len([ax for ax in axes if ax["navigate"]])
     scales, units, offsets = _get_scale_unit(axes, encoding=None)
     _logger.debug("{0}".format(units))
     tags_dict = _get_imagej_kwargs(scales, units, nav_dim, factor=factor)
-    scales, units, offsets = _get_scale_unit(axes, encoding='latin-1')
+    scales, units, offsets = _get_scale_unit(axes, encoding="latin-1")
 
     tags_dict["extratags"].extend(
-        _get_dm_kwargs_extratag(
-            signal,
-            scales,
-            units,
-            offsets,
-            nav_dim))
+        _get_dm_kwargs_extratag(signal, scales, units, offsets, nav_dim)
+    )
     tags_dict["extratags"].extend(extratags)
     return tags_dict
 
 
-def _get_imagej_kwargs(scales, units, nav_dim, factor=int(1E8)):
-    resolution = ((factor, int(scales[-1] * factor)),
-                  (factor, int(scales[-2] * factor)))
+def _get_imagej_kwargs(scales, units, nav_dim, factor=int(1e8)):
+    resolution = (
+        (factor, int(scales[-1] * factor)),
+        (factor, int(scales[-2] * factor)),
+    )
     if nav_dim == 1:  # For stacks
-        spacing = f'{scales[0]}'
+        spacing = f"{scales[0]}"
     else:
         spacing = None
     description_string = _imagej_description(unit=units[1], spacing=spacing)
     _logger.debug("Description tag: {description_string}")
-    extratag = [(270, 's', 1, description_string, False)]
+    extratag = [(270, "s", 1, description_string, False)]
     return {"resolution": resolution, "extratags": extratag}
 
 
 def _get_dm_kwargs_extratag(signal, scales, units, offsets, nav_dim):
-    extratags = [(65003, 's', 3, units[-1], False),  # x unit
-                 (65004, 's', 3, units[-2], False),  # y unit
-                 (65006, 'd', 1, offsets[-1], False),  # x origin
-                 (65007, 'd', 1, offsets[-2], False),  # y origin
-                 (65009, 'd', 1, float(scales[-1]), False),  # x scale
-                 (65010, 'd', 1, float(scales[-2]), False)]  # y scale
+    extratags = [
+        (65003, "s", 3, units[-1], False),  # x unit
+        (65004, "s", 3, units[-2], False),  # y unit
+        (65006, "d", 1, offsets[-1], False),  # x origin
+        (65007, "d", 1, offsets[-2], False),  # y origin
+        (65009, "d", 1, float(scales[-1]), False),  # x scale
+        (65010, "d", 1, float(scales[-2]), False),
+    ]  # y scale
     #                 (65012, 's', 3, units[-1], False),  # x unit full name
     #                 (65013, 's', 3, units[-2], False)]  # y unit full name
     #                 (65015, 'i', 1, 1, False), # don't know
     #                 (65016, 'i', 1, 1, False), # don't know
     #                 (65026, 'i', 1, 1, False)] # don't know
     md = DTBox(signal["metadata"], box_dots=True)
-    if 'Signal.quantity' in md:
-        intensity_units = md['Signal'].get('quantity', "")
-        extratags.extend([(65022, 's', 3, intensity_units, False),
-                          (65023, 's', 3, intensity_units, False)])
-    dic = md.get('Signal.Noise_properties.Variance_linear_model', None)
+    if "Signal.quantity" in md:
+        intensity_units = md["Signal"].get("quantity", "")
+        extratags.extend(
+            [
+                (65022, "s", 3, intensity_units, False),
+                (65023, "s", 3, intensity_units, False),
+            ]
+        )
+    dic = md.get("Signal.Noise_properties.Variance_linear_model", None)
     if dic:
         try:
             intensity_offset = dic.gain_offset
             intensity_scale = dic.gain_factor
         except BaseException:
-            _logger.info("The scale or the offset of the 'intensity axes'"
-                         "couldn't be retrieved, please report the bug.")
+            _logger.info(
+                "The scale or the offset of the 'intensity axes'"
+                "couldn't be retrieved, please report the bug."
+            )
             intensity_offset = 0.0
             intensity_scale = 1.0
-        extratags.extend([(65024, 'd', 1, intensity_offset, False),
-                          (65025, 'd', 1, intensity_scale, False)])
+        extratags.extend(
+            [
+                (65024, "d", 1, intensity_offset, False),
+                (65025, "d", 1, intensity_scale, False),
+            ]
+        )
     if nav_dim > 0:
-        extratags.extend([(65005, 's', 3, units[0], False),  # z unit
-                          (65008, 'd', 1, offsets[0], False),  # z origin
-                          (65011, 'd', 1, float(scales[0]), False),  # z scale
-                          # (65014, 's', 3, units[0], False), # z unit full name
-                          (65017, 'i', 1, 1, False)])
+        extratags.extend(
+            [
+                (65005, "s", 3, units[0], False),  # z unit
+                (65008, "d", 1, offsets[0], False),  # z origin
+                (65011, "d", 1, float(scales[0]), False),  # z scale
+                # (65014, 's', 3, units[0], False), # z unit full name
+                (65017, "i", 1, 1, False),
+            ]
+        )
     return extratags
 
 
@@ -841,33 +935,33 @@ def _get_scale_unit(axes, encoding=None):
     scales, units, offsets : list
         List of scales, units and offsets
     """
-    scales = [ax['scale'] for ax in axes]
-    units = [ax['units'] for ax in axes]
-    offsets = [ax['offset'] for ax in axes]
+    scales = [ax["scale"] for ax in axes]
+    units = [ax["units"] for ax in axes]
+    offsets = [ax["offset"] for ax in axes]
     for i, unit in enumerate(units):
         if unit == None:
-            units[i] = ''
+            units[i] = ""
         if encoding is not None:
             units[i] = units[i].encode(encoding)
     return scales, units, offsets
 
 
-def _imagej_description(version='1.11a', **kwargs):
-    """ Return a string that will be used by ImageJ to read the unit when
-        appropriate arguments are provided """
-    result = ['ImageJ=%s' % version]
+def _imagej_description(version="1.11a", **kwargs):
+    """Return a string that will be used by ImageJ to read the unit when
+    appropriate arguments are provided"""
+    result = ["ImageJ=%s" % version]
 
     append = []
-    if kwargs['spacing'] is None:
-        kwargs.pop('spacing')
+    if kwargs["spacing"] is None:
+        kwargs.pop("spacing")
     for key, value in list(kwargs.items()):
-        if value == 'µm':
-            value = 'micron'
-        if value == 'Å':
-            value = 'angstrom'
-        append.append(f'{key.lower()}={value}')
+        if value == "µm":
+            value = "micron"
+        if value == "Å":
+            value = "angstrom"
+        append.append(f"{key.lower()}={value}")
 
-    return '\n'.join(result + append + [''])
+    return "\n".join(result + append + [""])
 
 
 def _parse_beam_current_FEI(value):
@@ -919,158 +1013,194 @@ def _parse_tvips_date(value):
 
 
 def _parse_string(value):
-    if value == '':
+    if value == "":
         return None
     return value
 
 
 mapping_fei = {
-    'fei_metadata.Beam.HV':
-        ("Acquisition_instrument.SEM.beam_energy", _parse_beam_energy_FEI),
-    'fei_metadata.Stage.StageX':
-        ("Acquisition_instrument.SEM.Stage.x", None),
-    'fei_metadata.Stage.StageY':
-        ("Acquisition_instrument.SEM.Stage.y", None),
-    'fei_metadata.Stage.StageZ':
-        ("Acquisition_instrument.SEM.Stage.z", None),
-    'fei_metadata.Stage.StageR':
-        ("Acquisition_instrument.SEM.Stage.rotation", None),
-    'fei_metadata.Stage.StageT':
-        ("Acquisition_instrument.SEM.Stage.tilt", None),
-    'fei_metadata.Stage.WorkingDistance':
-        ("Acquisition_instrument.SEM.working_distance", _parse_working_distance_FEI),
-    'fei_metadata.Scan.Dwelltime':
-        ("Acquisition_instrument.SEM.dwell_time", None),
-    'fei_metadata.EBeam.BeamCurrent':
-        ("Acquisition_instrument.SEM.beam_current", _parse_beam_current_FEI),
-    'fei_metadata.System.SystemType':
-        ("Acquisition_instrument.SEM.microscope", None),
-    'fei_metadata.User.Date':
-        ("General.date", lambda x: parser.parse(x).date().isoformat()),
-    'fei_metadata.User.Time':
-        ("General.time", lambda x: parser.parse(x).time().isoformat()),
-    'fei_metadata.User.User':
-        ("General.authors", None)
+    "fei_metadata.Beam.HV": (
+        "Acquisition_instrument.SEM.beam_energy",
+        _parse_beam_energy_FEI,
+    ),
+    "fei_metadata.Stage.StageX": ("Acquisition_instrument.SEM.Stage.x", None),
+    "fei_metadata.Stage.StageY": ("Acquisition_instrument.SEM.Stage.y", None),
+    "fei_metadata.Stage.StageZ": ("Acquisition_instrument.SEM.Stage.z", None),
+    "fei_metadata.Stage.StageR": ("Acquisition_instrument.SEM.Stage.rotation", None),
+    "fei_metadata.Stage.StageT": ("Acquisition_instrument.SEM.Stage.tilt", None),
+    "fei_metadata.Stage.WorkingDistance": (
+        "Acquisition_instrument.SEM.working_distance",
+        _parse_working_distance_FEI,
+    ),
+    "fei_metadata.Scan.Dwelltime": ("Acquisition_instrument.SEM.dwell_time", None),
+    "fei_metadata.EBeam.BeamCurrent": (
+        "Acquisition_instrument.SEM.beam_current",
+        _parse_beam_current_FEI,
+    ),
+    "fei_metadata.System.SystemType": ("Acquisition_instrument.SEM.microscope", None),
+    "fei_metadata.User.Date": (
+        "General.date",
+        lambda x: parser.parse(x).date().isoformat(),
+    ),
+    "fei_metadata.User.Time": (
+        "General.time",
+        lambda x: parser.parse(x).time().isoformat(),
+    ),
+    "fei_metadata.User.User": ("General.authors", None),
 }
 
 
 def get_jeol_sightx_mapping(op):
     mapping = {
-        'ImageDescription.ElectronGun.AccelerationVoltage':
-            ("Acquisition_instrument.TEM.beam_energy", lambda x: float(x) * 0.001),  # keV
-        'ImageDescription.ElectronGun.BeamCurrent':
-            ("Acquisition_instrument.TEM.beam_current", lambda x: float(x) * 0.001),  # nA
-        'ImageDescription.Instruments':
-            ("Acquisition_instrument.TEM.microscope", None),
-
+        "ImageDescription.ElectronGun.AccelerationVoltage": (
+            "Acquisition_instrument.TEM.beam_energy",
+            lambda x: float(x) * 0.001,
+        ),  # keV
+        "ImageDescription.ElectronGun.BeamCurrent": (
+            "Acquisition_instrument.TEM.beam_current",
+            lambda x: float(x) * 0.001,
+        ),  # nA
+        "ImageDescription.Instruments": ("Acquisition_instrument.TEM.microscope", None),
         # Gonio Stage
         # depends on sample holder
         #    ("Acquisition_instrument.TEM.Stage.rotation", None),  #deg
-        'ImageDescription.GonioStage.StagePosition.TX':
-            ("Acquisition_instrument.TEM.Stage.tilt_alpha", None),  # deg
-        'ImageDescription.GonioStage.StagePosition.TY':
-            ("Acquisition_instrument.TEM.Stage.tilt_beta", None),  # deg
+        "ImageDescription.GonioStage.StagePosition.TX": (
+            "Acquisition_instrument.TEM.Stage.tilt_alpha",
+            None,
+        ),  # deg
+        "ImageDescription.GonioStage.StagePosition.TY": (
+            "Acquisition_instrument.TEM.Stage.tilt_beta",
+            None,
+        ),  # deg
         # ToDo: MX(Motor)+PX(Piezo), MY+PY should be used
         #    'ImageDescription.GonioStage.StagePosition.MX':
         #    ("Acquisition_instrument.TEM.Stage.x", lambda x: float(x)*1E-6), # mm
         #    'ImageDescription.GonioStage.StagePosition.MY':
         #    ("Acquisition_instrument.TEM.Stage.y", lambda x: float(x)*1E-6), # mm
-        'ImageDescription.GonioStage.MZ':
-            ("Acquisition_instrument.TEM.Stage.z", lambda x: float(x) * 1E-6),  # mm
-
+        "ImageDescription.GonioStage.MZ": (
+            "Acquisition_instrument.TEM.Stage.z",
+            lambda x: float(x) * 1e-6,
+        ),  # mm
         #    ("General.notes", None),
         #    ("General.title", None),
-        'ImageDescription.Eos.EosMode':
-            ("Acquisition_instrument.TEM.acquisition_mode",
-             lambda x: "STEM" if x == "eosASID" else "TEM"),
-
+        "ImageDescription.Eos.EosMode": (
+            "Acquisition_instrument.TEM.acquisition_mode",
+            lambda x: "STEM" if x == "eosASID" else "TEM",
+        ),
         "ImageDescription.ImageFormingSystem.SelectorValue": None,
     }
     if op["ImageDescription"]["ImageFormingSystem"]["ModeString"] == "DIFF":
         mapping["ImageDescription.ImageFormingSystem.SelectorValue"] = (
-            "Acquisition_instrument.TEM.camera_length", None)
+            "Acquisition_instrument.TEM.camera_length",
+            None,
+        )
     else:  # Mag Mode
-        mapping['ImageDescription.ImageFormingSystem.SelectorValue'] = (
-            "Acquisition_instrument.TEM.magnification", None)
+        mapping["ImageDescription.ImageFormingSystem.SelectorValue"] = (
+            "Acquisition_instrument.TEM.magnification",
+            None,
+        )
     return mapping
 
 
 mapping_cz_sem = {
-    'CZ_SEM.ap_actualkv':
-        ("Acquisition_instrument.SEM.beam_energy", _parse_tuple_Zeiss),
-    'CZ_SEM.ap_mag':
-        ("Acquisition_instrument.SEM.magnification", _parse_tuple_Zeiss),
-    'CZ_SEM.ap_stage_at_x':
-        ("Acquisition_instrument.SEM.Stage.x",
-         lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='mm')),
-    'CZ_SEM.ap_stage_at_y':
-        ("Acquisition_instrument.SEM.Stage.y",
-         lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='mm')),
-    'CZ_SEM.ap_stage_at_z':
-        ("Acquisition_instrument.SEM.Stage.z",
-         lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='mm')),
-    'CZ_SEM.ap_stage_at_r':
-        ("Acquisition_instrument.SEM.Stage.rotation", _parse_tuple_Zeiss),
-    'CZ_SEM.ap_stage_at_t':
-        ("Acquisition_instrument.SEM.Stage.tilt", _parse_tuple_Zeiss),
-    'CZ_SEM.ap_wd':
-        ("Acquisition_instrument.SEM.working_distance",
-         lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='mm')),
-    'CZ_SEM.dp_dwell_time':
-        ("Acquisition_instrument.SEM.dwell_time",
-         lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='s')),
-    'CZ_SEM.ap_iprobe':
-        ("Acquisition_instrument.SEM.beam_current",
-         lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='nA')),
-    'CZ_SEM.dp_detector_type':
-        ("Acquisition_instrument.SEM.Detector.detector_type",
-         lambda tup: _parse_tuple_Zeiss(tup)),
-    'CZ_SEM.sv_serial_number':
-        ("Acquisition_instrument.SEM.microscope", _parse_tuple_Zeiss),
-    'CZ_SEM.ap_date':
-        ("General.date", lambda tup: parser.parse(tup[1]).date().isoformat()),
-    'CZ_SEM.ap_time':
-        ("General.time", lambda tup: parser.parse(tup[1]).time().isoformat()),
-    'CZ_SEM.sv_user_name':
-        ("General.authors", _parse_tuple_Zeiss),
+    "CZ_SEM.ap_actualkv": (
+        "Acquisition_instrument.SEM.beam_energy",
+        _parse_tuple_Zeiss,
+    ),
+    "CZ_SEM.ap_mag": ("Acquisition_instrument.SEM.magnification", _parse_tuple_Zeiss),
+    "CZ_SEM.ap_stage_at_x": (
+        "Acquisition_instrument.SEM.Stage.x",
+        lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units="mm"),
+    ),
+    "CZ_SEM.ap_stage_at_y": (
+        "Acquisition_instrument.SEM.Stage.y",
+        lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units="mm"),
+    ),
+    "CZ_SEM.ap_stage_at_z": (
+        "Acquisition_instrument.SEM.Stage.z",
+        lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units="mm"),
+    ),
+    "CZ_SEM.ap_stage_at_r": (
+        "Acquisition_instrument.SEM.Stage.rotation",
+        _parse_tuple_Zeiss,
+    ),
+    "CZ_SEM.ap_stage_at_t": (
+        "Acquisition_instrument.SEM.Stage.tilt",
+        _parse_tuple_Zeiss,
+    ),
+    "CZ_SEM.ap_wd": (
+        "Acquisition_instrument.SEM.working_distance",
+        lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units="mm"),
+    ),
+    "CZ_SEM.dp_dwell_time": (
+        "Acquisition_instrument.SEM.dwell_time",
+        lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units="s"),
+    ),
+    "CZ_SEM.ap_iprobe": (
+        "Acquisition_instrument.SEM.beam_current",
+        lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units="nA"),
+    ),
+    "CZ_SEM.dp_detector_type": (
+        "Acquisition_instrument.SEM.Detector.detector_type",
+        lambda tup: _parse_tuple_Zeiss(tup),
+    ),
+    "CZ_SEM.sv_serial_number": (
+        "Acquisition_instrument.SEM.microscope",
+        _parse_tuple_Zeiss,
+    ),
+    "CZ_SEM.ap_date": (
+        "General.date",
+        lambda tup: parser.parse(tup[1]).date().isoformat(),
+    ),
+    "CZ_SEM.ap_time": (
+        "General.time",
+        lambda tup: parser.parse(tup[1]).time().isoformat(),
+    ),
+    "CZ_SEM.sv_user_name": ("General.authors", _parse_tuple_Zeiss),
 }
 
 
 def get_tvips_mapping(mapped_magnification):
     mapping_tvips = {
-        'TVIPS.TemMagnification':
-            ("Acquisition_instrument.TEM.%s" % mapped_magnification, None),
-        'TVIPS.CameraType':
-            ("Acquisition_instrument.TEM.Detector.Camera.name", None),
-        'TVIPS.ExposureTime':
-            ("Acquisition_instrument.TEM.Detector.Camera.exposure",
-             lambda x: float(x) * 1e-3),
-        'TVIPS.TemHighTension':
-            ("Acquisition_instrument.TEM.beam_energy", lambda x: float(x) * 1e-3),
-        'TVIPS.Comment':
-            ("General.notes", _parse_string),
-        'TVIPS.Date':
-            ("General.date", _parse_tvips_date),
-        'TVIPS.Time':
-            ("General.time", _parse_tvips_time),
-        'TVIPS.TemStagePosition':
-            ("Acquisition_instrument.TEM.Stage", lambda stage: {
-                'x': stage[0] * 1E3,
-                'y': stage[1] * 1E3,
-                'z': stage[2] * 1E3,
-                'tilt_alpha': stage[3],
-                'tilt_beta': stage[4]
-            }
-             )
+        "TVIPS.TemMagnification": (
+            "Acquisition_instrument.TEM.%s" % mapped_magnification,
+            None,
+        ),
+        "TVIPS.CameraType": ("Acquisition_instrument.TEM.Detector.Camera.name", None),
+        "TVIPS.ExposureTime": (
+            "Acquisition_instrument.TEM.Detector.Camera.exposure",
+            lambda x: float(x) * 1e-3,
+        ),
+        "TVIPS.TemHighTension": (
+            "Acquisition_instrument.TEM.beam_energy",
+            lambda x: float(x) * 1e-3,
+        ),
+        "TVIPS.Comment": ("General.notes", _parse_string),
+        "TVIPS.Date": ("General.date", _parse_tvips_date),
+        "TVIPS.Time": ("General.time", _parse_tvips_time),
+        "TVIPS.TemStagePosition": (
+            "Acquisition_instrument.TEM.Stage",
+            lambda stage: {
+                "x": stage[0] * 1e3,
+                "y": stage[1] * 1e3,
+                "z": stage[2] * 1e3,
+                "tilt_alpha": stage[3],
+                "tilt_beta": stage[4],
+            },
+        ),
     }
     return mapping_tvips
 
 
 mapping_olympus_sis = {
-    'Olympus_SIS_metadata.magnification':
-        ("Acquisition_instrument.TEM.magnification", None),
-    'Olympus_SIS_metadata.cameraname':
-        ("Acquisition_instrument.TEM.Detector.Camera.name", None),
+    "Olympus_SIS_metadata.magnification": (
+        "Acquisition_instrument.TEM.magnification",
+        None,
+    ),
+    "Olympus_SIS_metadata.cameraname": (
+        "Acquisition_instrument.TEM.Detector.Camera.name",
+        None,
+    ),
 }
 
 
@@ -1083,16 +1213,16 @@ def get_metadata_mapping(tiff_page, op):
 
     elif tiff_page.is_tvips:
         try:
-            if op['TVIPS']['TemMode'] == 3:
-                mapped_magnification = 'camera_length'
+            if op["TVIPS"]["TemMode"] == 3:
+                mapped_magnification = "camera_length"
             else:
-                mapped_magnification = 'magnification'
+                mapped_magnification = "magnification"
         except KeyError:
-            mapped_magnification = 'magnification'
+            mapped_magnification = "magnification"
         return get_tvips_mapping(mapped_magnification)
     elif tiff_page.is_sis:
         return mapping_olympus_sis
-    elif op.get('Make', None) == "JEOL Ltd.":
+    elif op.get("Make", None) == "JEOL Ltd.":
         return get_jeol_sightx_mapping(op)
     else:
         return {}

--- a/rsciio/usid_hdf5/api.py
+++ b/rsciio/usid_hdf5/api.py
@@ -61,23 +61,26 @@ def _get_dim_dict(labels, units, val_func, ignore_non_uniform_dims=True):
             except ValueError:
                 # non-uniform dimension! - see notes above
                 if ignore_non_uniform_dims:
-                    warn('Ignoring non-uniformity of dimension: '
-                         '{}'.format(dim_name))
+                    warn("Ignoring non-uniformity of dimension: " "{}".format(dim_name))
                     step_size = 1
                     dim_vals[0] = 0
                 else:
-                    raise ValueError('Cannot load provided dataset. '
-                                     'Parameter: {} was varied '
-                                     'non-uniformly. Supply keyword '
-                                     'argument "ignore_non_uniform_dims='
-                                     'True" to ignore this '
-                                     'error'.format(dim_name))
+                    raise ValueError(
+                        "Cannot load provided dataset. "
+                        "Parameter: {} was varied "
+                        "non-uniformly. Supply keyword "
+                        'argument "ignore_non_uniform_dims='
+                        'True" to ignore this '
+                        "error".format(dim_name)
+                    )
 
-        dim_dict[dim_name] = {'size': len(dim_vals),
-                              'name': dim_name,
-                              'units': units,
-                              'scale': step_size,
-                              'offset': dim_vals[0]}
+        dim_dict[dim_name] = {
+            "size": len(dim_vals),
+            "name": dim_name,
+            "units": units,
+            "scale": step_size,
+            "offset": dim_vals[0],
+        }
     return dim_dict
 
 
@@ -127,22 +130,30 @@ def _split_descriptor(desc):
         Units corresponding to the physical quantity
     """
     desc = desc.strip()
-    ind = desc.rfind('(')
+    ind = desc.rfind("(")
     if ind < 0:
-        ind = desc.rfind('[')
+        ind = desc.rfind("[")
         if ind < 0:
-            return desc, ''
+            return desc, ""
 
     quant = desc[:ind].strip()
     units = desc[ind:]
-    for item in '()[]':
-        units = units.replace(item, '')
+    for item in "()[]":
+        units = units.replace(item, "")
     return quant, units
 
 
-def _convert_to_signal_dict(ndim_form, quantity, units, dim_dict_list,
-                            h5_path, h5_dset_path, name, sig_type='',
-                            group_attrs={}):
+def _convert_to_signal_dict(
+    ndim_form,
+    quantity,
+    units,
+    dim_dict_list,
+    h5_path,
+    h5_dset_path,
+    name,
+    sig_type="",
+    group_attrs={},
+):
     """
     Packages required components that make up a Signal object
 
@@ -173,26 +184,26 @@ def _convert_to_signal_dict(ndim_form, quantity, units, dim_dict_list,
 
     """
 
-    sig = {'data': ndim_form,
-           'axes': dim_dict_list,
-           'metadata': {
-               'Signal': {'signal_type': sig_type},
-               'General': {'original_filename': h5_path,
-                           'title': name}
-                        },
-           'original_metadata': {'quantity': quantity,
-                                 'units': units,
-                                 'dataset_path': h5_dset_path,
-                                 'original_file_type': 'USID HDF5',
-                                 'pyUSID_version': usid.__version__,
-                                 'parameters': group_attrs
-                                 },
-           }
+    sig = {
+        "data": ndim_form,
+        "axes": dim_dict_list,
+        "metadata": {
+            "Signal": {"signal_type": sig_type},
+            "General": {"original_filename": h5_path, "title": name},
+        },
+        "original_metadata": {
+            "quantity": quantity,
+            "units": units,
+            "dataset_path": h5_dset_path,
+            "original_file_type": "USID HDF5",
+            "pyUSID_version": usid.__version__,
+            "parameters": group_attrs,
+        },
+    }
     return sig
 
 
-def _usidataset_to_signal(h5_main, ignore_non_uniform_dims=True, lazy=True,
-                          *kwds):
+def _usidataset_to_signal(h5_main, ignore_non_uniform_dims=True, lazy=True, *kwds):
     """
     Converts a single specified USIDataset object to one or more Signal objects
 
@@ -220,41 +231,44 @@ def _usidataset_to_signal(h5_main, ignore_non_uniform_dims=True, lazy=True,
     # TODO: Cannot handle data without N-dimensional form yet
     # First get dictionary of axes that HyperSpy likes to see. Ignore singular
     # dimensions
-    pos_dict = _get_dim_dict(h5_main.pos_dim_labels,
-                             usid.hdf_utils.get_attr(h5_main.h5_pos_inds,
-                                                     'units'),
-                             h5_main.get_pos_values,
-                             ignore_non_uniform_dims=ignore_non_uniform_dims)
-    spec_dict = _get_dim_dict(h5_main.spec_dim_labels,
-                              usid.hdf_utils.get_attr(h5_main.h5_spec_inds,
-                                                      'units'),
-                              h5_main.get_spec_values,
-                              ignore_non_uniform_dims=ignore_non_uniform_dims)
+    pos_dict = _get_dim_dict(
+        h5_main.pos_dim_labels,
+        usid.hdf_utils.get_attr(h5_main.h5_pos_inds, "units"),
+        h5_main.get_pos_values,
+        ignore_non_uniform_dims=ignore_non_uniform_dims,
+    )
+    spec_dict = _get_dim_dict(
+        h5_main.spec_dim_labels,
+        usid.hdf_utils.get_attr(h5_main.h5_spec_inds, "units"),
+        h5_main.get_spec_values,
+        ignore_non_uniform_dims=ignore_non_uniform_dims,
+    )
 
     num_spec_dims = len(spec_dict)
     num_pos_dims = len(pos_dict)
-    _logger.info('Dimensions: Positions: {}, Spectroscopic: {}'
-                 '.'.format(num_pos_dims, num_spec_dims))
+    _logger.info(
+        "Dimensions: Positions: {}, Spectroscopic: {}"
+        ".".format(num_pos_dims, num_spec_dims)
+    )
 
-    ret_vals = usid.hdf_utils.reshape_to_n_dims(h5_main, get_labels=True,
-                                                lazy=lazy)
+    ret_vals = usid.hdf_utils.reshape_to_n_dims(h5_main, get_labels=True, lazy=lazy)
     ds_nd, success, dim_labs = ret_vals
 
     if success is not True:
-        raise ValueError('Dataset could not be reshaped!')
+        raise ValueError("Dataset could not be reshaped!")
     ds_nd = ds_nd.squeeze()
-    _logger.info('N-dimensional shape: {}'.format(ds_nd.shape))
-    _logger.info('N-dimensional labels: {}'.format(dim_labs))
+    _logger.info("N-dimensional shape: {}".format(ds_nd.shape))
+    _logger.info("N-dimensional labels: {}".format(dim_labs))
 
     # Capturing metadata present in conventional h5USID files:
     group_attrs = dict()
     h5_chan_grp = h5_main.parent
     if isinstance(h5_chan_grp, h5py.Group):
-        if 'Channel' in h5_chan_grp.name.split('/')[-1]:
+        if "Channel" in h5_chan_grp.name.split("/")[-1]:
             group_attrs = sidpy.hdf_utils.get_attributes(h5_chan_grp)
             h5_meas_grp = h5_main.parent
             if isinstance(h5_meas_grp, h5py.Group):
-                if 'Measurement' in h5_meas_grp.name.split('/')[-1]:
+                if "Measurement" in h5_meas_grp.name.split("/")[-1]:
                     temp = sidpy.hdf_utils.get_attributes(h5_meas_grp)
                     group_attrs.update(temp)
 
@@ -270,12 +284,14 @@ def _usidataset_to_signal(h5_main, ignore_non_uniform_dims=True, lazy=True,
 
     _, is_complex, is_compound, _, _ = sidpy.hdf.dtype_utils.check_dtype(h5_main)
 
-    trunc_func = partial(_convert_to_signal_dict,
-                         dim_dict_list=dim_list,
-                         h5_path=h5_main.file.filename,
-                         h5_dset_path=h5_main.name,
-                         name=h5_main.name.split('/')[-1],
-                         group_attrs=group_attrs)
+    trunc_func = partial(
+        _convert_to_signal_dict,
+        dim_dict_list=dim_list,
+        h5_path=h5_main.file.filename,
+        h5_dset_path=h5_main.name,
+        name=h5_main.name.split("/")[-1],
+        group_attrs=group_attrs,
+    )
 
     # Extracting the quantity and units of the main dataset
     quant, units = _split_descriptor(h5_main.data_descriptor)
@@ -295,7 +311,7 @@ def _usidataset_to_signal(h5_main, ignore_non_uniform_dims=True, lazy=True,
 # ######## UTILITIES THAT SIMPLIFY WRITING TO H5USID FILES ####################
 
 
-def _flatten_dict(nested_dict, parent_key='', sep='-'):
+def _flatten_dict(nested_dict, parent_key="", sep="-"):
     """
     Flattens a nested dictionary
 
@@ -321,8 +337,7 @@ def _flatten_dict(nested_dict, parent_key='', sep='-'):
     for k, v in nested_dict.items():
         new_key = parent_key + sep + k if parent_key else k
         if isinstance(v, MutableMapping):
-            items.extend(_flatten_dict(v, new_key,
-                                       sep=sep).items())
+            items.extend(_flatten_dict(v, new_key, sep=sep).items())
         else:
             items.append((new_key, v))
     return dict(items)
@@ -330,38 +345,40 @@ def _flatten_dict(nested_dict, parent_key='', sep='-'):
 
 def _axes_list_to_dimensions(axes_list, data_shape, is_spec):
     dim_list = []
-    dim_type = 'Pos'
+    dim_type = "Pos"
     if is_spec:
-        dim_type = 'Spec'
+        dim_type = "Spec"
     # for dim_ind, (dim_size, dim) in enumerate(zip(data_shape, axes_list)):
     # we are going by data_shape for order (slowest to fastest)
     # so the order in axes_list does not matter
     for dim_ind, dim in enumerate(axes_list):
         dim = axes_list[dim_ind]
-        dim_name = dim_type + '_Dim_' + str(dim_ind)
-        if isinstance(dim['name'], str):
-            temp = dim['name'].strip()
+        dim_name = dim_type + "_Dim_" + str(dim_ind)
+        if isinstance(dim["name"], str):
+            temp = dim["name"].strip()
             if len(temp) > 0:
                 dim_name = temp
-        dim_units = 'a. u.'
-        if isinstance(dim['units'], str):
-            temp = dim['units'].strip()
+        dim_units = "a. u."
+        if isinstance(dim["units"], str):
+            temp = dim["units"].strip()
             if len(temp) > 0:
                 dim_units = temp
                 # use REAL dimension size rather than what is presented in the
                 # axes manager
         dim_size = data_shape[len(data_shape) - 1 - dim_ind]
-        ar = np.arange(dim_size) * dim['scale'] + dim['offset']
+        ar = np.arange(dim_size) * dim["scale"] + dim["offset"]
         dim_list.append(usid.Dimension(dim_name, dim_units, ar))
     if len(dim_list) == 0:
-        return usid.Dimension('Arb', 'a. u.', 1)
+        return usid.Dimension("Arb", "a. u.", 1)
     return dim_list[::-1]
+
 
 # ####### REQUIRED FUNCTIONS FOR AN IO PLUGIN #################################
 
 
-def file_reader(filename, dataset_path=None, ignore_non_uniform_dims=True,
-                lazy=False, **kwds):
+def file_reader(
+    filename, dataset_path=None, ignore_non_uniform_dims=True, lazy=False, **kwds
+):
     """
     Reads a USID Main dataset present in an HDF5 file into a HyperSpy Signal
 
@@ -387,32 +404,33 @@ def file_reader(filename, dataset_path=None, ignore_non_uniform_dims=True,
     list of hyperspy.signals.Signal object
     """
     if not isinstance(filename, str):
-        raise TypeError('filename should be a string')
+        raise TypeError("filename should be a string")
     if not os.path.isfile(filename):
-        raise FileNotFoundError(f'No file found at: {filename}')
+        raise FileNotFoundError(f"No file found at: {filename}")
 
     # Need to keep h5 file handle open indefinitely if lazy
     # Using "with" will cause the file to be closed
-    h5_f = h5py.File(filename, 'r')
+    h5_f = h5py.File(filename, "r")
     if dataset_path is None:
         all_main_dsets = usid.hdf_utils.get_all_main(h5_f)
         signals = []
         for h5_dset in all_main_dsets:
             # Note that the function returns a list already.
             # Should not append
-            signals += _usidataset_to_signal(h5_dset,
-                                             ignore_non_uniform_dims=
-                                             ignore_non_uniform_dims,
-                                             lazy=lazy, **kwds)
+            signals += _usidataset_to_signal(
+                h5_dset,
+                ignore_non_uniform_dims=ignore_non_uniform_dims,
+                lazy=lazy,
+                **kwds,
+            )
         return signals
     else:
         if not isinstance(dataset_path, str):
             raise TypeError("'dataset_path' should be a string")
         h5_dset = h5_f[dataset_path]
-        return _usidataset_to_signal(h5_dset,
-                                     ignore_non_uniform_dims=
-                                     ignore_non_uniform_dims,
-                                     lazy=lazy, **kwds)
+        return _usidataset_to_signal(
+            h5_dset, ignore_non_uniform_dims=ignore_non_uniform_dims, lazy=lazy, **kwds
+        )
 
     # At least close the file handle if not lazy load
     if not lazy:
@@ -434,24 +452,23 @@ def file_writer(filename, object2save, **kwds):
     if os.path.exists(filename):
         append = True
 
-    hs_shape = object2save['data'].shape
+    hs_shape = object2save["data"].shape
 
-    parm_dict = _flatten_dict(object2save['metadata'])
-    temp = object2save['original_metadata']
-    parm_dict.update(_flatten_dict(temp, parent_key='Original'))
+    parm_dict = _flatten_dict(object2save["metadata"])
+    temp = object2save["original_metadata"]
+    parm_dict.update(_flatten_dict(temp, parent_key="Original"))
 
-    axes = object2save['axes']
-    nav_axes = [ax for ax in axes if ax['navigate']][::-1]
-    sig_axes = [ax for ax in axes if not ax['navigate']][::-1]
+    axes = object2save["axes"]
+    nav_axes = [ax for ax in axes if ax["navigate"]][::-1]
+    sig_axes = [ax for ax in axes if not ax["navigate"]][::-1]
     nav_dim = len(nav_axes)
 
-    data = object2save['data']
+    data = object2save["data"]
     # data is assumed to have dimensions arranged from slowest to fastest
     # varying dimensions
     if nav_dim > 0 and len(sig_axes) > 0:
         # now flatten to 2D:
-        data = data.reshape(np.prod(hs_shape[:nav_dim]),
-                            np.prod(hs_shape[nav_dim:]))
+        data = data.reshape(np.prod(hs_shape[:nav_dim]), np.prod(hs_shape[nav_dim:]))
         pos_dims = _axes_list_to_dimensions(nav_axes, hs_shape[:nav_dim], False)
         spec_dims = _axes_list_to_dimensions(sig_axes, hs_shape[nav_dim:], True)
     elif nav_dim == 0:
@@ -467,23 +484,37 @@ def file_writer(filename, object2save, **kwds):
         spec_dims = _axes_list_to_dimensions(sig_axes, [], True)
 
     #  Does HyperSpy store the physical quantity and units somewhere?
-    phy_quant = 'Unknown Quantity'
-    phy_units = 'Unknown Units'
-    dset_name = 'Raw_Data'
-
-
+    phy_quant = "Unknown Quantity"
+    phy_units = "Unknown Units"
+    dset_name = "Raw_Data"
 
     if not append:
         tran = usid.NumpyTranslator()
-        _ = tran.translate(filename, dset_name, data, phy_quant, phy_units,
-                           pos_dims, spec_dims, parm_dict=parm_dict,
-                           slow_to_fast=True, **kwds)
+        _ = tran.translate(
+            filename,
+            dset_name,
+            data,
+            phy_quant,
+            phy_units,
+            pos_dims,
+            spec_dims,
+            parm_dict=parm_dict,
+            slow_to_fast=True,
+            **kwds,
+        )
     else:
-        with h5py.File(filename, mode='r+') as h5_f:
-            h5_grp = usid.hdf_utils.create_indexed_group(h5_f, 'Measurement')
+        with h5py.File(filename, mode="r+") as h5_f:
+            h5_grp = usid.hdf_utils.create_indexed_group(h5_f, "Measurement")
             usid.hdf_utils.write_simple_attrs(h5_grp, parm_dict)
-            h5_grp = usid.hdf_utils.create_indexed_group(h5_grp, 'Channel')
-            _ = usid.hdf_utils.write_main_dataset(h5_grp, data, dset_name,
-                                                  phy_quant, phy_units,
-                                                  pos_dims,  spec_dims,
-                                                  slow_to_fast=True, **kwds)
+            h5_grp = usid.hdf_utils.create_indexed_group(h5_grp, "Channel")
+            _ = usid.hdf_utils.write_main_dataset(
+                h5_grp,
+                data,
+                dset_name,
+                phy_quant,
+                phy_units,
+                pos_dims,
+                spec_dims,
+                slow_to_fast=True,
+                **kwds,
+            )

--- a/rsciio/utils/date_time_tools.py
+++ b/rsciio/utils/date_time_tools.py
@@ -25,7 +25,6 @@ import numpy as np
 _logger = logging.getLogger(__name__)
 
 
-
 def serial_date_to_ISO_format(serial):
     """
     Convert serial_date to a tuple of string (date, time, time_zone) in ISO
@@ -36,19 +35,16 @@ def serial_date_to_ISO_format(serial):
     return dt_local.date().isoformat(), dt_local.time().isoformat(), dt_local.tzname()
 
 
-def ISO_format_to_serial_date(date, time, timezone='UTC'):
-    """ Convert ISO format to a serial date. """
-    if timezone is None or timezone == 'Coordinated Universal Time':
-        timezone = 'UTC'
-    dt = parser.parse(
-        '%sT%s' %
-        (date, time)).replace(
-        tzinfo=tz.gettz(timezone))
+def ISO_format_to_serial_date(date, time, timezone="UTC"):
+    """Convert ISO format to a serial date."""
+    if timezone is None or timezone == "Coordinated Universal Time":
+        timezone = "UTC"
+    dt = parser.parse("%sT%s" % (date, time)).replace(tzinfo=tz.gettz(timezone))
     return datetime_to_serial_date(dt)
 
 
 def datetime_to_serial_date(dt):
-    """ Convert datetime.datetime object to a serial date. """
+    """Convert datetime.datetime object to a serial date."""
     if dt.tzname() is None:
         dt = dt.replace(tzinfo=tz.tzutc())
     origin = datetime.datetime(1899, 12, 30, tzinfo=tz.tzutc())
@@ -57,7 +53,7 @@ def datetime_to_serial_date(dt):
 
 
 def serial_date_to_datetime(serial):
-    """ Convert serial date to a datetime.datetime object. """
+    """Convert serial date to a datetime.datetime object."""
     # Excel date&time format
     origin = datetime.datetime(1899, 12, 30, tzinfo=tz.tzutc())
     secs = (serial % 1.0) * 86400
@@ -65,7 +61,7 @@ def serial_date_to_datetime(serial):
     return origin + delta
 
 
-def get_date_time_from_metadata(metadata, formatting='ISO'):
+def get_date_time_from_metadata(metadata, formatting="ISO"):
     """
     Get the date and time from a metadata tree.
 
@@ -83,30 +79,30 @@ def get_date_time_from_metadata(metadata, formatting='ISO'):
         string, datetime.datetime or numpy.datetime64 object
 
     """
-    md_gen = metadata['General']
-    date, time = md_gen.get('date'), md_gen.get('time')
+    md_gen = metadata["General"]
+    date, time = md_gen.get("date"), md_gen.get("time")
     if date and time:
-        dt = parser.parse(f'{date}T{time}')
-        time_zone = md_gen.get('time_zone')
+        dt = parser.parse(f"{date}T{time}")
+        time_zone = md_gen.get("time_zone")
         if time_zone:
             dt = dt.replace(tzinfo=tz.gettz(time_zone))
             if dt.tzinfo is None:
                 # time_zone metadata must be offset string
-                dt = parser.parse(f'{date}T{time}{time_zone}')
+                dt = parser.parse(f"{date}T{time}{time_zone}")
 
     elif not date and time:
-        dt = parser.parse(f'{time}').time()
+        dt = parser.parse(f"{time}").time()
     elif date and not time:
-        dt = parser.parse(f'{date}').date()
+        dt = parser.parse(f"{date}").date()
     else:
         return
 
-    if formatting == 'ISO':
+    if formatting == "ISO":
         res = dt.isoformat()
-    if formatting == 'datetime':
+    if formatting == "datetime":
         res = dt
     # numpy.datetime64 doesn't support time zone
-    if formatting == 'datetime64':
-        res = np.datetime64(f'{date}T{time}')
+    if formatting == "datetime64":
+        res = np.datetime64(f"{date}T{time}")
 
     return res

--- a/rsciio/utils/rgb_tools.py
+++ b/rsciio/utils/rgb_tools.py
@@ -22,20 +22,12 @@ from dask.array import Array
 from hyperspy.misc.utils import get_numpy_kwargs
 
 
-rgba8 = np.dtype({'names': ['R', 'G', 'B', 'A'],
-                  'formats': ['u1', 'u1', 'u1', 'u1']})
-rgb8 = np.dtype({'names': ['R', 'G', 'B'],
-                 'formats': ['u1', 'u1', 'u1']})
+rgba8 = np.dtype({"names": ["R", "G", "B", "A"], "formats": ["u1", "u1", "u1", "u1"]})
+rgb8 = np.dtype({"names": ["R", "G", "B"], "formats": ["u1", "u1", "u1"]})
 
-rgba16 = np.dtype({'names': ['R', 'G', 'B', 'A'],
-                   'formats': ['u2', 'u2', 'u2', 'u2']})
-rgb16 = np.dtype({'names': ['R', 'G', 'B'],
-                  'formats': ['u2', 'u2', 'u2']})
-rgb_dtypes = {
-    'rgb8': rgb8,
-    'rgb16': rgb16,
-    'rgba8': rgba8,
-    'rgba16': rgba16}
+rgba16 = np.dtype({"names": ["R", "G", "B", "A"], "formats": ["u2", "u2", "u2", "u2"]})
+rgb16 = np.dtype({"names": ["R", "G", "B"], "formats": ["u2", "u2", "u2"]})
+rgb_dtypes = {"rgb8": rgb8, "rgb16": rgb16, "rgba8": rgba8, "rgba16": rgba16}
 
 
 def is_rgba(array):
@@ -73,33 +65,34 @@ def rgbx2regular_array(data, plot_friendly=False):
     # Make sure that the data is contiguous
     if isinstance(data, Array):
         from dask.diagnostics import ProgressBar
+
         # an expensive thing, but nothing to be done for now...
         with ProgressBar():
             data = data.compute()
-    if data.flags['C_CONTIGUOUS'] is False:
+    if data.flags["C_CONTIGUOUS"] is False:
         if np.ma.is_masked(data):
-            data = data.copy(order='C')
+            data = data.copy(order="C")
         else:
             data = np.ascontiguousarray(data, **get_numpy_kwargs(data))
     if is_rgba(data) is True:
-        dt = data.dtype.fields['B'][0]
+        dt = data.dtype.fields["B"][0]
         data = data.view((dt, 4))
     elif is_rgb(data) is True:
-        dt = data.dtype.fields['B'][0]
+        dt = data.dtype.fields["B"][0]
         data = data.view((dt, 3))
     else:
         return data
     if plot_friendly is True and data.dtype == np.dtype("uint16"):
         data = data.astype("float")
-        data /= 2 ** 16 - 1
+        data /= 2**16 - 1
     return data
 
 
 def regular_array2rgbx(data):
     # Make sure that the data is contiguous
-    if data.flags['C_CONTIGUOUS'] is False:
+    if data.flags["C_CONTIGUOUS"] is False:
         if np.ma.is_masked(data):
-            data = data.copy(order='C')
+            data = data.copy(order="C")
         else:
             data = np.ascontiguousarray(data, **get_numpy_kwargs(data))
     if data.shape[-1] == 3:
@@ -112,5 +105,6 @@ def regular_array2rgbx(data):
         formats = [data.dtype] * len(names)
     else:
         raise ValueError("The data dtype must be uint16 or uint8")
-    return data.view(np.dtype({"names": names,
-                               "formats": formats})).reshape(data.shape[:-1])
+    return data.view(np.dtype({"names": names, "formats": formats})).reshape(
+        data.shape[:-1]
+    )

--- a/rsciio/utils/skimage_exposure.py
+++ b/rsciio/utils/skimage_exposure.py
@@ -8,9 +8,7 @@ import dask.array as da
 from skimage.exposure.exposure import intensity_range, _output_dtype, DTYPE_RANGE
 
 
-
-
-def rescale_intensity(image, in_range='image', out_range='dtype'):
+def rescale_intensity(image, in_range="image", out_range="dtype"):
     """Return image after stretching or shrinking its intensity levels.
 
     The desired intensity range of the input and output, `in_range` and
@@ -102,21 +100,22 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     >>> rescale_intensity(image, out_range=(0, 127)).astype(np.int32)
     array([127, 127, 127], dtype=int32)
     """
-    if out_range in ['dtype', 'image']:
+    if out_range in ["dtype", "image"]:
         out_dtype = _output_dtype(image.dtype.type, image.dtype)
     else:
         out_dtype = _output_dtype(out_range, image.dtype)
 
     imin, imax = map(float, intensity_range(image, in_range))
-    omin, omax = map(float, intensity_range(image, out_range,
-                                            clip_negative=(imin >= 0)))
+    omin, omax = map(
+        float, intensity_range(image, out_range, clip_negative=(imin >= 0))
+    )
 
     if np.any(np.isnan([imin, imax, omin, omax])):
         utils.warn(
             "One or more intensity levels are NaN. Rescaling will broadcast "
             "NaN to the full image. Provide intensity levels yourself to "
             "avoid this. E.g. with np.nanmin(image), np.nanmax(image).",
-            stacklevel=2
+            stacklevel=2,
         )
 
     image = np.clip(image, imin, imax)

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -34,9 +34,11 @@ _UREG = UnitRegistry()
 
 _logger = logging.getLogger(__name__)
 
+
 @contextmanager
 def dummy_context_manager(*args, **kwargs):
     yield
+
 
 def dump_dictionary(
     file, dic, string="root", node_separator=".", value_separator=" = "
@@ -101,7 +103,7 @@ def ensure_directory(path):
 
 
 def overwrite(fname):
-    """ If file exists 'fname', ask for overwriting and return True or False,
+    """If file exists 'fname', ask for overwriting and return True or False,
     else return True.
 
     Parameters
@@ -115,8 +117,9 @@ def overwrite(fname):
         Whether to overwrite file.
 
     """
-    if Path(fname).is_file() or (Path(fname).is_dir() and
-                                 os.path.splitext(fname)[1] == '.zspy'):
+    if Path(fname).is_file() or (
+        Path(fname).is_dir() and os.path.splitext(fname)[1] == ".zspy"
+    ):
         message = f"Overwrite '{fname}' (y/n)?\n"
         try:
             answer = input(message)
@@ -160,10 +163,12 @@ class DTBox(Box):
             if self.get(key) is None:
                 self[key] = {}
             self = self[key]
+
     def set_item(self, path, value):
         if self.get(path) is None:
             self.add_node(path)
         self[path] = value
+
     def has_item(self, path):
         return self.get(path) is not None
 
@@ -231,6 +236,7 @@ def dict2sarray(dictionary, sarray=None, dtype=None):
 def convert_units(value, units, to_units):
     return (value * _UREG(units)).to(to_units).magnitude
 
+
 def get_object_package_info(obj):
     """Get info about object package
 
@@ -287,6 +293,8 @@ def get_file_handle(data, warn=True):
             return data.dask[arrkey].file
         except (AttributeError, ValueError):
             if warn:
-                _logger.warning("Failed to retrieve file handle, either "
-                                "the file is already closed or it is not "
-                                "an hdf5 file.")
+                _logger.warning(
+                    "Failed to retrieve file handle, either "
+                    "the file is already closed or it is not "
+                    "an hdf5 file."
+                )

--- a/rsciio/utils/utils_readfile.py
+++ b/rsciio/utils/utils_readfile.py
@@ -35,38 +35,38 @@ _logger = logging.getLogger(__name__)
 # type = (u)short, (u)long, float, double, bool (unsigned char),
 # byte (signed char), char
 
-B_short = struct.Struct('>h')
-L_short = struct.Struct('<h')
+B_short = struct.Struct(">h")
+L_short = struct.Struct("<h")
 
-B_ushort = struct.Struct('>H')
-L_ushort = struct.Struct('<H')
+B_ushort = struct.Struct(">H")
+L_ushort = struct.Struct("<H")
 
-B_long = struct.Struct('>l')
-L_long = struct.Struct('<l')
+B_long = struct.Struct(">l")
+L_long = struct.Struct("<l")
 
-B_long_long = struct.Struct('>q')
-L_long_long = struct.Struct('<q')
+B_long_long = struct.Struct(">q")
+L_long_long = struct.Struct("<q")
 
-B_ulong = struct.Struct('>L')
-L_ulong = struct.Struct('<L')
+B_ulong = struct.Struct(">L")
+L_ulong = struct.Struct("<L")
 
-B_ulong_long = struct.Struct('>Q')
-L_ulong_long = struct.Struct('<Q')
+B_ulong_long = struct.Struct(">Q")
+L_ulong_long = struct.Struct("<Q")
 
-B_float = struct.Struct('>f')
-L_float = struct.Struct('<f')
+B_float = struct.Struct(">f")
+L_float = struct.Struct("<f")
 
-B_double = struct.Struct('>d')
-L_double = struct.Struct('<d')
+B_double = struct.Struct(">d")
+L_double = struct.Struct("<d")
 
-B_bool = struct.Struct('>B')    # use unsigned char
-L_bool = struct.Struct('<B')
+B_bool = struct.Struct(">B")  # use unsigned char
+L_bool = struct.Struct("<B")
 
-B_byte = struct.Struct('>b')    # use signed char
-L_byte = struct.Struct('<b')
+B_byte = struct.Struct(">b")  # use signed char
+L_byte = struct.Struct("<b")
 
-B_char = struct.Struct('>c')
-L_char = struct.Struct('<c')
+B_char = struct.Struct(">c")
+L_char = struct.Struct("<c")
 
 
 def read_short(f, endian):
@@ -74,14 +74,14 @@ def read_short(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
-        data = f.read(2)      # hexadecimal representation
-        if endian == 'big':
+        data = f.read(2)  # hexadecimal representation
+        if endian == "big":
             s = B_short
-        elif endian == 'little':
+        elif endian == "little":
             s = L_short
         return s.unpack(data)[0]  # struct.unpack returns a tuple
 
@@ -91,14 +91,14 @@ def read_ushort(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(2)
-        if endian == 'big':
+        if endian == "big":
             s = B_ushort
-        elif endian == 'little':
+        elif endian == "little":
             s = L_ushort
         return s.unpack(data)[0]
 
@@ -108,14 +108,14 @@ def read_long(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(4)
-        if endian == 'big':
+        if endian == "big":
             s = B_long
-        elif endian == 'little':
+        elif endian == "little":
             s = L_long
         return s.unpack(data)[0]
 
@@ -125,14 +125,14 @@ def read_long_long(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(8)
-        if endian == 'big':
+        if endian == "big":
             s = B_long_long
-        elif endian == 'little':
+        elif endian == "little":
             s = L_long_long
         return s.unpack(data)[0]
 
@@ -142,14 +142,14 @@ def read_ulong(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(4)
-        if endian == 'big':
+        if endian == "big":
             s = B_ulong
-        elif endian == 'little':
+        elif endian == "little":
             s = L_ulong
         return s.unpack(data)[0]
 
@@ -159,14 +159,14 @@ def read_ulong_long(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(8)
-        if endian == 'big':
+        if endian == "big":
             s = B_ulong_long
-        elif endian == 'little':
+        elif endian == "little":
             s = L_ulong_long
         return s.unpack(data)[0]
 
@@ -176,14 +176,14 @@ def read_float(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(4)
-        if endian == 'big':
+        if endian == "big":
             s = B_float
-        elif endian == 'little':
+        elif endian == "little":
             s = L_float
         return s.unpack(data)[0]
 
@@ -193,14 +193,14 @@ def read_double(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(8)
-        if endian == 'big':
+        if endian == "big":
             s = B_double
-        elif endian == 'little':
+        elif endian == "little":
             s = L_double
         return s.unpack(data)[0]
 
@@ -210,14 +210,14 @@ def read_boolean(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(1)
-        if endian == 'big':
+        if endian == "big":
             s = B_bool
-        elif endian == 'little':
+        elif endian == "little":
             s = L_bool
         return s.unpack(data)[0]
 
@@ -227,14 +227,14 @@ def read_byte(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(1)
-        if endian == 'big':
+        if endian == "big":
             s = B_byte
-        elif endian == 'little':
+        elif endian == "little":
             s = L_byte
         return s.unpack(data)[0]
 
@@ -244,13 +244,13 @@ def read_char(f, endian):
     with a given endianness (byte order).
     endian can be either 'big' or 'little'.
     """
-    if (endian != 'little') and (endian != 'big'):
-        _logger.debug('File address:', f.tell())
+    if (endian != "little") and (endian != "big"):
+        _logger.debug("File address:", f.tell())
         raise ByteOrderError(endian)
     else:
         data = f.read(1)
-        if endian == 'big':
+        if endian == "big":
             s = B_char
-        elif endian == 'little':
+        elif endian == "little":
             s = L_char
         return s.unpack(data)[0]

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from setuptools import setup, find_packages, Extension, Command
 import os
 import warnings
 from os import path
+
 # io.open is needed for projects that support Python 2.7
 # It ensures open() defaults to text mode with universal newlines,
 # and accepts an argument to specify the text encoding
@@ -28,24 +29,26 @@ from rsciio.version import __version__
 setup_path = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(setup_path, 'README.md'), encoding='utf-8') as f:
+with open(path.join(setup_path, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 # Extensions. Add your extension here:
-raw_extensions = [Extension("rsciio.bruker.unbcf_fast",
-                            [os.path.join('rsciio', 'bruker', 'unbcf_fast.pyx')]),
-                  ]
+raw_extensions = [
+    Extension(
+        "rsciio.bruker.unbcf_fast", [os.path.join("rsciio", "bruker", "unbcf_fast.pyx")]
+    ),
+]
 
 cleanup_list = []
 for leftover in raw_extensions:
     path, ext = os.path.splitext(leftover.sources[0])
-    if ext in ('.pyx', '.py'):
-        cleanup_list.append(''.join([os.path.join(setup_path, path), '.c*']))
-        if os.name == 'nt':
-            bin_ext = '.cpython-*.pyd'
+    if ext in (".pyx", ".py"):
+        cleanup_list.append("".join([os.path.join(setup_path, path), ".c*"]))
+        if os.name == "nt":
+            bin_ext = ".cpython-*.pyd"
         else:
-            bin_ext = '.cpython-*.so'
-        cleanup_list.append(''.join([os.path.join(setup_path, path), bin_ext]))
+            bin_ext = ".cpython-*.so"
+        cleanup_list.append("".join([os.path.join(setup_path, path), bin_ext]))
 
 
 def count_c_extensions(extensions):
@@ -55,7 +58,7 @@ def count_c_extensions(extensions):
         # it is cythonised or pure c/c++ extension:
         sfile = extension.sources[0]
         path, ext = os.path.splitext(sfile)
-        if os.path.exists(path + '.c') or os.path.exists(path + '.cpp'):
+        if os.path.exists(path + ".c") or os.path.exists(path + ".cpp"):
             c_num += 1
     return c_num
 
@@ -63,14 +66,17 @@ def count_c_extensions(extensions):
 def cythonize_extensions(extensions):
     try:
         from Cython.Build import cythonize
+
         return cythonize(extensions)
     except ImportError:
-        warnings.warn("""WARNING: cython required to generate fast c code is not found on this system.
+        warnings.warn(
+            """WARNING: cython required to generate fast c code is not found on this system.
 Only slow pure python alternative functions will be available.
 To use fast implementation of some functions writen in cython either:
 a) install cython and re-run the installation,
 b) try alternative source distribution containing cythonized C versions of fast code,
-c) use binary distribution (i.e. wheels, egg).""")
+c) use binary distribution (i.e. wheels, egg)."""
+        )
         return []
 
 
@@ -79,11 +85,11 @@ def no_cythonize(extensions):
         sources = []
         for sfile in extension.sources:
             path, ext = os.path.splitext(sfile)
-            if ext in ('.pyx', '.py'):
-                if extension.language == 'c++':
-                    ext = '.cpp'
+            if ext in (".pyx", ".py"):
+                if extension.language == "c++":
+                    ext = ".cpp"
                 else:
-                    ext = '.c'
+                    ext = ".c"
                 sfile = path + ext
             sources.append(sfile)
         extension.sources[:] = sources
@@ -103,24 +109,28 @@ assert isinstance(compiler, distutils.ccompiler.CCompiler)
 distutils.sysconfig.customize_compiler(compiler)
 try:
     compiler.compile(
-        [os.path.join(setup_path, 'rsciio', 'tests', 'bruker_data',
-                      'test_compilers.c')])
+        [os.path.join(setup_path, "rsciio", "tests", "bruker_data", "test_compilers.c")]
+    )
 except (CompileError, DistutilsPlatformError):
-    warnings.warn("""WARNING: C compiler can't be found.
+    warnings.warn(
+        """WARNING: C compiler can't be found.
 Only slow pure python alternative functions will be available.
 To use fast implementation of some functions writen in cython/c either:
 a) check that you have compiler (EXACTLY SAME as your python
 distribution was compiled with) installed,
 b) use binary distribution of hyperspy (i.e. wheels, egg, (only osx and win)).
-Installation will continue in 5 sec...""")
+Installation will continue in 5 sec..."""
+    )
     extensions = []
     from time import sleep
+
     sleep(5)  # wait 5 secs for user to notice the message
 
 
 class Recythonize(Command):
 
     """cythonize all extensions"""
+
     description = "(re-)cythonize all changed cython extensions"
 
     user_options = []
@@ -136,38 +146,46 @@ class Recythonize(Command):
     def run(self):
         # if there is no cython it is supposed to fail:
         from Cython.Build import cythonize
+
         global raw_extensions
         global extensions
         cythonize(extensions)
 
 
 install_requires = [
-    'dask[array]>=2.11',
-    'h5py>=2.3',
-    'imageio',
-    'numba>=0.52',
-    'numpy>=1.17.1',
-    'pint>=0.8',
-    'python-box>=6.0',
-    'pyyaml',
-    'scipy>=1.1',
-    'sparse',
+    "dask[array]>=2.11",
+    "h5py>=2.3",
+    "imageio",
+    "numba>=0.52",
+    "numpy>=1.17.1",
+    "pint>=0.8",
+    "python-box>=6.0",
+    "pyyaml",
+    "scipy>=1.1",
+    "sparse",
 ]
 
 extras_require = {
-    "mrcz": ["blosc>=1.5", 'mrcz>=0.3.6'],
+    "mrcz": ["blosc>=1.5", "mrcz>=0.3.6"],
     "scalebar_export": ["matplotlib>=3.1.3"],
     "tiff": ["tifffile>=2020.2.16", "imagecodecs>=2020.1.31"],
-    "tests": ["pytest>=3.6", "pytest-xdist", "pytest-rerunfailures", "pytest-cov"],  # for testing
+    "tests": [
+        "pytest>=3.6",
+        "pytest-xdist",
+        "pytest-rerunfailures",
+        "pytest-cov",
+    ],  # for testing
     "docs": ["pydata-sphinx-theme", "sphinxcontrib-towncrier"],  # for building the docs
 }
 
 # Don't include "tests" and "docs" requirements since "all" is designed to be
 # used for user installation.
-runtime_extras_require = {x: extras_require[x] for x in extras_require.keys()
-                          if x not in ["tests", "coverage", "build-doc"]}
-extras_require["all"] = list(itertools.chain(*list(
-    runtime_extras_require.values())))
+runtime_extras_require = {
+    x: extras_require[x]
+    for x in extras_require.keys()
+    if x not in ["tests", "coverage", "build-doc"]
+}
+extras_require["all"] = list(itertools.chain(*list(runtime_extras_require.values())))
 
 extras_require["dev"] = list(itertools.chain(*list(extras_require.values())))
 
@@ -187,8 +205,7 @@ setup(
     # There are some restrictions on what makes a valid project name
     # specification here:
     # https://packaging.python.org/specifications/core-metadata/#name
-    name='RosettaSciIO',  # Required
-
+    name="RosettaSciIO",  # Required
     # Versions should comply with PEP 440:
     # https://www.python.org/dev/peps/pep-0440/
     #
@@ -196,12 +213,10 @@ setup(
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
     version=__version__,  # Required
-
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
-    description='Scientific file formats',  # Optional
-
+    description="Scientific file formats",  # Optional
     # This is an optional longer description of your project that represents
     # the body of text which users will see when they visit PyPI.
     #
@@ -211,7 +226,6 @@ setup(
     # This field corresponds to the "Description" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#description-optional
     long_description=long_description,  # Optional
-
     # Denotes that our long_description is in Markdown; valid values are
     # text/plain, text/x-rst, and text/markdown
     #
@@ -222,22 +236,18 @@ setup(
     #
     # This field corresponds to the "Description-Content-Type" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#description-content-type-optional
-    long_description_content_type='text/markdown',  # Optional (see note above)
-
+    long_description_content_type="text/markdown",  # Optional (see note above)
     # This should be a valid link to your project's main homepage.
     #
     # This field corresponds to the "Home-Page" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#home-page-optional
-    url='https://github.com/hyperspy/rosettasciio',  # Optional
-
+    url="https://github.com/hyperspy/rosettasciio",  # Optional
     # This should be your name or the name of the organization which owns the
     # project.
-    author='The HyperSpy Develoopers',  # Optional
-
+    author="The HyperSpy Develoopers",  # Optional
     # This should be a valid email address corresponding to the author listed
     # above.
     # author_email='pypa-dev@googlegroups.com',  # Optional
-
     # Classifiers help users find your project by categorizing it.
     #
     # For a list of valid classifiers, see https://pypi.org/classifiers/
@@ -246,32 +256,27 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
-
+        "Development Status :: 3 - Alpha",
         # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Build Tools",
         # Pick your license as you wish
-        'License :: OSI Approved :: MIT License',
-
+        "License :: OSI Approved :: MIT License",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         # These classifiers are *not* checked by 'pip install'. See instead
         # 'python_requires' below.
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
-
     # This field adds keywords for your project which will appear on the
     # project page. What does your project relate to?
     #
     # Note that this is a string of words separated by whitespace, not a list.
-    keywords='IO scientific format',  # Optional
-
+    keywords="IO scientific format",  # Optional
     # You can just specify package directories manually here if your project is
     # simple. Or you can use find_packages().
     #
@@ -281,19 +286,17 @@ setup(
     #
     #   py_modules=["my_module"],
     #
-
     ext_modules=extensions,  # For Cython code
     cmdclass={
-        'recythonize': Recythonize, },
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),  # Required
-
+        "recythonize": Recythonize,
+    },
+    packages=find_packages(exclude=["contrib", "docs", "tests"]),  # Required
     # Specify which Python versions you support. In contrast to the
     # 'Programming Language' classifiers above, 'pip install' will check this
     # and refuse to install the project if the version does not match. If you
     # do not support Python 2, you can simplify this to '>=3.5' or similar, see
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.6, <4',
-
+    python_requires=">=3.6, <4",
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is
     # installed, so they must be valid existing projects.
@@ -301,7 +304,6 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=install_requires,  # Optional
-
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"
     # syntax, for example:
@@ -311,7 +313,6 @@ setup(
     # Similar to `install_requires` above, these must be valid existing
     # projects.
     extras_require=extras_require,
-
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     #
@@ -319,60 +320,58 @@ setup(
     # MANIFEST.in as well.
     package_data={
         "rsciio": [
-            'tests/blockfile_data/*.blo',
-            'tests/dens_data/*.dens',
-            'tests/dm_stackbuilder_plugin/test_stackbuilder_imagestack.dm3',
-            'tests/dm3_1D_data/*.dm3',
-            'tests/dm3_2D_data/*.dm3',
-            'tests/dm3_3D_data/*.dm3',
-            'tests/dm4_1D_data/*.dm4',
-            'tests/dm4_2D_data/*.dm4',
-            'tests/dm4_3D_data/*.dm4',
-            'tests/dm3_locale/*.dm3',
-            'tests/FEI_new/*.emi',
-            'tests/FEI_new/*.ser',
-            'tests/FEI_old/*.emi',
-            'tests/FEI_old/*.ser',
-            'tests/FEI_old/*.npy',
-            'tests/FEI_old/*.tar.gz',
-            'tests/impulse_data/*.csv',
-            'tests/impulse_data/*.log',
-            'tests/impulse_data/*.npy',
-            'tests/msa_files/*.msa',
-            'tests/hdf5_files/*.hdf5',
-            'tests/hdf5_files/*.hspy',
-            'tests/JEOL_files/*',
-            'tests/JEOL_files/Sample/00_View000/*',
-            'tests/JEOL_files/InvalidFrame/*',
-            'tests/JEOL_files/InvalidFrame/Sample/00_Dummy-Data/*',
-            'tests/tiff_files/*.zip',
-            'tests/tiff_files/*.tif',
-            'tests/tiff_files/*.tif.gz',
-            'tests/tiff_files/*.dm3',
-            'tests/tvips_files/*.tvips',
-            'tests/npz_files/*.npz',
-            'tests/unf_files/*.unf',
-            'tests/bruker_data/*.bcf',
-            'tests/bruker_data/*.json',
-            'tests/bruker_data/*.npy',
-            'tests/bruker_data/*.spx',
-            'tests/ripple_files/*.rpl',
-            'tests/ripple_files/*.raw',
-            'tests/emd_files/*.emd',
-            'tests/emd_files/fei_emd_files.zip',
-            'tests/protochips_data/*.npy',
-            'tests/protochips_data/*.csv',
-            'tests/nexus_files/*.nxs',
+            "tests/blockfile_data/*.blo",
+            "tests/dens_data/*.dens",
+            "tests/dm_stackbuilder_plugin/test_stackbuilder_imagestack.dm3",
+            "tests/dm3_1D_data/*.dm3",
+            "tests/dm3_2D_data/*.dm3",
+            "tests/dm3_3D_data/*.dm3",
+            "tests/dm4_1D_data/*.dm4",
+            "tests/dm4_2D_data/*.dm4",
+            "tests/dm4_3D_data/*.dm4",
+            "tests/dm3_locale/*.dm3",
+            "tests/FEI_new/*.emi",
+            "tests/FEI_new/*.ser",
+            "tests/FEI_old/*.emi",
+            "tests/FEI_old/*.ser",
+            "tests/FEI_old/*.npy",
+            "tests/FEI_old/*.tar.gz",
+            "tests/impulse_data/*.csv",
+            "tests/impulse_data/*.log",
+            "tests/impulse_data/*.npy",
+            "tests/msa_files/*.msa",
+            "tests/hdf5_files/*.hdf5",
+            "tests/hdf5_files/*.hspy",
+            "tests/JEOL_files/*",
+            "tests/JEOL_files/Sample/00_View000/*",
+            "tests/JEOL_files/InvalidFrame/*",
+            "tests/JEOL_files/InvalidFrame/Sample/00_Dummy-Data/*",
+            "tests/tiff_files/*.zip",
+            "tests/tiff_files/*.tif",
+            "tests/tiff_files/*.tif.gz",
+            "tests/tiff_files/*.dm3",
+            "tests/tvips_files/*.tvips",
+            "tests/npz_files/*.npz",
+            "tests/unf_files/*.unf",
+            "tests/bruker_data/*.bcf",
+            "tests/bruker_data/*.json",
+            "tests/bruker_data/*.npy",
+            "tests/bruker_data/*.spx",
+            "tests/ripple_files/*.rpl",
+            "tests/ripple_files/*.raw",
+            "tests/emd_files/*.emd",
+            "tests/emd_files/fei_emd_files.zip",
+            "tests/protochips_data/*.npy",
+            "tests/protochips_data/*.csv",
+            "tests/nexus_files/*.nxs",
         ]
-        },
-
+    },
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # https://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
     #
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
     # data_files=[('my_data', ['data/data_file'])],  # Optional
-
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # `pip` to create the appropriate form of executable for the target
@@ -385,7 +384,6 @@ setup(
     #         'sample=sample:main',
     #     ],
     # },
-
     # List additional URLs that are relevant to your project as a dict.
     #
     # This field corresponds to the "Project-URL" metadata fields:
@@ -396,9 +394,9 @@ setup(
     # maintainers, and where to support the project financially. The key is
     # what's used to render the link text on PyPI.
     project_urls={  # Optional
-        'Bug Reports': 'https://github.com/hyperspy/rosettasciio/issues',
+        "Bug Reports": "https://github.com/hyperspy/rosettasciio/issues",
         # 'Funding': 'https://donate.pypi.org',
         # 'Say Thanks!': 'https://saythanks.io/to/example',
-        'Source': 'https://github.com/hyperspy/rosettasciio/',
+        "Source": "https://github.com/hyperspy/rosettasciio/",
     },
 )


### PR DESCRIPTION
### Description of the change
With all relevant PRs having been dealt with in the course of the split, I think it is a good occasion to enforce black formatting for the repo.

Used the `black` command to reformat all `.py` files.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add black lint test to PR-actions
- [na] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [na] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.
