### PR TITLE
Bugfix for  Issue #101 (failing tests after merging #100)

### DIFF
--- a/rsciio/tiff/_api.py
+++ b/rsciio/tiff/_api.py
@@ -540,15 +540,17 @@ def _is_jeol_sightx(op) -> bool:
 
 def _axes_jeol_sightx(tiff, op, shape, names):
     # convert xml text to dictionary of tiff op['ImageDescription']
-    # convert_xml_to_dict need to remove white spaces before decoding XML
-    scales, offsets, units = _axes_defaults()
+    import xml.etree.ElementTree as ET
+    from rsciio.utils.tools import XmlToDict
+    from box import Box
 
+    scales, offsets, units = _axes_defaults()
     jeol_xml = "".join(
         [line.strip(" \r\n\t\x01\x00") for line in op["ImageDescription"].split("\n")]
     )
-    from rsciio.utils.tools import convert_xml_to_dict
-
-    jeol_dict = convert_xml_to_dict(jeol_xml)
+    jeol_xml_obj = ET.fromstring(jeol_xml)
+    xml_to_dict = XmlToDict()
+    jeol_dict = Box(xml_to_dict.dictionarize(jeol_xml_obj))
     op["ImageDescription"] = jeol_dict["TemReporter"]
     eos = op["ImageDescription"]["Eos"]["EosMode"]
     illumi = op["ImageDescription"]["IlluminationSystem"]

--- a/upcoming_changes/101.bugfix.rst
+++ b/upcoming_changes/101.bugfix.rst
@@ -1,0 +1,1 @@
+For more robust xml to dict conversion, convert_xml_to_dict is replaced by XmlToDict (introduced by PR #111).


### PR DESCRIPTION
### Description of the change
- xml name space in JEOL SightX tiff is rewritten with '_'.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```pytest tests/test_tiff
```

