### PR TITLE
expose some functions under bruker.api

### DIFF
--- a/rsciio/bruker/__init__.py
+++ b/rsciio/bruker/__init__.py
@@ -1,8 +1,10 @@
 from ._api import file_reader
+from . import api
 
 
 __all__ = [
     "file_reader",
+    "api",
 ]
 
 

--- a/rsciio/bruker/__init__.py
+++ b/rsciio/bruker/__init__.py
@@ -1,10 +1,8 @@
 from ._api import file_reader
-from . import api
 
 
 __all__ = [
     "file_reader",
-    "api",
 ]
 
 

--- a/rsciio/bruker/_api.py
+++ b/rsciio/bruker/_api.py
@@ -289,7 +289,7 @@ but compression signature is missing in the header. Aborting...."""
         return data
 
 
-class SFS_reader(object):
+class SfsReader(object):
     """Class to read sfs file.
     SFS is AidAim software's(tm) single file system.
     The class provides basic reading capabilities of such container.
@@ -871,11 +871,11 @@ class HyperHeader(object):
         return i
 
 
-class BCF_reader(SFS_reader):
+class BCF_reader(SfsReader):
 
     """Class to read bcf (Bruker hypermapping) file.
 
-    Inherits SFS_reader and all its attributes and methods.
+    Inherits SfsReader and all its attributes and methods.
 
     Attributes:
     filename
@@ -888,7 +888,7 @@ class BCF_reader(SFS_reader):
     """
 
     def __init__(self, filename, instrument=None):
-        SFS_reader.__init__(self, filename)
+        SfsReader.__init__(self, filename)
         header_file = self.get_file("EDSDatabase/HeaderData")
         self.available_indexes = []
         # get list of presented indexes from file tree of binary sfs container
@@ -968,7 +968,7 @@ class BCF_reader(SFS_reader):
             ceil(self.header.image.width / downsample),
             n_channels,
         )
-        sfs_file = SFS_reader(self.filename)
+        sfs_file = SfsReader(self.filename)
         vrt_file_hand = sfs_file.get_file("EDSDatabase/SpectrumData" + str(index))
         if fast_unbcf:
             parse_func = unbcf_fast.parse_to_numpy
@@ -1076,7 +1076,7 @@ def py_parse_hypermap(virtual_file, shape, dtype, downsample=1):
 
     Parameters
     ----------
-    virtual_file -- virtual file handle returned by SFS_reader instance
+    virtual_file -- virtual file handle returned by SfsReader instance
         or by object inheriting it (e.g. BCF_reader instance)
     shape -- numpy shape
     dtype -- numpy dtype

--- a/rsciio/bruker/_api.py
+++ b/rsciio/bruker/_api.py
@@ -82,7 +82,7 @@ class SFSTreeItem(object):
 
     Attributes:
     item_raw_string -- the bytes from sfs file table describing the file
-    parent -- the index of parent item in SFS file table. 
+    parent -- the index of parent item in SFS file table.
     The index of root is -1.
 
     Methods:
@@ -116,7 +116,7 @@ class SFSTreeItem(object):
             self.uncompressed_block_size = None
             self.n_compressed_blocks = None
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f"<SFSTreeItem {self.name}  {self.size} Bytes>"
 
     def _calc_pointer_table_size(self):

--- a/rsciio/bruker/_api.py
+++ b/rsciio/bruker/_api.py
@@ -1035,8 +1035,9 @@ def spx_reader(filename, lazy=False):
         xml_str = spx.read()
     root = ET.fromstring(xml_str)
     sp_node = root.find("./ClassInstance[@Type='TRTSpectrum']")
-    rsc_sig = spectra_from_xml(sp_node)
-    rsc_sig[0]["metadata"]["General"]["original_filename"] = basename(filename)
+    spect = spectra_from_xml(sp_node)
+    spect[0]["metadata"]["General"]["original_filename"] = basename(filename)
+    return spect
 
 
 def spectra_from_xml(sp_node):
@@ -1079,7 +1080,7 @@ def spectra_from_xml(sp_node):
             },
             "Sample": {"name": name},
             "Signal": {
-                "signal_type": "EDS_%s" % mode,
+                "signal_type": f"EDS_{mode}",
                 "record_by": "spectrum",
                 "quantity": "X-rays (Counts)",
             },

--- a/rsciio/bruker/api.py
+++ b/rsciio/bruker/api.py
@@ -1,0 +1,1 @@
+from ._api import *

--- a/rsciio/tests/test_bruker.py
+++ b/rsciio/tests/test_bruker.py
@@ -239,11 +239,11 @@ def test_wrong_file():
 
 def test_fast_bcf():
     thingy = pytest.importorskip("rsciio.bruker.unbcf_fast")
-    from rsciio.bruker import _api
+    from rsciio.bruker import _api, api
 
     for bcffile in test_files:
         filename = os.path.join(my_path, "bruker_data", bcffile)
-        thingy = _api.BCFReader(filename)
+        thingy = api.BCFReader(filename)
         for j in range(2, 5, 1):
             print("downsampling:", j)
             _api.fast_unbcf = True  # manually enabling fast parsing

--- a/rsciio/tests/test_bruker.py
+++ b/rsciio/tests/test_bruker.py
@@ -243,7 +243,7 @@ def test_fast_bcf():
 
     for bcffile in test_files:
         filename = os.path.join(my_path, "bruker_data", bcffile)
-        thingy = _api.BCF_reader(filename)
+        thingy = _api.BCFReader(filename)
         for j in range(2, 5, 1):
             print("downsampling:", j)
             _api.fast_unbcf = True  # manually enabling fast parsing


### PR DESCRIPTION
### Description of the change
This PR aims to modernise and extend the `bruker._api.py`:
- expose middle layer functions and classes under `bruker.api`
- review, update and extend the docstrings, in particular of these functions and class'es which or which child are
  going to be exposed through `.api`
- review the code for possible cleanup, scope-separation and streamlining for public exposition in `.api`

### Progress of the PR
- [x] expose `SfsReader`
- [ ] expose `xml_to_spectrum`
- [ ] expose `xml_to_image` 
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

???
are `xml_to_spectrum` and `xml_to_image` good naming for these functions. functions require particular etree nodes - maybe `et_node_to_spectrum` and `et_node_to_image` would be better naming?

### Minimal example of the bug fix or the new feature
```python
from sciio.bruker import api as b_api

b_api.SFSReader('somefile.pan')  # *.pan are particle analysis files using same container as bcf 
```


