### PR TITLE
Remove deprecation Bruker, EMD, Nexus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,20 +8,6 @@ https://rosettasciio.readthedocs.io/en/latest/changes.html
 
 .. towncrier release notes start
 
-API Removal
------------
-
-Following the deprecation cycle announced in `HyperSpy
-<https://hyperspy.org/hyperspy-doc/current/user_guide/changes.html>`_,
-the following keywords and attributes have been removed:
-
-- :ref:`Bruker composite file (BCF) <bcf-format>`: The 'spectrum' option for the
-  `select_type` parameter was removed. Use 'spectrum_image' instead.
-- :ref:`Electron Microscopy Dataset (EMD) NCEM <emd_ncem-format>`: Using the
-  keyword 'dataset_name' was removed, use 'dataset_path' instead.
-- :ref:`NeXus data format <nexus-format>`: The `dataset_keys`, `dataset_paths`
-  and `metadata_keys` keywords were removed. Use `dataset_key`, `dataset_path`
-  and `metadata_key` instead.
 
 Initiation (2022-07-23)
 =======================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,9 @@ https://rosettasciio.readthedocs.io/en/latest/changes.html
 API Removal
 -----------
 
-Following the deprecation cycle, the following keywords and attributes have been
-removed:
+Following the deprecation cycle announced in `HyperSpy
+<https://hyperspy.org/hyperspy-doc/current/user_guide/changes.html>`_,
+the following keywords and attributes have been removed:
 
 - :ref:`Bruker composite file (BCF) <bcf-format>`: The 'spectrum' option for the
   `select_type` parameter was removed. Use 'spectrum_image' instead.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,20 @@ https://rosettasciio.readthedocs.io/en/latest/changes.html
 
 .. towncrier release notes start
 
+API Removal
+-----------
+
+Following the deprecation cycle, the following keywords and attributes have been
+removed:
+
+- :ref:`Bruker composite file (BCF) <bcf-format>`: The 'spectrum' option for the
+  `select_type` parameter was removed. Use 'spectrum_image' instead.
+- :ref:`Electron Microscopy Dataset (EMD) NCEM <emd_ncem-format>`: Using the
+  keyword 'dataset_name' was removed, use 'dataset_path' instead.
+- :ref:`NeXus data format <nexus-format>`: The `dataset_keys`, `dataset_paths`
+  and `metadata_keys` keywords were removed. Use `dataset_key`, `dataset_path`
+  and `metadata_key` instead.
+
 Initiation (2022-07-23)
 =======================
 

--- a/docs/supported_formats/bruker.rst
+++ b/docs/supported_formats/bruker.rst
@@ -25,8 +25,8 @@ currently supported by RosettaSciIO.
 Extra loading arguments
 +++++++++++++++++++++++
 
-- ``select_type`` : one of (None, 'spectrum', 'image'). If specified, only the
-  corresponding type of data, either spectrum or image, is returned.
+- ``select_type`` : one of (None, 'spectrum_image', 'image'). If specified, only
+  the corresponding type of data, either spectrum image or image, is returned.
   By default (None), all data are loaded.
 - ``index`` : one of (None, int, "all"). Allow to select the index of the dataset
   in the ``.bcf`` file, which can contains several datasets. Default None value
@@ -55,7 +55,7 @@ Example of loading reduced (downsampled, and with energy range cropped)
 
 .. code-block:: python
 
-    >>> hs.load("sample80kv.bcf", select_type='spectrum', downsample=2, cutoff_at_kV=10)
+    >>> hs.load("sample80kv.bcf", select_type='spectrum_image', downsample=2, cutoff_at_kV=10)
     <EDSSEMSpectrum, title: EDX, dimensions: (50, 38|595)>
 
 load the same file with limiting array size to SEM acceleration voltage:

--- a/docs/supported_formats/emd.rst
+++ b/docs/supported_formats/emd.rst
@@ -29,12 +29,12 @@ Extra loading arguments
   See the ``chunks`` arguments of the ``hspy`` file format for more details.
 
 
-For files containing several datasets, the `dataset_name` argument can be
+For files containing several datasets, the `dataset_path` argument can be
 used to select a specific one:
 
 .. code-block:: python
 
-    >>> s = hs.load("adatafile.emd", dataset_name="/experimental/science_data_1/data")
+    >>> s = hs.load("adatafile.emd", dataset_path="/experimental/science_data_1/data")
 
 
 Or several by using a list:
@@ -42,7 +42,7 @@ Or several by using a list:
 .. code-block:: python
 
     >>> s = hs.load("adatafile.emd",
-    ...             dataset_name=[
+    ...             dataset_path=[
     ...                 "/experimental/science_data_1/data",
     ...                 "/experimental/science_data_2/data"])
 

--- a/rsciio/bruker/api.py
+++ b/rsciio/bruker/api.py
@@ -44,8 +44,6 @@ import dask.delayed as dd
 import dask.array as da
 import numpy as np
 
-from rsciio.exceptions import VisibleDeprecationWarning
-
 
 _logger = logging.getLogger(__name__)
 
@@ -1336,14 +1334,6 @@ def bcf_reader(
 
     # objectified bcf file:
     obj_bcf = BCF_reader(filename, instrument=instrument)
-    if select_type == "spectrum":
-        select_type = "spectrum_image"
-        msg = (
-            "The 'spectrum' option for the `select_type` parameter is "
-            "deprecated and will be removed in v2.0. Use 'spectrum_image' "
-            "instead."
-        )
-        warnings.warn(msg, VisibleDeprecationWarning)
     if select_type == "image":
         return bcf_images(obj_bcf)
     elif select_type == "spectrum_image":

--- a/rsciio/emd/api.py
+++ b/rsciio/emd/api.py
@@ -39,7 +39,6 @@ import dask.array as da
 from dateutil import tz
 
 from rsciio.utils.tools import _UREG, DTBox
-from rsciio.exceptions import VisibleDeprecationWarning
 from rsciio.utils.elements import atomic_number2name
 import rsciio.utils.fei_stream_readers as stream_readers
 from rsciio._hierarchical import get_signal_chunks
@@ -1547,14 +1546,6 @@ def file_reader(filename, lazy=False, **kwds):
             emd_reader.read_file(file)
         elif is_EMD_NCEM(file):
             _logger.debug("EMD file is a Berkeley variant.")
-            dataset_name = kwds.pop("dataset_name", None)
-            if dataset_name is not None:
-                msg = (
-                    "Using 'dataset_name' is deprecated and will be removed "
-                    "in HyperSpy 2.0, use 'dataset_path' instead."
-                )
-                warnings.warn(msg, VisibleDeprecationWarning)
-                dataset_path = f"{dataset_name}/data"
             dataset_path = kwds.pop("dataset_path", None)
             stack_group = kwds.pop("stack_group", None)
             emd_reader = EMD_NCEM(**kwds)

--- a/rsciio/nexus/api.py
+++ b/rsciio/nexus/api.py
@@ -18,7 +18,6 @@
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 #
 import logging
-import warnings
 import os
 
 import dask.array as da
@@ -26,7 +25,6 @@ import h5py
 import numpy as np
 import pprint
 
-from rsciio.exceptions import VisibleDeprecationWarning
 from rsciio._hierarchical import get_signal_chunks
 from rsciio.hspy.api import overwrite_dataset
 from rsciio.utils.tools import DTBox
@@ -504,27 +502,6 @@ def file_reader(
     learning = {}
     fin = h5py.File(filename, "r")
     signal_dict_list = []
-
-    if "dataset_keys" in kwds:
-        warnings.warn(
-            "The `dataset_keys` keyword is deprecated. " "Use `dataset_key` instead.",
-            VisibleDeprecationWarning,
-        )
-        dataset_key = kwds["dataset_keys"]
-
-    if "dataset_paths" in kwds:
-        warnings.warn(
-            "The `dataset_paths` keyword is deprecated. " "Use `dataset_path` instead.",
-            VisibleDeprecationWarning,
-        )
-        dataset_path = kwds["dataset_paths"]
-
-    if "metadata_keys" in kwds:
-        warnings.warn(
-            "The `metadata_keys` keyword is deprecated. " "Use `metadata_key` instead.",
-            VisibleDeprecationWarning,
-        )
-        metadata_key = kwds["metadata_keys"]
 
     dataset_key = _check_search_keys(dataset_key)
     dataset_path = _check_search_keys(dataset_path)

--- a/rsciio/tests/test_bruker.py
+++ b/rsciio/tests/test_bruker.py
@@ -4,8 +4,6 @@ import os
 import numpy as np
 import pytest
 
-from rsciio.exceptions import VisibleDeprecationWarning
-
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
 from hyperspy.misc.test_utils import assert_deep_almost_equal
@@ -90,8 +88,6 @@ def test_hyperspy_wrap():
     filename = os.path.join(my_path, "bruker_data", test_files[0])
     print("testing bcf wrap to hyperspy signal...")
 
-    with pytest.warns(VisibleDeprecationWarning):
-        hype = hs.load(filename, select_type="spectrum")
     hype = hs.load(filename, select_type="spectrum_image")
     np.testing.assert_allclose(hype.axes_manager[0].scale, 1.66740910949362, atol=1e-12)
     np.testing.assert_allclose(hype.axes_manager[1].scale, 1.66740910949362, atol=1e-12)

--- a/rsciio/tests/test_emd.py
+++ b/rsciio/tests/test_emd.py
@@ -173,11 +173,6 @@ class TestDatasetName:
                 dataset_path=[self.dataset_path_list[0], "a_wrong_name"],
             )
 
-    def test_deprecated_dataset_name(self):
-        with pytest.warns(UserWarning):
-            dataset_name = os.path.dirname(self.dataset_path_list[0])
-            hs.load(self.hdf5_dataset_path, dataset_name=dataset_name)
-
 
 def test_minimal_save():
     signal = hs.signals.Signal1D([0, 1])

--- a/rsciio/tests/test_nexus_hdf.py
+++ b/rsciio/tests/test_nexus_hdf.py
@@ -26,7 +26,7 @@ hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 import traits.api as t
 import h5py
 
-from hyperspy.exceptions import VisibleDeprecationWarning as VisibleDeprecationWarning
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 from rsciio.nexus.api import (
     _byte_to_string,

--- a/rsciio/tests/test_nexus_hdf.py
+++ b/rsciio/tests/test_nexus_hdf.py
@@ -26,9 +26,8 @@ hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 import traits.api as t
 import h5py
 
-from hyperspy.exceptions import VisibleDeprecationWarning as HSVisibleDeprecationWarning
+from hyperspy.exceptions import VisibleDeprecationWarning as VisibleDeprecationWarning
 
-from rsciio.exceptions import VisibleDeprecationWarning
 from rsciio.nexus.api import (
     _byte_to_string,
     _fix_exclusion_keys,
@@ -134,17 +133,6 @@ class TestDLSNexus:
         with pytest.raises(AttributeError):
             s.original_metadata.entry1.instrument.stage1_x.value_set.value
 
-    def test_deprecated_metadata_keys(self):
-        with pytest.warns(VisibleDeprecationWarning):
-            _ = hs.load(self.file, metadata_keys="stage1_x")
-
-    def test_deprecated_dataset_keys(self):
-        with pytest.warns(VisibleDeprecationWarning):
-            _ = hs.load(self.file, dataset_keys="rocks")
-
-    def test_deprecated_dataset_paths(self):
-        with pytest.warns(VisibleDeprecationWarning):
-            _ = hs.load(self.file, dataset_paths="/entry1/testdata/nexustest/data")
 
 
 class TestDLSNexusNoAxes:
@@ -194,7 +182,7 @@ class TestDLSNexusNoAxes:
 
 class TestSavedSignalLoad:
     def setup_method(self, method):
-        with pytest.warns(HSVisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             self.s = hs.load(file1, nxdata_only=True)
 
     def test_string(self):
@@ -225,7 +213,7 @@ class TestSavedSignalLoad:
 
 class TestSavedMultiSignalLoad:
     def setup_method(self, method):
-        with pytest.warns(HSVisibleDeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             self.s = hs.load(
                 file2, nxdata_only=True, hardlinks_only=True, use_default=False
             )
@@ -455,19 +443,19 @@ def test_saving_multi_signals(tmp_path):
 
 
 def test_read_file2_dataset_key_test():
-    with pytest.warns(HSVisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning):
         s = hs.load(file2, nxdata_only=True, dataset_key=["rocks"])
     assert not isinstance(s, list)
 
 
 def test_read_file2_signal1():
-    with pytest.warns(HSVisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning):
         s = hs.load(file2, nxdata_only=True, dataset_key=["rocks"])
     assert s.metadata.General.title == "rocks"
 
 
 def test_read_file2_default():
-    with pytest.warns(HSVisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning):
         s = hs.load(
             file2,
             use_default=False,
@@ -476,7 +464,7 @@ def test_read_file2_default():
             dataset_key=["unnamed__1"],
         )
     assert s.metadata.General.title == "unnamed__1"
-    with pytest.warns(HSVisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning):
         s = hs.load(
             file2,
             use_default=True,
@@ -488,7 +476,7 @@ def test_read_file2_default():
 
 
 def test_read_file2_metadata_keys():
-    with pytest.warns(HSVisibleDeprecationWarning):
+    with pytest.warns(VisibleDeprecationWarning):
         s = hs.load(
             file2, nxdata_only=True, dataset_key=["rocks"], metadata_key=["energy"]
         )

--- a/rsciio/tests/test_nexus_hdf.py
+++ b/rsciio/tests/test_nexus_hdf.py
@@ -134,7 +134,6 @@ class TestDLSNexus:
             s.original_metadata.entry1.instrument.stage1_x.value_set.value
 
 
-
 class TestDLSNexusNoAxes:
     def setup_method(self, method):
         self.file = file4

--- a/upcoming_changes/30.maintenance.rst
+++ b/upcoming_changes/30.maintenance.rst
@@ -1,0 +1,11 @@
+Following the deprecation cycle announced in `HyperSpy
+<https://hyperspy.org/hyperspy-doc/current/user_guide/changes.html>`_,
+the following keywords and attributes have been removed:
+
+  - :ref:`Bruker composite file (BCF) <bcf-format>`: The 'spectrum' option for the
+    `select_type` parameter was removed. Use 'spectrum_image' instead.
+  - :ref:`Electron Microscopy Dataset (EMD) NCEM <emd_ncem-format>`: Using the
+    keyword 'dataset_name' was removed, use 'dataset_path' instead.
+  - :ref:`NeXus data format <nexus-format>`: The `dataset_keys`, `dataset_paths`
+    and `metadata_keys` keywords were removed. Use `dataset_key`, `dataset_path`
+    and `metadata_key` instead.


### PR DESCRIPTION
### Description of the change
Remove deprecated keywords and attributes from readers before first release (which will be the one used by HyperSpy 2.0, for which these deprecations were announced).

Closes #24

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] update user guide (if appropriate),
- [X] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [X] remove tests,
- [X] ready for review.
