### PR TITLE
move the xml_to_dict and msfiletime to datetime from bruker parser to utils.tools

### DIFF
--- a/rsciio/bruker/_api.py
+++ b/rsciio/bruker/_api.py
@@ -63,8 +63,7 @@ Falling back to slow python only backend."""
     )
 
 # create dictionizer customized to Bruker Xml streams:
-x2d = XmlToDict(pre_str_dub_attr="XmlClass",
-                tags_to_flatten=["ClassInstance"])
+x2d = XmlToDict(dub_attr_pre_str="XmlClass", tags_to_flatten="ClassInstance")
 
 
 class Container(object):
@@ -360,7 +359,7 @@ class SFS_reader(object):
                 raw_tree = temp_str.read(self.n_tree_items * 0x200)
                 temp_str.close()
             temp_item_list = [
-                SFSTreeItem(raw_tree[i * 0x200: (i + 1) * 0x200], self)
+                SFSTreeItem(raw_tree[i * 0x200 : (i + 1) * 0x200], self)
                 for i in range(self.n_tree_items)
             ]
             # temp list with parents of items

--- a/rsciio/tests/test_bruker.py
+++ b/rsciio/tests/test_bruker.py
@@ -254,7 +254,7 @@ def test_fast_bcf():
 
 
 def test_decimal_regex():
-    from rsciio.bruker._api import fix_dec_patterns
+    from rsciio.utils.tools import sanitize_msxml_float
 
     dummy_xml_positive = [
         b"<dummy_tag>85,658</dummy_tag>",
@@ -268,9 +268,9 @@ def test_decimal_regex():
         b"<dum_tag>12e1,23,-24E-5</dum_tag>",
     ]
     for i in dummy_xml_positive:
-        assert b"85.658" in fix_dec_patterns.sub(b"\\1.\\2", i)
+        assert b"85.658" in sanitize_msxml_float(i)
     for j in dummy_xml_negative:
-        assert b"." not in fix_dec_patterns.sub(b"\\1.\\2", j)
+        assert b"." not in sanitize_msxml_float(j)
 
 
 def test_all_spx_loads():

--- a/rsciio/tests/utils/ToastedBreakFastSDD.xml
+++ b/rsciio/tests/utils/ToastedBreakFastSDD.xml
@@ -21,13 +21,13 @@
           <Dim axes="width, depth, height">33.3,27.4,25.2</Dim>
           <IsCoated/>
           <IsToasted>not today</IsToasted>
-          <IsToasting>True</IsToasting>
+          <IsToasting>affirmative</IsToasting>
        </Instrument>
        <Sample name="breakfast test" number="23">With one of these components
           <Components>
             <ComponentChildren>
               <Instance name="Eggs" calories="345.2" breaking-speed="5.2"></Instance>
-              <Instance name="Bakon" calories="5000" breaking-speed="11"></Instance>
+              <Instance name="Bacon" calories="5000" breaking-speed="11"></Instance>
               <Instance name="Spam" calories="0.1" breaking-speed="24.6"></Instance>
             </ComponentChildren>
           </Components>

--- a/rsciio/tests/utils/ToastedBreakFastSDD.xml
+++ b/rsciio/tests/utils/ToastedBreakFastSDD.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestXML>
+  <Header>
+    <ShortDescription>Test XML</ShortDescription>
+    <HTMLDescription><![CDATA[This utter <i>nonsense</i> <b>XML</b> was created to check far-fetched ideas about sub-worst case of OEM-generated XML scenarios.]]></HTMLDescription>
+  </Header>
+  <Main>
+    <ClassInstance>
+       <Detector>
+          <ClassInstance>
+            <Angle>15.345</Angle>
+            <Type>SDD</Type>
+            <Model>BreakFast™</Model>
+            <PulseProcessor>FPGAv11</PulseProcessor>
+            <BufferSize units="bytes">2048</BufferSize>
+          </ClassInstance>
+       </Detector>
+       <Instrument ClassInstance="Analytical">
+          <Type class="chasis">Toaster</Type>
+          <SerialNumber>1234-5</SerialNumber>
+          <Dim axes="width, depth, height">33.3,27.4,25.2</Dim>
+          <IsCoated/>
+          <IsToasted>not today</IsToasted>
+          <IsToasting>True</IsToasting>
+       </Instrument>
+       <Sample name="breakfast test" number="23">With one of these components
+          <Components>
+            <ComponentChildren>
+              <Instance name="Eggs" calories="345.2" breaking-speed="5.2"></Instance>
+              <Instance name="Bakon" calories="5000" breaking-speed="11"></Instance>
+              <Instance name="Spam" calories="0.1" breaking-speed="24.6"></Instance>
+            </ComponentChildren>
+          </Components>
+          <Project>BreakFast</Project> SDD risks to be Toasted.
+       </Sample>
+    </ClassInstance>
+  </Main>
+</TestXML>

--- a/rsciio/tests/utils/test_utils.py
+++ b/rsciio/tests/utils/test_utils.py
@@ -72,7 +72,7 @@ def test_concat_interchild_text_val_flatten():
     )
     pynode = x2d.dictionarize(XML_TEST_NODE.find("Main"))
     assert pynode["Instrument"]["Type"].get("#value") is None
-    assert pynode["Instrument"]["type"]["#text"] == "Toaster"
+    assert pynode["Instrument"]["Type"]["#text"] == "Toaster"
     assert pynode["Sample"].get("#value") is None
     assert pynode["Sample"].get("#text") is None
     t = "With one of these componentsSDD risks to be Toasted."

--- a/rsciio/tests/utils/test_utils.py
+++ b/rsciio/tests/utils/test_utils.py
@@ -1,12 +1,21 @@
 from dateutil import parser, tz
 
+import os
 import numpy as np
 import pytest
 
-from rsciio.utils.tools import DTBox, dict2sarray
+from rsciio.utils.tools import DTBox, dict2sarray, XmlToDict, ET
 import rsciio.utils.date_time_tools as dtt
 
 dt = [("x", np.uint8), ("y", np.uint16), ("text", (bytes, 6))]
+
+MY_PATH = os.path.dirname(__file__)
+TEST_XML_PATH = os.path.join(MY_PATH, "ToastedBreakFastSDD.xml")
+
+with open(TEST_XML_PATH, 'r') as fn:
+    weird_but_valid_xml_str = fn.read()
+
+XML_TEST_NODE = ET.fromstring(weird_but_valid_xml_str)
 
 
 def _get_example(date, time, time_zone=None):

--- a/rsciio/tests/utils/test_utils.py
+++ b/rsciio/tests/utils/test_utils.py
@@ -43,9 +43,15 @@ def test_default_x2d():
     """
     x2d = XmlToDict()
     pynode = x2d.dictionarize(XML_TEST_NODE)
-    assert pynode["TestXML"]["Main"]["ClassInstance"]["Sample"]["Components"]["ComponentChildren"]["Instance"][0]["name"] == 'Eggs'
+    assert (
+        pynode["TestXML"]["Main"]["ClassInstance"]["Sample"]["Components"][
+            "ComponentChildren"
+        ]["Instance"][0]["name"]
+        == 'Eggs'
+    )
     t = "With one of these components"
     assert pynode["TestXML"]["Main"]["ClassInstance"]["Sample"]["#value"] == t
+
 
 def test_skip_interchild_text_flatten():
     """test of XmlToDict translation with interchild_text_parsing set to 'skip',
@@ -53,12 +59,11 @@ def test_skip_interchild_text_flatten():
     """
     x2d = XmlToDict(
         interchild_text_parsing='skip',
-        tags_to_flatten=["ClassInstance", "ComponentChildren", "Instance", "TestXML"]
+        tags_to_flatten=["ClassInstance", "ComponentChildren", "Instance", "TestXML"],
     )
     pynode = x2d.dictionarize(XML_TEST_NODE)
     assert pynode["Main"]["Sample"]["Components"]["name"][0] == "Eggs"
     assert pynode["Main"]["Sample"].get("#value") is None
-# fmt: on
 
 
 def test_concat_interchild_text_val_flatten():
@@ -69,7 +74,7 @@ def test_concat_interchild_text_val_flatten():
     x2d = XmlToDict(
         dub_text_str="#text",
         interchild_text_parsing='cat',
-        tags_to_flatten=["ClassInstance", "ComponentChildren", "Instance", "Main"]
+        tags_to_flatten=["ClassInstance", "ComponentChildren", "Instance", "Main"],
     )
     pynode = x2d.dictionarize(XML_TEST_NODE.find("Main"))
     assert pynode["Instrument"]["Type"].get("#value") is None
@@ -92,13 +97,14 @@ def test_list_interchild_text_val_flatten():
     assert pynode["Sample"]["#interchild_text"] == [
         "With one of these components",
         "",
-        "SDD risks to be Toasted."
+        "SDD risks to be Toasted.",
     ]
 
 
 def x2d_subclass_for_custom_bool():
     """test subclass of XmlToDict with updated eval function"""
-    class CusXmlToDict(XmlToDict):
+
+    class CustomXmlToDict(XmlToDict):
         @staticmethod
         def eval(string):
             if string == "not today":
@@ -107,9 +113,9 @@ def x2d_subclass_for_custom_bool():
                 return True
             return XmlToDict.eval(string)
 
-    x2d = CusXmlToDict(
+    x2d = CustomXmlToDict(
         dub_text_str="#value",
-        tags_to_flatten=["ClassInstance", "ComponentChildren", "Instance"]
+        tags_to_flatten=["ClassInstance", "ComponentChildren", "Instance"],
     )
     node = XML_TEST_NODE.find("Main//Instrument")
     pynode = x2d.dictionarize(node)

--- a/rsciio/tests/utils/test_utils.py
+++ b/rsciio/tests/utils/test_utils.py
@@ -94,6 +94,7 @@ def test_list_interchild_text_val_flatten():
         "SDD risks to be Toasted."
     ]
 
+
 def x2d_subclass_for_custom_bool():
     """test subclass of XmlToDict with updated eval function"""
     class CusXmlToDict(XmlToDict):
@@ -113,6 +114,17 @@ def x2d_subclass_for_custom_bool():
     pynode = x2d.dictionarize(node)
     assert pynode["IsToasted"] is False
     assert pynode["IsToasting"] is True
+
+
+def test_wrong_type_x2d_initiation():
+    with pytest.raises(ValueError):
+        XmlToDict(dub_attr_pre_str=1)
+    with pytest.raises(ValueError):
+        XmlToDict(tags_to_flatten=0)
+    with pytest.raises(ValueError):
+        XmlToDict(interchild_text_parsing="simple")
+    with pytest.raises(ValueError):
+        XmlToDict(dub_text_str=2)
 
 
 def _get_example(date, time, time_zone=None):

--- a/rsciio/tests/utils/test_utils.py
+++ b/rsciio/tests/utils/test_utils.py
@@ -18,7 +18,7 @@ with open(TEST_XML_PATH, "r") as fn:
 
 XML_TEST_NODE = ET.fromstring(weird_but_valid_xml_str)
 
-
+# fmt: off
 def test_msxml_sanitization():
     bad_msxml = b"""
     <main>
@@ -58,6 +58,7 @@ def test_skip_interchild_text_flatten():
     pynode = x2d.dictionarize(XML_TEST_NODE)
     assert pynode["Main"]["Sample"]["Components"]["name"][0] == "Eggs"
     assert pynode["Main"]["Sample"].get("#value") is None
+# fmt: on
 
 
 def test_concat_interchild_text_val_flatten():

--- a/rsciio/tests/utils/test_utils.py
+++ b/rsciio/tests/utils/test_utils.py
@@ -20,7 +20,7 @@ XML_TEST_NODE = ET.fromstring(weird_but_valid_xml_str)
 
 
 def test_msxml_sanitization():
-    bad_msxml = """
+    bad_msxml = b"""
     <main>
       <simpleFloat>0,2</simpleFloat>
       <scientificSmall>1,9E-5</scientificSmall>

--- a/rsciio/utils/date_time_tools.py
+++ b/rsciio/utils/date_time_tools.py
@@ -119,6 +119,5 @@ def msfiletime_to_unix(msfiletime):
     Returns
     -------
         datetime.datetime object"""
-    dt = datetime.datetime(1601, 1, 1) +\
-        datetime.timedelta(microseconds=msfiletime / 10)
-    return dt
+    return datetime.datetime(1601, 1, 1) + datetime.timedelta(
+        microseconds=msfiletime / 10)

--- a/rsciio/utils/date_time_tools.py
+++ b/rsciio/utils/date_time_tools.py
@@ -120,4 +120,5 @@ def msfiletime_to_unix(msfiletime):
     -------
         datetime.datetime object"""
     return datetime.datetime(1601, 1, 1) + datetime.timedelta(
-        microseconds=msfiletime / 10)
+        microseconds=msfiletime / 10
+    )

--- a/rsciio/utils/date_time_tools.py
+++ b/rsciio/utils/date_time_tools.py
@@ -106,3 +106,19 @@ def get_date_time_from_metadata(metadata, formatting="ISO"):
         res = np.datetime64(f"{date}T{time}")
 
     return res
+
+
+def msfiletime_to_unix(msfiletime):
+    """Convert microsoft's filetime to unix datetime used in python
+    built-in datetime
+    Parameters
+    ----------
+    msfiletime: 64-bit integer representing number of 10 microsecond ticks
+    from 1601
+
+    Returns
+    -------
+        datetime.datetime object"""
+    dt = datetime.datetime(1601, 1, 1) +\ 
+         datetime.timedelta(microseconds=msfiletime / 10)
+    return dt

--- a/rsciio/utils/date_time_tools.py
+++ b/rsciio/utils/date_time_tools.py
@@ -119,6 +119,6 @@ def msfiletime_to_unix(msfiletime):
     Returns
     -------
         datetime.datetime object"""
-    dt = datetime.datetime(1601, 1, 1) +\ 
-         datetime.timedelta(microseconds=msfiletime / 10)
+    dt = datetime.datetime(1601, 1, 1) +\
+        datetime.timedelta(microseconds=msfiletime / 10)
     return dt

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -185,6 +185,7 @@ def overwrite(filename):
 
 class XmlToDict:
     """Customisable XML to python dict and list based tree translator"""
+
     def __init__(
         self, dub_attr_pre_str="@", dub_text_str="#text", tags_to_flatten=None
     ):

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -195,7 +195,7 @@ class XmlToDict:
         dub_attr_pre_str="@",
         dub_text_str="#value",
         tags_to_flatten=None,
-        interchild_text_parsing="first"
+        interchild_text_parsing="first",
     ):
         """Create translator for hierarchical XML etree node into
         dict/list conversion.
@@ -339,8 +339,10 @@ class XmlToDict:
                     if self.poor_text_mode == "first":
                         d_node[et_node.tag][self.dub_text_str] = self.eval(text)
                     elif self.poor_text_mode in ("cat", "list"):
-                        tails = [str(c.tail if c.tail is not None else "").strip()
-                                 for c in children]
+                        tails = [
+                            str(c.tail if c.tail is not None else "").strip()
+                            for c in children
+                        ]
                         if any(tails):
                             inter_pieces = [text]
                             inter_pieces.extend(tails)

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -187,9 +187,12 @@ class XmlToDict:
     """Customisable XML to python dict and list based tree translator"""
 
     def __init__(
-        self, dub_attr_pre_str="@", dub_text_str="#text", tags_to_flatten=None
+        self, dub_attr_pre_str="@", dub_text_str="#value", tags_to_flatten=None,
+        interchild_text_parsing="first"
     ):
-        """create parser for XML etree node to dict/list conversion
+        """Create translator for hierarchical XML etree node into
+        dict/list conversion.
+
         Parameters for initialization
         -----------------------------
         dub_attr_pre_str: string (default: "@"), which
@@ -197,30 +200,44 @@ class XmlToDict:
             dictionary tree if children element with same name is used
         dub_text_str: string (default: "#text"), which is going to be
             used for key in case element contains text and children tag
-        tags_to_flatten: string or list of strings with tag names
-            which should be flattened/skipped, bringing children of such tag
-            one level up. It is useful when OEM generated XML are not human
-            designed, but machine/programming language generated:
+        interchild_text_parsing: string (default: "first") one from
+            ("skip", "first", "cat", "list"). This considers the
+            behaviour when both .text and children tags are presented
+            under same element tree node:
+            "skip" - will not try to retrieve any .text values from such node.
+            "first" - only string under .text attribute will be returned
+            "cat" - return concatenated string from .text of node and .tail's
+            of children nodes.
+            "list" - similar to "cat", but return the result in list
+            without concatenation.
+        tags_to_flatten: (default: None) None, string or list of strings
+            with tag names which should be flattened/skipped,
+            placing children of such tag one level shallower in constructed
+            python structure.
+            It is useful when OEM generated XML are not human designed,
+            but machine/programming language/framework generated
+            and painfully verboise. See example below:
 
-            Example:
-            by initialization of parser with "ClassInstance"
-            such overly-verbose tree (i.e. Bruker):
+        Example:
+            Consider such redundant tree structure:
 
             DetectorHeader
-            |-ClassInstance
+            |-ClassInstances
               |-ClassInstance
                 |-Type
                 |-Window
                 ...
 
-            can be sanitized to such:
+            it can be sanitized/simplified by setting tags_to_flatten keyword
+            with ["ClassInstances", "ClassInstance"] to eliminate redundant
+            levels of tree with such tag names:
 
             DetectorHeader
             |-Type
             |-Window
             ...
 
-            where produced dict/list structures are good enought to be
+            Produced dict/list structures are then good enought to be
             returned as part of original metadata without making any more
             copies.
 
@@ -234,7 +251,7 @@ class XmlToDict:
         xml_to_dict = XmlToDict(pre_str_dub_attr="XmlClass",
                                 tags_to_flatten=["ClassInstance",
                                                  "ChildrenClassInstance",
-                                                 "JustOtherPointlessNode"])
+                                                 "JustAnotherRedundantTag"])
         # use parser:
         pytree = xml_to_dict.dictionarize(etree_node)
         """
@@ -245,19 +262,25 @@ class XmlToDict:
                 "tags_to_flatten keyword accepts string or list of strings"
             )
         if not isinstance(dub_attr_pre_str, str):
-            raise ValueError("dub_attr_pre_str value is not set with string type")
+            raise ValueError("dub_attr_pre_str should be of string type")
         if not isinstance(dub_text_str, str):
-            raise ValueError("dub_text_str value is not set with string type")
+            raise ValueError("dub_text_str should be of string type")
         if isinstance(tags_to_flatten, str):
             tags_to_flatten = [tags_to_flatten]
+        if interchild_text_parsing not in ("skip", "first", "cat", "list"):
+            raise ValueError("interleaved_text_parsing should be set to the one of: "
+                             "('skip', 'first', 'cat', 'list')")
         self.tags_to_flatten = tags_to_flatten
         self.dub_attr_pre_str = dub_attr_pre_str
         self.dub_text_str = dub_text_str
+        self.poor_text_mode = interchild_text_parsing
 
     @staticmethod
-    def _eval(string):
+    def eval(string):
         """interpret any string and return casted to appropriate
-        dtype python object
+        dtype python object.
+        If this does not return desired type, consider subclassing
+        and reimplementing this method.
         """
         try:
             return literal_eval(string)
@@ -279,26 +302,31 @@ class XmlToDict:
                     dd_node[key].append(val)
             d_node = {
                 et_node.tag: {
-                    key: self._eval(val[0]) if len(val) == 1 else val
+                    key: self.eval(val[0]) if len(val) == 1 else val
                     for key, val in dd_node.items()
                 }
             }
         if et_node.attrib:
             d_node[et_node.tag].update(
-                (self.dub_attr_pre_str + key if children else key, self._eval(val))
+                (self.dub_attr_pre_str + key if children else key, self.eval(val))
                 for key, val in et_node.attrib.items()
             )
         if et_node.text:
             text = et_node.text.strip()
-            # if there are children  or attributes
-            # present and text, then text cant go directly under
-            # key, but needs to be denoted alongside the attributes
-            # or children with pre-specified str as the key:
-            if children or et_node.attrib:
-                if text:
-                    d_node[et_node.tag][self.dub_text_str] = self._eval(text)
-            else:
-                d_node[et_node.tag] = self._eval(text)
+            if text:
+                if not et_node.attrib and not children:
+                    d_node[et_node.tag] = self.eval(text)
+                elif children:
+                    if self.poor_text_mode == "first":
+                        d_node[et_node.tag][self.dub_text_str] = self.eval(text)
+                    elif self.poor_text_mode in ("cat", "list"):
+                        inter_pieces = [text]
+                        inter_pieces.extend([str(child.tail).strip() for child in children])
+                        if self.poor_text_mode == "cat":
+                            inter_pieces = " ".join(inter_pieces)
+                        d_node[et_node.tag]["#interchild_text"] = inter_pieces
+                elif et_node.attrib:
+                    d_node[et_node.tag][self.dub_text_str] = self.eval(text)
         for tag in self.tags_to_flatten:
             if tag in d_node:
                 return d_node[tag]

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -281,9 +281,9 @@ class XmlToDict:
             for dc_node in map(self.dictionarize, children):
                 for key, val in dc_node.items():
                     dd_node[key].append(val)
-            d_node[et_node.tag] = {
+            d_node = {et_node.tag: {
                 key: interpret(val[0]) if len(val) == 1 else val
-                for key, val in dd_node.items()}
+                for key, val in dd_node.items()}}
         if et_node.attrib:
             d_node[et_node.tag].update(
                 (self.pre_str_dub_attr + key if children else key,
@@ -296,8 +296,9 @@ class XmlToDict:
             # present and text, then text cant go directly under
             # key, but needs to be denoted alongside the attributes
             # or children with specified text as the key:
-            if (children or et_node.attrib) and text:
-                d_node[et_node.tag][self.str_dub_text] = interpret(text)
+            if (children or et_node.attrib):
+                if text:
+                    d_node[et_node.tag][self.str_dub_text] = interpret(text)
             else:
                 d_node[et_node.tag] = interpret(text)
         for tag in self.tags_to_flatten:

--- a/upcoming_changes/111.api.rst
+++ b/upcoming_changes/111.api.rst
@@ -1,0 +1,4 @@
+Move, enhance and share xml to dict/list translation and other tools (new api for devs) from Bruker._api to utils:
+``utils.date_time_tools.msfiletime_to_unix`` function to convert the uint64 MSFILETIME to  datetime.datetime object.
+``utils.tools.sanitize_msxml_float`` function to sanitize some MSXML generated xml where comma is used as float decimal separator.
+``utils.tools.XmlToDict`` Xml to dict/list translator class with rich customization options as kwargs, and main method for translation ``dictionarize``


### PR DESCRIPTION
### Description of the change
There are some dublication attempts spotted (i.e. XML handling) where different kind of
parsers have its own implementation.
This PR moves some of functions from bruker api to utils.functionaly_coresponding_file:
- move and expose  msfiletime_to_unix (datetime.datetime) in utils.date_time_tools
- prelude to unification of XML to dictionary translations: move and refactor customizable xml to dictionary translator from bruker api:
  - float sanitizer function
  - xml dictionarization

This is first step. Next step (other PR) will be format by format review if XML can be parsed using the same tools.

### Progress of the PR
- [x] msfiletime_to_unix
- [x] move xml helper tools to utils.tools, make it customizable for reusing and switch bruker api to use that.
- [x] functions contains rich docstrings (done), update user guide (after wider adoption of xml_to_dict translator to other formats in other PR)
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests, (there is no needed, as it still do same job)
- [x] ready for review.

