### PR TITLE
Tweak pre-commit config to disable `autofix_prs`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,7 @@ repos:
     rev: 23.1.0
     hooks:
     -   id: black
+ci:
+    # Don't run automatically on PRs, instead add the comment
+    # "pre-commit.ci autofix" on a pull request to manually trigger auto-fixing 
+    autofix_prs: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -14,7 +20,6 @@ formats:
   - htmlzip
 
 python:
-   version: 3.8
    install:
       - method: pip
         path: .

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,3 @@
-
 Contributing
 ************
 
@@ -30,8 +29,18 @@ Please refer to the
 `HyperSpy developer guide <http://hyperspy.org/hyperspy-doc/current/dev_guide/intro.html>`_
 in order to get started and for detailed contributing guidelines.
 
-Reviewing
----------
+Lint
+----
+To keep the code style consistent (and more readable), `black <https://black.readthedocs.io/>`_
+is used to check the code formatting. When the code doesn't comply with the expected formatting,
+the `lint <https://github.com/hyperspy/rosettasciio/actions/workflows/black.yml>`_ will fail. 
+In practise, the code formatting can be fixed by installing ``black`` and running it on the
+source code or by using `pre-commit <https://pre-commit.com>`_ to format code automatically.
+Alternatively, the comment ``pre-commit.ci autofix`` can be added to a PR to fix the formatting
+using `pre-commit.ci <https://pre-commit.ci>`_.
+
+Review
+------
 
 As quality assurance, to improve the code, and to ensure a generalized
 functionality, pull requests need to be thoroughly reviewed by at least one

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 
 html_theme_options = {
-    "github_url": "https://github.com/hyperspy/hyperspy",
+    "github_url": "https://github.com/hyperspy/rosettasciio",
     "icon_links": [
         {
             "name": "Gitter",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,11 +87,6 @@ html_theme_options = {
     "header_links_before_dropdown": 6,
 }
 
-# Remove when pydata_sphinx_theme minimum requirement is bumped to 0.13
-if Version(pydata_sphinx_theme.__version__) < Version("0.13.0.dev0"):
-    html_theme_options["logo"]["image_light"] = "logo_rec_oct22.svg"
-    html_theme_options["logo"]["image_dark"] = "logo_rec_dark_oct22.svg"
-
 # -- Options for towncrier_draft extension -----------------------------------
 
 # Options: draft/sphinx-version/sphinx-release

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ extras_require = {
         "pytest-cov",
     ],  # for testing
     "docs": [
-        "pydata-sphinx-theme",
+        "pydata-sphinx-theme>=0.13",
         "sphinxcontrib-towncrier",
         # TODO: Remove explicit dependency on sphinx when pydata-sphinx-theme >= 0.13
         #  is available, and 0.13 as minimial supported version of pydata-sphinx-theme


### PR DESCRIPTION
I enabled [pre-commit ci](https://pre-commit.ci/), so that we can running pre-commit on PR by adding the comment "pre-commit.ci autofix" on a pull request to manually trigger auto-fixing.
To avoid being too intrusive, this PR disable running automatically on PR.