### PR TITLE
Fix error when reading pts file with frame_list, frame_start_index (was PR #67)

### DIFF
--- a/rsciio/jeol/api.py
+++ b/rsciio/jeol/api.py
@@ -63,15 +63,13 @@ def file_reader(filename, **kwargs):
 
 def _read_asw(filename, **kwargs):
     image_list = []
-    fd = open(filename, "br")
-    file_magic = np.fromfile(fd, "<I", 1)[0]
-    if file_magic != 0:
-        _logger.warning("Not a valid JEOL asw format")
-        fd.close()
-        return []
-    fd.seek(12)
-    filetree = _parsejeol(fd)
-    fd.close()
+    with open(filename, "br") as fd:
+        file_magic = np.fromfile(fd, "<I", 1)[0]
+        if file_magic != 0:
+            raise ValueError(f"Not a valid JEOL asw format '{filename}'")
+        fd.seek(12)
+        filetree = _parsejeol(fd)
+
     filepath, filen = os.path.split(os.path.abspath(filename))
     if "SampleInfo" in filetree.keys():
         for i in filetree["SampleInfo"].keys():
@@ -109,82 +107,77 @@ def _read_img(filename, **kwargs):
         (Always len(image_list) == 1)
     """
 
-    fd = open(filename, "br")
-    file_magic = np.fromfile(fd, "<I", 1)[0]
-    if file_magic == 52:
+    with open(filename, "br") as fd:
+        file_magic = np.fromfile(fd, "<I", 1)[0]
+        if file_magic != 52:
+            _logger.warning(f"Not a valid JEOL img format '{filename}'")
+            return []
+
         # fileformat
         _ = _decode(fd.read(32).rstrip(b"\x00"))
         head_pos, head_len, data_pos = np.fromfile(fd, "<I", 3)
         fd.seek(data_pos + 12)
         header_long = _parsejeol(fd)
-        width, height = header_long["Image"]["Size"]
-        header_long["Image"]["Bits"].resize((height, width))
-        data = header_long["Image"]["Bits"]
 
-        scale = (
-            header_long["Instrument"]["ScanSize"]
-            / header_long["Instrument"]["Mag"]
-            * 1.0e3
-        )
-        xscale = scale / width
-        yscale = scale / height
-        units = "µm"
+    width, height = header_long["Image"]["Size"]
+    header_long["Image"]["Bits"].resize((height, width))
+    data = header_long["Image"]["Bits"]
 
-        axes = [
-            {
-                "name": "y",
-                "size": height,
-                "offset": 0,
-                "scale": yscale,
-                "units": units,
-            },
-            {
-                "name": "x",
-                "size": width,
-                "offset": 0,
-                "scale": xscale,
-                "units": units,
-            },
-        ]
+    scale = (
+        header_long["Instrument"]["ScanSize"] / header_long["Instrument"]["Mag"] * 1.0e3
+    )
+    xscale = scale / width
+    yscale = scale / height
+    units = "µm"
 
-        datefile = datetime(1899, 12, 30) + timedelta(
-            days=header_long["Image"]["Created"]
-        )
-        hv = header_long["Instrument"]["AccV"]
-        if hv <= 30.0:
-            mode = "SEM"
-        else:
-            mode = "TEM"
+    axes = [
+        {
+            "name": "y",
+            "size": height,
+            "offset": 0,
+            "scale": yscale,
+            "units": units,
+        },
+        {
+            "name": "x",
+            "size": width,
+            "offset": 0,
+            "scale": xscale,
+            "units": units,
+        },
+    ]
 
-        metadata = {
-            "Acquisition_instrument": {
-                mode: {
-                    "beam_energy": hv,
-                    "magnification": header_long["Instrument"]["Mag"],
-                },
-            },
-            "General": {
-                "original_filename": os.path.basename(filename),
-                "date": datefile.date().isoformat(),
-                "time": datefile.time().isoformat(),
-                "title": header_long["Image"]["Title"],
-            },
-            "Signal": {
-                "record_by": "image",
-            },
-        }
-
-        dictionary = {
-            "data": data,
-            "axes": axes,
-            "metadata": metadata,
-            "original_metadata": header_long,
-        }
+    datefile = datetime(1899, 12, 30) + timedelta(days=header_long["Image"]["Created"])
+    hv = header_long["Instrument"]["AccV"]
+    if hv <= 30.0:
+        mode = "SEM"
     else:
-        _logger.warning("Not a valid JEOL img format")
+        mode = "TEM"
 
-    fd.close()
+    metadata = {
+        "Acquisition_instrument": {
+            mode: {
+                "beam_energy": hv,
+                "magnification": header_long["Instrument"]["Mag"],
+            },
+        },
+        "General": {
+            "original_filename": os.path.basename(filename),
+            "date": datefile.date().isoformat(),
+            "time": datefile.time().isoformat(),
+            "title": header_long["Image"]["Title"],
+        },
+        "Signal": {
+            "record_by": "image",
+        },
+    }
 
+    dictionary = {
+        "data": data,
+        "axes": axes,
+        "metadata": metadata,
+        "original_metadata": header_long,
+    }
     return [dictionary]
 
 
@@ -246,18 +239,20 @@ def _read_pts(
         The dictionary used to create the signals, list of dictionaries of
         spectrum image and SEM/STEM image if read_em_image == True
     """
-    fd = open(filename, "br")
-    file_magic = np.fromfile(fd, "<I", 1)[0]
 
-    def check_multiple(factor, number, string):
+    def _check_divisor(factor, number, string):
         if factor > 1 and number % factor != 0:
-            fd.close()
-            raise ValueError(f"`{string}` must be a multiple of {number}.")
+            raise ValueError(f"`{string}`({factor}) must be a divisor of {number}.")
 
-    check_multiple(rebin_energy, 4096, "rebin_energy")
+    _check_divisor(rebin_energy, 4096, "rebin_energy")
     rebin_energy = int(rebin_energy)
 
-    if file_magic == 304:
+    with open(filename, "br") as fd:
+        file_magic = np.fromfile(fd, "<I", 1)[0]
+        if file_magic != 304:
+            _logger.warning(f"Not a valid JEOL pts format '{filename}'")
+            return []
+
         # fileformat
         _ = _decode(fd.read(8).rstrip(b"\x00"))
         a, b, head_pos, head_len, data_pos, data_len = np.fromfile(fd, "<I", 6)
@@ -280,15 +275,15 @@ def _read_pts(
                 )
             downsample_width = downsample[0]
             downsample_height = downsample[1]
-            check_multiple(downsample_width, width, "downsample[0]")
-            check_multiple(downsample_height, height, "downsample[1]")
+            _check_divisor(downsample_width, width, "downsample[0]")
+            _check_divisor(downsample_height, height, "downsample[1]")
         else:
             downsample_width = downsample_height = int(downsample)
-            check_multiple(downsample_width, width, "downsample")
-            check_multiple(downsample_height, height, "downsample")
+            _check_divisor(downsample_width, width, "downsample")
+            _check_divisor(downsample_height, height, "downsample")
 
-        check_multiple(downsample_width, width, "downsample[0]")
-        check_multiple(downsample_height, height, "downsample[1]")
+        _check_divisor(downsample_width, width, "downsample[0]")
+        _check_divisor(downsample_height, height, "downsample[1]")
 
         # Normalisation factor for the x and y position in the stream; depends
         # on the downsampling and the size of the navigation space
@@ -303,7 +298,6 @@ def _read_pts(
         fd.seek(data_pos)
         # read spectrum image
         rawdata = np.fromfile(fd, dtype="u2")
-        fd.close()
 
         scale = (
             header["PTTD Param"]["Params"]["PARAMPAGE0_SEM"]["ScanSize"]
@@ -334,8 +328,6 @@ def _read_pts(
         # Sweep value is not reliable, so +1 frame is needed if sum_frames = False
         # priority of the length of frame_start_index is higher than "sweep" in header
         sweep = meas_data_header["Doc"]["Sweep"]
-        if frame_start_index:
-            sweep = len(frame_start_index)
 
         auto_frame_list = False
         if frame_list:
@@ -369,7 +361,7 @@ def _read_pts(
 
         if len(wrong_frames_list) > 0:
             wrong_frames = wrong_frames_list.flatten().tolist()
-            _logger.info(
+            _logger.warning(
                 f"Invalid frame number is specified. The frame {wrong_frames} is not found in pts data."
             )
 
@@ -378,6 +370,7 @@ def _read_pts(
 
         if frame_start_index is None:
             frame_start_index = np.full(max_frame, -1, dtype=np.int32)
+            frame_start_index[0] = 0
         else:
             frame_start_index = np.asarray(frame_start_index)
 
@@ -389,11 +382,14 @@ def _read_pts(
 
         if frame_shifts is None:
             frame_shifts = np.zeros((max_frame, 3), dtype=np.int16)
-        if len(frame_shifts) < max_frame:
-            fs = np.zeros((max_frame, 3), dtype=np.int16)
-            if len(frame_shifts) > 0:
-                fs[0 : len(frame_shifts), 0 : len(frame_shifts[0])] = frame_shifts
-            frame_shifts = fs
+
+        # always False
+        # if len(frame_shifts) < max_frame:
+        #    fs = np.zeros((max_frame, 3), dtype=np.int16)
+        #    if len(frame_shifts) > 0:
+        #        fs[0 : len(frame_shifts), 0 : len(frame_shifts[0])] = frame_shifts
+        #    frame_shifts = fs
+
         if len(frame_shifts[0]) == 2:  # fill z with 0
             fr = np.zeros((max_frame, 3), dtype=np.int16)
             fr[: len(frame_shifts), 0:2] = np.asarray(frame_shifts)
@@ -552,10 +548,6 @@ def _read_pts(
                 },
             )
         return image_list
-    else:
-        _logger.warning("Not a valid JEOL pts format")
-        fd.close()
-        return []
 
 
 def _parsejeol(fd):
@@ -739,6 +731,7 @@ def _readcube(
     frame_shifts -= max_shift
     width += sxyz[1]
     height += sxyz[0]
+    valid = None
 
     if lazy:
         readframe = _readframe_lazy
@@ -750,19 +743,21 @@ def _readcube(
     target_frame_num = 0
     has_em_image = False
     for frame_idx in frame_list:
-        if frame_idx < 0:
+        if frame_idx < 0:  # skip invalid frame number
             continue
-        elif frame_start_index[frame_idx] >= 0:
-            # if frame_idx is already indexed
-            p_start = frame_start_index[frame_idx]
-        elif frame_num < frame_idx and frame_start_index[frame_num] < 0:
+
+        # find the last indexed frame
+        _i = frame_idx
+        while _i > 0 and frame_start_index[_i] < 0:
+            _i -= 1
+        p_start = frame_start_index[_i]
+        frame_num = _i
+
+        while frame_num < frame_idx:
             # record start point of frame and skip frame
-            frame_start_index[frame_num] = p_start
             p_start += _readframe_dummy(rawdata[p_start:])
             frame_num += 1
-            continue
-        else:
-            frame_start_index[frame_idx] = p_start  # = end of last frame
+            frame_start_index[frame_num] = p_start
 
         if frame_idx < frame_shifts.size:
             fs = frame_shifts[frame_idx]
@@ -822,6 +817,9 @@ def _readcube(
             break
 
         p_start += length
+        if frame_num < frame_start_index.size:
+            frame_start_index[frame_num] = p_start
+
     if not lazy:
         if sum_frames:
             # the first frame has integrated intensity
@@ -915,7 +913,7 @@ def _readframe_dense(
     dy,
     dz,
     max_value,
-):  # pragma: nocover
+):  # pragma: no cover
     """
     Read one frame from pts file. Used in a inner loop of _readcube function.
     This function always read SEM/STEM image even if read_em_image == False

--- a/rsciio/jeol/api.py
+++ b/rsciio/jeol/api.py
@@ -89,6 +89,17 @@ def _read_asw(filename, **kwargs):
                                 d["original_metadata"]["asw"] = filetree
                                 d["original_metadata"]["asw_viewdata"] = node2
                                 image_list.append(d)
+                    else:
+                        _logger.warning(
+                            f"{filename} : SampleInfo[{i}].ViewInfo[{j}] does not have ViewData section."
+                        )
+            else:
+                _logger.warning(
+                    f"{filename} : SampleInfo[{i}] does not have ViewInfo section."
+                )
+    else:
+        _logger.warning(f"{filename} does not have SampleInfo section.")
+
     return image_list
 
 

--- a/rsciio/tests/test_jeol.py
+++ b/rsciio/tests/test_jeol.py
@@ -517,7 +517,6 @@ def test_pts_frame_shift():
             assert d2[frame] == d0[frame]
 
     # test frame shift with default values (no energy shift)
-    # s0 = hs.load(file, frame_list=[0, 1, 2], sum_frames=False, only_valid_data=False)
     sfts = np.array([[1, 2], [10, 3]])
     max_sfts = sfts.max(axis=0)
     min_sfts = sfts.min(axis=0)

--- a/rsciio/tests/test_jeol.py
+++ b/rsciio/tests/test_jeol.py
@@ -580,6 +580,36 @@ def test_seq_eds_files():
         assert isinstance(s[1], hs.signals.EDSTEMSpectrum)
         assert isinstance(s[2], hs.signals.EDSTEMSpectrum)
 
+        # test with broken asw file
+        fname = Path(tmpdir) / "1" / "1.ASW"
+        fname2 = Path(tmpdir) / "1" / "2.ASW"
+        with open(fname, "rb") as f:
+            data = bytearray(f.read())
+
+        # No ViewData
+        data2 = data.copy()
+        data2[0x42D] = 0x30
+        with open(fname2, "wb") as f:
+            f.write(data2)
+        dat = hs.load(fname2)
+        assert len(dat) == 0
+
+        # No ViewInfo
+        data2 = data.copy()
+        data2[0x1AD] = 0x30
+        with open(fname2, "wb") as f:
+            f.write(data2)
+        dat = hs.load(fname2)
+        assert len(dat) == 0
+
+        # No SampleInfo
+        data2 = data.copy()
+        data2[0x6E] = 0x30
+        with open(fname2, "wb") as f:
+            f.write(data2)
+        dat = hs.load(fname2)
+        assert len(dat) == 0
+
         # test read for pseudo SEM eds/img data
         sub_dir = Path(tmpdir) / "1" / "Sample" / "00_View002"
         test_files = ["View002_0000000.img", "View002_0000001.eds"]
@@ -676,5 +706,7 @@ def test_frame_start_index():
             data[0x1117] = 0x41
         with open(test_file, "wb") as f:
             f.write(data)
-            s = hs.load(test_file, downsample=[32, 32], rebin_energy=512, SI_dtype=np.int32)
+            s = hs.load(
+                test_file, downsample=[32, 32], rebin_energy=512, SI_dtype=np.int32
+            )
         assert s.metadata["Signal"]["signal_type"] == "EDS_SEM"

--- a/rsciio/tests/test_jeol.py
+++ b/rsciio/tests/test_jeol.py
@@ -179,7 +179,7 @@ def test_load_datacube_rebin_energy():
 
     np.testing.assert_allclose(s2_sum.data[11:12], ref_data.data.sum())
 
-    with pytest.raises(ValueError, match="must be a multiple"):
+    with pytest.raises(ValueError, match="must be a divisor"):
         _ = hs.load(filename, rebin_energy=10)
 
 
@@ -217,18 +217,24 @@ def test_load_datacube_downsample():
 
     np.testing.assert_allclose(s_sum.data, s2_sum.data)
 
-    with pytest.raises(ValueError, match="must be a multiple"):
+    with pytest.raises(ValueError, match="must be a divisor"):
         _ = hs.load(filename, downsample=10)[-1]
+
+    with pytest.raises(
+        ValueError,
+        match="`downsample` can't be an iterable of length different from 2.",
+    ):
+        _ = hs.load(filename, downsample=[2, 2, 2])[-1]
 
     downsample = [8, 16]
     s = hs.load(filename, downsample=downsample)[-1]
     assert s.axes_manager["x"].size * downsample[0] == 512
     assert s.axes_manager["y"].size * downsample[1] == 512
 
-    with pytest.raises(ValueError, match="must be a multiple"):
+    with pytest.raises(ValueError, match="must be a divisor"):
         _ = hs.load(filename, downsample=[256, 100])[-1]
 
-    with pytest.raises(ValueError, match="must be a multiple"):
+    with pytest.raises(ValueError, match="must be a divisor"):
         _ = hs.load(filename, downsample=[100, 256])[-1]
 
 
@@ -510,16 +516,37 @@ def test_pts_frame_shift():
             d2[frame] = dt[frame, pos[1], pos[0], pos[2]]
             assert d2[frame] == d0[frame]
 
+    # test frame shift with default values (no energy shift)
+    # s0 = hs.load(file, frame_list=[0, 1, 2], sum_frames=False, only_valid_data=False)
+    sfts = np.array([[1, 2], [10, 3]])
+    max_sfts = sfts.max(axis=0)
+    min_sfts = sfts.min(axis=0)
+    fs = sfts - max_sfts
+    s = hs.load(file, frame_shifts=sfts, sum_frames=False, only_valid_data=False)
+    sz = min_sfts - max_sfts + ref[0].data.shape[1:3]
+    assert s.data.shape == (2, sz[0], sz[1], 4096)
+    for fr, sft in enumerate(fs):
+        assert np.array_equal(
+            s.data[fr, 20 + sft[0] : 30 + sft[0], 20 + sft[1] : 30 + sft[1], 106],
+            ref[0].data[fr, 20:30, 20:30, 106],
+        )
+
 
 def test_broken_files():
-    TEST_BROKEN_FILES = ["test.asw", "test.pts"]
+    TEST_BROKEN_FILES = ["test.asw", "test.pts", "test.img"]
     with tempfile.TemporaryDirectory() as tmpdir:
         for _file in TEST_BROKEN_FILES:
             file = Path(tmpdir) / _file
             with open(file, "w") as fd:
                 fd.write("aaaaaaaa")
-            s = hs.load(file)
-            assert s == []
+            if file.suffix == ".asw":
+                # in case of asw, valid data can not be obtained
+                with pytest.raises(ValueError, match="Not a valid JEOL asw format"):
+                    _ = hs.load(file)
+            else:
+                # just skipping broken files
+                s = hs.load(file)
+                assert s == []
 
 
 def test_seq_eds_files():
@@ -551,3 +578,64 @@ def test_seq_eds_files():
                 assert viewdata["Memo"] == memo[i]
             assert isinstance(s[1], hs.signals.EDSTEMSpectrum)
             assert isinstance(s[2], hs.signals.EDSTEMSpectrum)
+
+
+def test_frame_start_index():
+    file = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[7]
+    frame_start_index_ref = [
+        0,
+        49660,
+        98602,
+        147633,
+        196414,
+        245078,
+        294263,
+        343283,
+        392081,
+        441310,
+        490126,
+        539395,
+        588409,
+        637523,
+        686084,
+    ]
+
+    ref = hs.load(
+        file, sum_frames=False, downsample=[32, 32], rebin_energy=512, SI_dtype=np.int32
+    )
+    frame_start_index = ref.original_metadata.jeol_pts_frame_start_index
+    assert np.array_equal(frame_start_index, frame_start_index_ref)
+
+    s = hs.load(
+        file,
+        frame_list=[2, 5],
+        downsample=[32, 32],
+        rebin_energy=512,
+        SI_dtype=np.int32,
+    )
+    frame_start_index = s.original_metadata.jeol_pts_frame_start_index
+    assert np.array_equal(frame_start_index[0:6], frame_start_index_ref[0:6])
+    assert np.all(frame_start_index[6:] == -1)
+
+    s = hs.load(
+        file,
+        frame_list=[4, 9],
+        frame_start_index=frame_start_index,
+        downsample=[32, 32],
+        rebin_energy=512,
+        SI_dtype=np.int32,
+    )
+    frame_start_index = s.original_metadata.jeol_pts_frame_start_index
+    assert np.array_equal(frame_start_index[0:10], frame_start_index_ref[0:10])
+    assert np.all(frame_start_index[10:] == -1)
+
+    s = hs.load(
+        file,
+        frame_list=[11, 5, 20],
+        sum_frames=False,
+        frame_start_index=frame_start_index,
+        downsample=[32, 32],
+        rebin_energy=512,
+        SI_dtype=np.int32,
+    )
+    assert s.data.shape == (2, 16, 16, 8)

--- a/upcoming_changes/68.bugfix.rst
+++ b/upcoming_changes/68.bugfix.rst
@@ -1,0 +1,3 @@
+Fix error when reading JEOL .pts file with un-ordered frame list or when length of ``frame_start_index`` is smaller than the sweep count
+
+


### PR DESCRIPTION
### Description of the change

- Bugfix : error when reading JEOL .pts file with un-ordered frame list
- Bugfix : error when length of frame_start_index is smaller than sweep count
- Revise warning message
- Add test for frame list, frame_shift and frame_start_index
- Add test for broken asw file
- Add test for SEM data 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```import hyperspy.api as hs
s = hs.load("file.pts", frame_list=[1,3])
frame_start_index = s.original_metadata.jeol_pts_frame_start_index
s = hs.load("file.pts", frame_list=[5,2], frame_start_index=frame_start_index)
```

