### PR TITLE
Remove persistent search field in left sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *pyd
 .spyproject/*
 rsciio/bruker/unbcf_fast.c
+.idea

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,19 +89,6 @@ html_theme_options = {
 }
 
 
-# If you’re hosting your documentation on ReadTheDocs, you should consider
-# adding an explicit placement for their ethical advertisements. These are
-# non-tracking advertisements from ethical companies, and they help
-# ReadTheDocs sustain themselves and their free service.
-#
-# Ethical advertisements are added to your sidebar by default. To ensure
-# they are there if you manually update your sidebar, ensure that the
-# sidebar-ethical-ads.html template is added to your list. For example:
-
-html_sidebars = {
-    "**": ["search-field.html", "sidebar-nav-bs.html", "sidebar-ethical-ads.html"]
-}
-
 # -- Options for towncrier_draft extension -----------------------------------
 
 # Options: draft/sphinx-version/sphinx-release

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,9 @@ extras_require = {
     "docs": [
         "pydata-sphinx-theme",
         "sphinxcontrib-towncrier",
+        # TODO: Remove explicit dependency on sphinx when pydata-sphinx-theme >= 0.13
+        #  is available, and 0.13 as minimial supported version of pydata-sphinx-theme
+        "sphinx~=5.3",
         # pin towncrier until https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/60 is fixed
         "towncrier<22.8",
     ],  # for building the docs

--- a/upcoming_changes/84.doc.rst
+++ b/upcoming_changes/84.doc.rst
@@ -1,1 +1,2 @@
 Remove persistent search field in left sidebar since this makes finding the sidebar on narrow screens difficult.
+Set maximal major version of Sphinx to 5.

--- a/upcoming_changes/84.doc.rst
+++ b/upcoming_changes/84.doc.rst
@@ -1,0 +1,1 @@
+Remove persistent search field in left sidebar since this makes finding the sidebar on narrow screens difficult.


### PR DESCRIPTION
### Description of the change
This PR removes the persistent search field in the left sidebar. Having both the search field in the left sidebar *and* the search button in the navbar is not recommended by the PyData Sphinx Theme creators ([their reasoning](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/search.html#configure-the-search-field-position)).

Another option is to remove the search button and have the persistent search field in the left sidebar only.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.