### PR TITLE
Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           # test oldest supported version of main dependencies on python 3.8
           - os: ubuntu
             PYTHON_VERSION: '3.8'
-            # Set pillow and scikit-image version to be compatible imageio and scipy
+            # Set pillow and scikit-image version to be compatible with imageio and scipy
             DEPENDENCIES: matplotlib==3.1.3 numpy==1.20.0 scipy==1.4.0 imagecodecs==2020.1.31 tifffile==2020.2.16 dask==2.11.0 distributed==2.11.0 numba==0.52 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0
             LABEL: '-oldest'
           # test minimum requirement

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ jobs:
           # test oldest supported version of main dependencies on python 3.8
           - os: ubuntu
             PYTHON_VERSION: '3.8'
-            DEPENDENCIES: matplotlib==3.1.3 numpy==1.20.0 scipy==1.1 imagecodecs==2020.1.31 tifffile==2020.2.16 dask==2.11.0 distributed==2.11.0 numba==0.52 imageio==2.16 pillow==8.3.2
+            # Set pillow and scikit-image version to be compatible imageio and scipy
+            DEPENDENCIES: matplotlib==3.1.3 numpy==1.20.0 scipy==1.4.0 imagecodecs==2020.1.31 tifffile==2020.2.16 dask==2.11.0 distributed==2.11.0 numba==0.52 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0
             LABEL: '-oldest'
           # test minimum requirement
           - os: ubuntu
@@ -67,16 +68,16 @@ jobs:
         run: |
           pip install numba --pre
 
+      - name: Install oldest supported version
+        if: contains(matrix.LABEL, 'oldest')
+        run: |
+          pip install ${{ matrix.DEPENDENCIES }}
+
       - name: Install (HyperSpy dev)
         if: "!contains(matrix.LABEL, 'wo-hyperspy')"
         # Need to install hyperspy dev until hyperspy 2.0 is released
         run: |
           pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
-
-      - name: Install oldest supported version
-        if: contains(matrix.LABEL, 'oldest')
-        run: |
-          pip install ${{ matrix.DEPENDENCIES }}
 
       - name: Install
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,28 +13,28 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        PYTHON_VERSION: ['3.8', '3.9']
+        PYTHON_VERSION: ['3.9', '3.10']
         LABEL: ['']
         include:
-          # test oldest supported version of main dependencies on python 3.6
+          # test oldest supported version of main dependencies on python 3.8
           - os: ubuntu
-            PYTHON_VERSION: '3.7'
+            PYTHON_VERSION: '3.8'
             DEPENDENCIES: matplotlib==3.1.3 numpy==1.20.0 scipy==1.1 imagecodecs==2020.1.31 tifffile==2020.2.16 dask==2.11.0 distributed==2.11.0 numba==0.52 imageio==2.16 pillow==8.3.2
             LABEL: '-oldest'
           # test minimum requirement
           - os: ubuntu
-            PYTHON_VERSION: '3.8'
+            PYTHON_VERSION: '3.9'
             LABEL: '-minimum'
           - os: ubuntu
-            PYTHON_VERSION: '3.8'
+            PYTHON_VERSION: '3.9'
             LABEL: '-minimum-wo-hyperspy'
           - os: ubuntu
-            PYTHON_VERSION: '3.8'
+            PYTHON_VERSION: '3.9'
             LABEL: '-wo-hyperspy'
           - os: ubuntu
-            PYTHON_VERSION: '3.7'
+            PYTHON_VERSION: '3.8'
           - os: ubuntu
-            PYTHON_VERSION: '3.10'
+            PYTHON_VERSION: '3.11'
 
     steps:
       - uses: actions/checkout@v3
@@ -59,6 +59,13 @@ jobs:
         run: |
           python --version
           pip --version
+
+      - name: Install numba rc
+        if: contains(matrix.PYTHON_VERSION, '3.11')
+        # Require for python 3.11 support, remove when numba 0.57 is release
+        shell: bash
+        run: |
+          pip install numba --pre
 
       - name: Install (HyperSpy dev)
         if: "!contains(matrix.LABEL, 'wo-hyperspy')"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,25 +35,21 @@ strategy:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.8'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
-    Linux_Python37:
-      vmImage: 'ubuntu-latest'
-      PYTHON_VERSION: '3.7'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     MacOS_Python38:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.8'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
-    MacOS_Python37:
+    MacOS_Python310:
       vmImage: 'macOS-latest'
-      PYTHON_VERSION: '3.7'
+      PYTHON_VERSION: '3.10'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     Windows_Python38:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.8'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
-    Windows_Python37:
+    Windows_Python310:
       vmImage: 'windows-latest'
-      PYTHON_VERSION: '3.7'
+      PYTHON_VERSION: '3.10'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
 
 pool:

--- a/rsciio/utils/skimage_exposure.py
+++ b/rsciio/utils/skimage_exposure.py
@@ -1,9 +1,10 @@
 """skimage's `rescale_intensity` that takes and returns dask arrays.
 """
-
+from packaging.version import Version
 import warnings
 
 import numpy as np
+import skimage
 from skimage.exposure.exposure import intensity_range, _output_dtype
 
 
@@ -99,10 +100,13 @@ def rescale_intensity(image, in_range="image", out_range="dtype"):
     >>> rescale_intensity(image, out_range=(0, 127)).astype(np.int32)
     array([127, 127, 127], dtype=int32)
     """
+    args = ()
+    if Version(skimage.__version__) >= Version("0.19.0"):
+        args = (image.dtype,)
     if out_range in ["dtype", "image"]:
-        out_dtype = _output_dtype(image.dtype.type, image.dtype)
+        out_dtype = _output_dtype(image.dtype.type, *args)
     else:
-        out_dtype = _output_dtype(out_range, image.dtype)
+        out_dtype = _output_dtype(out_range, *args)
 
     imin, imax = map(float, intensity_range(image, in_range))
     omin, omax = map(

--- a/setup.py
+++ b/setup.py
@@ -161,12 +161,12 @@ install_requires = [
     "pint>=0.8",
     "python-box>=6,<7",
     "pyyaml",
-    "scipy>=1.1",
+    "scipy>=1.4.0",
     "sparse",
 ]
 
 extras_require = {
-    "blockfile": ["scikit-image"],
+    "blockfile": ["scikit-image>=0.18"],
     "mrcz": ["blosc>=1.5", "mrcz>=0.3.6"],
     "scalebar_export": ["matplotlib-scalebar", "matplotlib>=3.1.3"],
     "tiff": ["tifffile>=2020.2.16", "imagecodecs>=2020.1.31"],

--- a/setup.py
+++ b/setup.py
@@ -277,11 +277,10 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         # These classifiers are *not* checked by 'pip install'. See instead
         # 'python_requires' below.
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     # This field adds keywords for your project which will appear on the
     # project page. What does your project relate to?
@@ -307,7 +306,7 @@ setup(
     # and refuse to install the project if the version does not match. If you
     # do not support Python 2, you can simplify this to '>=3.5' or similar, see
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires=">=3.6, <4",
+    python_requires=">=3.8, <4",
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is
     # installed, so they must be valid existing projects.

--- a/upcoming_changes/109.maintenance.rst
+++ b/upcoming_changes/109.maintenance.rst
@@ -1,0 +1,1 @@
+Add explicit support for python 3.11 and drop support for python 3.7, 3.8

--- a/upcoming_changes/109.maintenance.rst
+++ b/upcoming_changes/109.maintenance.rst
@@ -1,1 +1,1 @@
-Add explicit support for python 3.11 and drop support for python 3.7, 3.8
+Add explicit support for python 3.11 and drop support for python 3.6, 3.7


### PR DESCRIPTION
### Progress of the PR
- [x] Add python 3.11 to the test build and drop python 3.6-3.7,
- [x] Bump scipy version to 1.4 - scipy supports python 3.8 since version 1.3.2 and hyperspy 2.0 branch needs scipy 1.4, use the latter for convenient of running the test suite with hyperspy
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


