### PR TITLE
Add (optional) code style check before commits (w/pre-commit + Black)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 /dist/*
 /RosettaSciIO.egg-info/*
 *__pycache__*
-*test_compilers.obj
+*test_compilers.o
 *pyd
 .spyproject/*
-rsciio/bruker/unbcf_fast.c
 .idea
+rsciio/bruker/unbcf_fast.c
+rsciio/bruker/*.so
+rsciio/bruker/*.pyd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    # Version can be updated by running "pre-commit autoupdate"
+    rev: 23.1.0
+    hooks:
+    -   id: black

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,9 @@ runtime_extras_require = {
 }
 extras_require["all"] = list(itertools.chain(*list(runtime_extras_require.values())))
 
-extras_require["dev"] = list(itertools.chain(*list(extras_require.values())))
+extras_require["dev"] = [
+    "black",
+] + list(itertools.chain(*list(extras_require.values())))
 
 
 # Arguments marked as "Required" below must be included for upload to PyPI.

--- a/upcoming_changes/86.maintenance.rst
+++ b/upcoming_changes/86.maintenance.rst
@@ -1,0 +1,2 @@
+Add black as a development dependency.
+Add pre-commit configuration file with black code style check, which when installed will require changes to pass a style check before commiting.


### PR DESCRIPTION
### Description of the change
I've added an option for developers to run a code style check before commiting with git (a git hook), using [pre-commit](https://pre-commit.com/) and Black (see Black's [Version control integration page](https://black.readthedocs.io/en/stable/integrations/source_version_control.html)). These are added to the development dependencies.

The "Lint" GitHub check in this repo uses the (latest) stable version of Black to check changes. pre-commit requires specific versions of software used in their git hooks ([reasoning here](https://pre-commit.com/#using-the-latest-version-for-a-repository)). I set it to the latest, v23.1.0, however the "Lint" check and the pre-commit version might become out of sync at some point. When that happens, a pre-commit config update can be run with `pre-commit autoupdate` (and the updated config file must be pushed to `main`).

The use of this optional code style check should be added to the contributing guide. However, I noticed that in the relevant section, RosettaSciIO's contributing refers to HyperSpy's contributing guide. Should I add a brief explanation below this reference, or should all this be done in HyperSpy as well?

Also updated .gitignore to fix #85.

### Progress of the PR
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] Update contributing guide
- [ ] ready for review.