### PR TITLE
Add support for Jeol epma data format (Issue #115)

### DIFF
--- a/rsciio/jeol/_api.py
+++ b/rsciio/jeol/_api.py
@@ -153,9 +153,23 @@ def _read_asw(filename, **kwargs):
 file_reader.__doc__ %= (FILENAME_DOC, LAZY_DOC, RETURNS_DOC)
 
 def _read_epma_img(filename, **kwargs):
+    """
+    Parameters
+    ----------
+    filename : str
+        img file name
+    kwargs :
+        not used
+
+    Returns
+    -------
+    image_list : list of images(dict)
+        (Always len(image_list) == 1)
+        None if image is not an EPMA map.
+    """
     with open(filename, "br") as fd:
         file_magic = np.fromfile(fd, "<I", 1)[0]
-        if file_magic != 1:
+        if file_magic != 1:   #  Is this correct?
             return None
         fd.seek(32)
         _w = 256
@@ -214,13 +228,14 @@ def _read_img(filename, **kwargs):
 
     with open(filename, "br") as fd:
         file_magic = np.fromfile(fd, "<I", 1)[0]
-        if file_magic != 52:
+        if file_magic != 52:  # Not an EDS related image
+            # Try to read as an EPMA image
             _epma = _read_epma_img(filename)
-            if _epma == None:
-                _logger.warning(f"Not a valid JEOL img format '{filename}'")
-                return []
-            else:
+            if _epma is not None:
                 return _epma
+
+            _logger.warning(f"Not a valid JEOL img format '{filename}'")
+            return []
 
         # fileformat
         _ = _decode(fd.read(32).rstrip(b"\x00"))

--- a/rsciio/jeol/_api.py
+++ b/rsciio/jeol/_api.py
@@ -211,6 +211,7 @@ def _read_epma_img(filename, **kwargs):
     }
     return [dictionary]
 
+
 def _read_img(filename, **kwargs):
     """
     Parameters

--- a/rsciio/tests/test_jeol.py
+++ b/rsciio/tests/test_jeol.py
@@ -702,20 +702,21 @@ def test_frame_start_index(tmp_path):
         data[0x1117] = 0x41
     with open(test_file, "wb") as f:
         f.write(data)
-        s = hs.load(
-            test_file, downsample=[32, 32], rebin_energy=512, SI_dtype=np.int32
-        )
+        s = hs.load(test_file, downsample=[32, 32], rebin_energy=512, SI_dtype=np.int32)
     assert s.metadata["Signal"]["signal_type"] == "EDS_SEM"
 
+
 def test_epma_map(tmp_path):
-    EPMA_HEADER = b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00' \
-                  b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    EPMA_HEADER = (
+        b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00'
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    )
     img_size = 256
     test_file = Path(tmp_path) / "epma.map"
     vals = np.arange(img_size * img_size, dtype=np.double)
     with open(test_file, "wb") as f:
         f.write(EPMA_HEADER)
-        vals.tofile(f, '')
+        vals.tofile(f, "")
     s = hs.load(test_file)
     assert s.metadata.Signal.signal_type == "EPMA"
     for y in range(img_size):


### PR DESCRIPTION
### Draft
This is not suitable for merging into main stream

more sample data is needed

### Description of the change
- Minimum support for JEOL EPMA map
- Not enough metadata, filesize info
- Image size is fixed. (256x256)

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
from rsciio.jeol import file_reader
file_reader("your_msa_file.map")
# Your new feature...
```

This is just a minimum EPMA map support for discussion.
I don't know if new signal_type should be defined or not.

