### PR TITLE
Fix MSA signaltype

### DIFF
--- a/docs/supported_formats/msa.rst
+++ b/docs/supported_formats/msa.rst
@@ -7,7 +7,8 @@ The ``.msa`` format is an `open standard format
 <https://www.microscopy.org/resources/scientific_data/index.cfm>`_
 widely used to exchange single spectrum data, but does not support
 multidimensional data. It can for example be used to exchange single spectra
-with Gatan's Digital Micrograph.
+with Gatan's Digital Micrograph or other software packages. A wide range of
+programs supports exporting to and reading from the ``.msa`` format.
 
 .. WARNING::
     If several spectra are loaded and stacked (``hs.load('pattern', stack_signals=True``)

--- a/rsciio/msa/api.py
+++ b/rsciio/msa/api.py
@@ -287,7 +287,7 @@ def parse_msa_string(string, filename=None):
             mapped.set_item("Signal.signal_type", "EELS")
         elif parameters["SIGNALTYPE"] == "CLS":
             mapped.set_item("Signal.signal_type", "CL")
-        else:
+        else:  # pragma: no cover
             if parameters["SIGNALTYPE"] not in [
                 "EDS",
                 "WDS",

--- a/rsciio/msa/api.py
+++ b/rsciio/msa/api.py
@@ -20,6 +20,7 @@ from datetime import datetime as dt
 import codecs
 import os
 import logging
+import warnings
 from turtle import dot
 
 import numpy as np
@@ -66,7 +67,7 @@ keywords = {
     "OFFSET": {"dtype": float, "mapped_to": None},
     # Optional parameters
     # Signal1D characteristics
-    "SIGNALTYPE": {"dtype": str, "mapped_to": "Signal.signal_type"},
+    "SIGNALTYPE": {"dtype": str, "mapped_to": None},
     "XLABEL": {"dtype": str, "mapped_to": None},
     "YLABEL": {"dtype": str, "mapped_to": None},
     "XUNITS": {"dtype": str, "mapped_to": None},
@@ -281,14 +282,28 @@ def parse_msa_string(string, filename=None):
     if filename is not None:
         mapped.set_item("General.original_filename", os.path.split(filename)[1])
     mapped.set_item("Signal.record_by", "spectrum")
-    if mapped.has_item("Signal.signal_type"):
-        if mapped.Signal.signal_type == "ELS":
-            mapped.Signal.signal_type = "EELS"
-        if mapped.Signal.signal_type in ["EDX", "XEDS"]:
-            mapped.Signal.signal_type = "EDS"
+    if "SIGNALTYPE" in parameters and parameters["SIGNALTYPE"]:
+        if parameters["SIGNALTYPE"] == "ELS":
+            mapped.set_item("Signal.signal_type", "EELS")
+        elif parameters["SIGNALTYPE"] == "CLS":
+            mapped.set_item("Signal.signal_type", "CL")
+        else:
+            if parameters["SIGNALTYPE"] not in [
+                "EDS",
+                "WDS",
+                "AES",
+                "PES",
+                "XRF",
+                "GAM",
+            ]:
+                warnings.warn(
+                    """SIGNALTYPE does not correspond to any of the valid strings
+                    according to the MSA file format definition."""
+                )
+            mapped.set_item("Signal.signal_type", parameters["SIGNALTYPE"])
     else:
-        # Defaulting to EELS looks reasonable
-        mapped.set_item("Signal.signal_type", "EELS")
+        # Defaults to empty signal type, which is Signal1D for HyperSpy
+        mapped.set_item("Signal.signal_type", "")
     if "YUNITS" in parameters.keys():
         yunits = "(%s)" % parameters["YUNITS"]
     else:
@@ -350,6 +365,25 @@ def file_writer(filename, signal, format=None, separator=", ", encoding="latin-1
         if "General.item" in md:
             time = dt.strptime(md.General.time, "%H:%M:%S")
             loc_kwds["TIME"] = time.strftime("%H:%M")
+    if md.Signal.signal_type in ["EDS_SEM", "EDS_TEM"]:
+        loc_kwds["SIGNALTYPE"] = "EDS"
+    elif md.Signal.signal_type in ["EELS"]:
+        loc_kwds["SIGNALTYPE"] = "ELS"
+    elif md.Signal.signal_type in ["CL", "CL_SEM", "CL_STEM"]:
+        loc_kwds["SIGNALTYPE"] = "CLS"
+    elif md.Signal.signal_type not in [
+        "EDS",
+        "WDS",
+        "ELS",
+        "AES",
+        "PES",
+        "XRF",
+        "CLS",
+        "GAM",
+    ]:
+        loc_kwds["SIGNALTYPE"] = ""
+    else:
+        loc_kwds["SIGNALTYPE"] = md.Signal.signal_type
     keys_from_signal = {
         # Required parameters
         "FORMAT": FORMAT,
@@ -361,7 +395,7 @@ def file_writer(filename, signal, format=None, separator=", ", encoding="latin-1
         "NPOINTS": signal["axes"][0]["size"],
         "NCOLUMNS": 1,
         "DATATYPE": format,
-        "SIGNALTYPE": md.Signal.signal_type,
+        "SIGNALTYPE": "",
         "XPERCHAN": signal["axes"][0]["scale"],
         "OFFSET": signal["axes"][0]["offset"],
         # Signal1D characteristics

--- a/rsciio/tests/msa_files/minimum_metadata.msa
+++ b/rsciio/tests/msa_files/minimum_metadata.msa
@@ -14,5 +14,5 @@
 #XUNITS      : 
 #COMMENT     : File created by HyperSpy version 1.1.2+dev
 #SPECTRUM    : Spectral Data Starts Here
-0.000000, 
+0.000000, 1.0
 #ENDOFDATA   : End Of Data and File

--- a/rsciio/tests/test_msa.py
+++ b/rsciio/tests/test_msa.py
@@ -379,3 +379,48 @@ class TestExample2:
 def test_minimum_metadata_example():
     s = hs.load(os.path.join(my_path, "msa_files", "minimum_metadata.msa"))
     assert minimum_md_om == s.original_metadata.as_dictionary()
+
+
+class TestSignalType:
+    def setup_method(self, method):
+        self.s = hs.load(os.path.join(my_path, "msa_files", "minimum_metadata.msa"))
+        # delete timestamp from metadata since it's runtime dependent
+        del self.s.metadata.General.FileIO.Number_0.timestamp
+
+    @pytest.mark.parametrize(
+        "signaltype", ("EDS_SEM", "EDS_TEM", "CL", "EELS", "PES", "brian")
+    )
+    def test_write_minimum_metadata_signaltype(self, signaltype):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname2 = os.path.join(tmpdir, "example-min-export.msa")
+            self.s.metadata.Signal.signal_type = signaltype
+            self.s.save(fname2)
+            s2 = hs.load(fname2)
+            if "EDS" in signaltype:
+                assert s2.original_metadata["SIGNALTYPE"] == "EDS"
+            elif signaltype == "CL":
+                assert s2.original_metadata["SIGNALTYPE"] == "CLS"
+            elif signaltype == "EELS":
+                assert s2.original_metadata["SIGNALTYPE"] == "ELS"
+            elif signaltype not in [
+                "EDS",
+                "WDS",
+                "ELS",
+                "AES",
+                "PES",
+                "XRF",
+                "CLS",
+                "GAM",
+            ]:
+                assert s2.original_metadata["SIGNALTYPE"] == ""
+            else:
+                assert s2.original_metadata["SIGNALTYPE"] in [
+                    "EDS",
+                    "WDS",
+                    "ELS",
+                    "AES",
+                    "PES",
+                    "XRF",
+                    "CLS",
+                    "GAM",
+                ]

--- a/upcoming_changes/39.bugfix.rst
+++ b/upcoming_changes/39.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that the ``.msa`` plugin handles ``SIGNALTYPE`` values according to the official format specification.


### PR DESCRIPTION
### Description of the change
As brought up in #37, the current implementation of the MSA writer does not comply to the format definitions according to
https://the-mas.org/wp-content/uploads/2018/11/emmff_ascii.txt

In particular, HyperSpy `signal_types` where written to MSA 1:1, even if they deviate from the allowed strings according to the format definition.

This PR correctly converts HyperSpy signal strings to the corresponding MSA ones when writing. On the reading side, the resulting `signal_types` don't necessarily correspond to the HyperSpy ones. Correct conversion to signal types of HypersSpy has to be done on the HyperSpy/LumiSpy side (e.g. choosing which voltage corresponds to SEM or TEM) as proposed in #37.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
s = hs.load("rosettasciio/rsciio/tests/msa_files/minimum_metadata.msa")
s.metadata.Signal.signal_type = "EDS_SEM"
s.save("tmp.msa")
s2 = hs.load("tmp.msa")
```
Note that this example can be useful to update the user guide.

