### PR TITLE
Fix failing test following hyperspy API deprecation removal

### DIFF
--- a/rsciio/tests/test_nexus_hdf.py
+++ b/rsciio/tests/test_nexus_hdf.py
@@ -342,16 +342,6 @@ class TestSavingMetadataContainers:
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
         s.original_metadata.set_item("testarray3", np.array([1, 2, 3, 4, 5]))
 
-        with pytest.warns(
-            UserWarning, match="Setting the `original_metadata` attribute"
-        ):
-            s.original_metadata = s.original_metadata.as_dictionary()
-        with pytest.warns(UserWarning, match="Setting the `metadata` attribute"):
-            s.metadata = s.metadata.as_dictionary()
-
-        assert isinstance(s.metadata, DictionaryTreeBrowser)
-        assert isinstance(s.original_metadata, DictionaryTreeBrowser)
-
         fname = tmp_path / "test.nxs"
         s.save(fname)
         lin = hs.load(fname, nxdata_only=True)


### PR DESCRIPTION
### Progress of the PR
- [x] Remove code which test hyperspy `as_dictionary` method but not the nexus plugin,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


