### PR TITLE
duplicate label in contributing guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,8 +40,6 @@ other member of the development team before being merged.
 
 .. _defining-plugins:
 
-.. _defining-plugins:
-
 Defining new RosettaSciIO plugins
 =================================
 


### PR DESCRIPTION
remove duplicate label