### PR TITLE
Add drone CI to test `arm64`/`aarch64` platform

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,22 @@
+kind: pipeline
+name: test on arm64
+
+platform:
+  arch: arm64
+
+steps:
+- name: test
+  image: quay.io/condaforge/mambaforge:latest
+  environment:
+    MATPLOTLIB: agg
+  commands:
+    - lscpu
+    # Update with rosettasciio once it is available on conda-forge
+    # For now use hyperspy package to install dependencies
+    - mamba install hyperspy-base --only-deps
+    - mamba install imagecodecs mrcz pyusid
+    - mamba install pytest pytest-xdist
+    # We need hyperspy dev branch for testing
+    - pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
+    - pip install -e .
+    - pytest -n 4

--- a/rsciio/msa/api.py
+++ b/rsciio/msa/api.py
@@ -21,7 +21,6 @@ import codecs
 import os
 import logging
 import warnings
-from turtle import dot
 
 import numpy as np
 

--- a/upcoming_changes/42.maintenance.rst
+++ b/upcoming_changes/42.maintenance.rst
@@ -1,0 +1,1 @@
+Add drone CI to test on ``arm64``/``aarch64`` platform


### PR DESCRIPTION
For now, this is set to run only on push, not pull request, as there is only one concurrent build and with hyperspy, it was very slow. As the test suite here is faster, we may consider running on pull request too in the future.

https://cloud.drone.io/hyperspy/rosettasciio

### Progress of the PR
- [x] Add drone CI configuration,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [ ] ready for review.


