### PR TITLE
Revert tests/build to hyperspy next_major branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,7 @@ jobs:
 
       - name: Install HyperSpy (dev)
         run: |
-          #pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
-          # Remove once https://github.com/hyperspy/hyperspy/pull/3009 is merged
-          pip install https://github.com/jlaehne/hyperspy/archive/refs/heads/rsciio-format-alias.zip
+          pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
 
       - name: Test distribution
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,9 +74,7 @@ jobs:
         if: "!contains(matrix.LABEL, 'wo-hyperspy')"
         # Need to install hyperspy dev until hyperspy 2.0 is released
         run: |
-          #pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
-          # Remove once https://github.com/hyperspy/hyperspy/pull/3009 is merged
-          pip install https://github.com/jlaehne/hyperspy/archive/refs/heads/rsciio-format-alias.zip
+          pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
 
       - name: Pip list
         run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,9 +76,7 @@ steps:
 # Need to install hyperspy dev until hyperspy 2.0 is released
 - bash: |
     source activate $ENV_NAME
-    #pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
-    # Remove once https://github.com/hyperspy/hyperspy/pull/3009 is merged
-    pip install https://github.com/jlaehne/hyperspy/archive/refs/heads/rsciio-format-alias.zip
+    pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
     conda list
   displayName: Install (HyperSpy dev)
 


### PR DESCRIPTION
Follow up to #35

Reactivating the hyperspy next_major branch for tests and build