### PR TITLE
Fix exporting scalebar with reciprocal units containing space

### DIFF
--- a/rsciio/image/_api.py
+++ b/rsciio/image/_api.py
@@ -179,8 +179,13 @@ def file_writer(
             if units is None:
                 units = "px"
                 scalebar_kwds["dimension"] = "pixel-length"
-            if _UREG.Quantity(units).check("1/[length]"):
-                scalebar_kwds["dimension"] = "si-length-reciprocal"
+            else:
+                units = _UREG.Quantity(units)
+                if units.check("1/[length]"):
+                    scalebar_kwds["dimension"] = "si-length-reciprocal"
+                # Standard formatting of units to avoid issue with
+                # matplotlib-scalebar
+                units = f"{units.units:~C}"
 
             ax.add_artist(ScaleBar(axis["scale"], units, **scalebar_kwds))
 

--- a/rsciio/tests/test_image.py
+++ b/rsciio/tests/test_image.py
@@ -100,12 +100,13 @@ def test_export_scalebar(ext, tmp_path):
     assert s.data.shape == s_reload.data.shape
 
 
-def test_export_scalebar_reciprocal(tmp_path):
+@pytest.mark.parametrize(("units"), ["1/nm", "1 / nm", "1 / nanometer", "1/nanometer"])
+def test_export_scalebar_reciprocal(tmp_path, units):
     hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
     pixels = 512
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     for axis in s.axes_manager.signal_axes:
-        axis.units = "1/nm"
+        axis.units = units
         axis.scale = 0.1
 
     filename = tmp_path / "test_scalebar_export.jpg"

--- a/upcoming_changes/90.bugfix.rst
+++ b/upcoming_changes/90.bugfix.rst
@@ -1,0 +1,1 @@
+Fix exporting scalebar with reciprocal units containing space


### PR DESCRIPTION

### Progress of the PR
- [x] Fix formatting units when exporting scalebar,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.BaseSignal(np.arange(512*512).reshape((512, 512)))
for ax in s.axes_manager.signal_axes:
    ax.units = "1 /nm"
s.save('test.jpg', scalebar=True)
```

