### PR TITLE
Add support for pixelwise EDS live time / real time into digital micrograph file reader

### DIFF
--- a/rsciio/digitalmicrograph/_api.py
+++ b/rsciio/digitalmicrograph/_api.py
@@ -1064,6 +1064,18 @@ class ImageObject(object):
                         "Acquisition_instrument.TEM.Detector.EDS.solid_angle",
                         None,
                     ),
+                    "{}.EDS.Images.Count rate".format(tags_path): (
+                        "EDS.Count_rate_map",
+                        lambda x: np.array(x).reshape(self.shape[1:]),
+                    ),
+                    "{}.EDS.Images.Live time".format(tags_path): (
+                        "EDS.Live_time_map",
+                        lambda x: np.array(x).reshape(self.shape[1:])
+                    ),
+                    "{}.EDS.Images.Real time".format(tags_path): (
+                        "EDS.Real_time_map",
+                        lambda x: np.array(x).reshape(self.shape[1:])
+                    ),
                     "{}.EDS.Live_time".format(tags_path): (
                         "Acquisition_instrument.TEM.Detector.EDS.live_time",
                         None,

--- a/rsciio/digitalmicrograph/_api.py
+++ b/rsciio/digitalmicrograph/_api.py
@@ -739,7 +739,7 @@ class ImageObject(object):
             )
         ]
 
-    def get_metadata(self, metadata=None):
+    def new_metadata(self, metadata=None):
         if metadata is None:
             metadata = {}
         if "General" not in metadata:
@@ -771,6 +771,24 @@ class ImageObject(object):
             return "SEM"
         else:
             return "TEM"
+
+    def _get_illumination_mode(self):
+        # check if instrument is SEM or TEM
+        if (
+            "Microscope Info" in self.imdict.ImageTags
+            and "Illumination Mode" in self.imdict.ImageTags["Microscope Info"]
+        ):
+            microscope = (
+                "SEM"
+                if self._get_mode(
+                    self.imdict.ImageTags["Microscope Info"]["Illumination Mode"]
+                )
+                == "SEM"
+                else "TEM"
+            )
+        else:
+            microscope = "TEM"
+        return microscope
 
     def _get_time(self, time):
         try:
@@ -806,6 +824,81 @@ class ImageObject(object):
                 return mic
         _logger.info("Microscope name not present")
         return None
+
+
+    def get_EDS_pixel_time(self, mp, om, overwrite_pixeltime=False):
+        # mp and om are dict, not Box in this stage
+        def _get_item(dic, tag_name):
+            tags = tag_name.split('.')
+            for tag in tags:
+                dic = dic.get(tag)
+                if dic is None:
+                    break
+            return dic
+        def _set_item(dic, tag_name, val):
+            tags = tag_name.split('.')
+            for tag in tags[:-1]:
+                if tag not in dic:
+                    dic[tag] = {}
+                dic = dic[tag]
+            dic[tags[-1]] = val
+
+        _mode = self._get_illumination_mode()
+        if "SEM" not in _mode: # SEM/TEM/STEM
+            _mode = "TEM"
+        _om_eds_images = _get_item(om, "ImageTags.EDS.Images")
+        _om_si = _get_item(om, "ImageTags.SI.Acquisition")
+        _eds_tag_name = "Acquisition_instrument."+_mode+".Detector.EDS"
+        if _om_eds_images is None or _om_si is None:
+            # No pixel-wise EDS live-time data in original_metadata
+            return
+        _notes = _get_item(mp, "General.notes")
+        if _notes is None:
+            _notes = ""
+        _num_cycle = _om_si.get("Number of cycles")
+        _pi = _om_si.get("Pixel iterator")
+        _pt = _om_si.get("Pixel time (s)")
+        _shape = self.shape[1:] # (Energy, Height, Width)
+        _rtm = _om_eds_images.get("Real time")
+        _ltm = _om_eds_images.get("Live time")
+        _ctm = _om_eds_images.get("Count rate")
+        if _ltm is None or _rtm is None:
+            # No pixel-wise EDS live-time data in original_metadata
+            return
+        _ct = np.array(_ctm).reshape(_shape)
+        _rt = np.array(_rtm).reshape(_shape)
+        _lt = np.array(_ltm).reshape(_shape)
+
+        ###
+        ###  Overwrite data shape 
+        ###
+        _om_eds_images["Real time"] = _rt
+        _om_eds_images["Live time"] = _lt
+        _om_eds_images["Count rate"] = _ct
+
+        _rta = np.average(_rt)
+        _lta = np.average(_lt)
+        _cta = np.average(_ct)
+        _rts = np.std(_rt)
+        _lts = np.std(_lt)
+        _cts = np.std(_ct)
+        _set_item(mp, _eds_tag_name+".real_time (s)", _rta)
+        _set_item(mp, _eds_tag_name+".live_time (s)", _lta)
+
+        _notes += "Pixel time(Setting) = {:.1f} ms, ".format(_pt * 1000)
+        _notes += "ave. real time = {:.2f} ms (std = {:.2f}), ".format(_rta * 1000, _rts * 1000)
+        _notes += "ave. live time = {:.2f} ms (std = {:.2f}), ".format(_rta * 1000, _lts * 1000)
+        _notes += "ave. count rate = {:.2f} ms (std = {:.2f}), ".format(_cta * 1000, _cts * 1000)
+        _notes += "number of cycles = {}.\n".format(_num_cycle)
+
+        if _pt * 1.1 < _rta:
+            _logger.warning("Pixel time ({:.1f} ms) / EDS real time ({:.1f} ms) mismatch".format(_pt * 1000, _rta * 1000))
+        if _num_cycle != 1:
+            _warn = "Part of pixel-wise real-time/live-time data was lost when number of cycles != 1"
+        if _notes != "":
+            _set_item(mp, "General.notes", _notes)
+        return
+
 
     def _parse_string(self, tag, convert_to_float=False, tag_name=None):
         if len(tag) == 0:
@@ -855,6 +948,7 @@ class ImageObject(object):
             _logger.info("CL detector type can't be read.")
             return None
 
+
     def get_mapping(self):
         if "source" in self.imdict.ImageTags.keys():
             # For stack created with the stack builder plugin
@@ -865,21 +959,7 @@ class ImageObject(object):
             tags_path = "ImageList.TagGroup0.ImageTags"
             image_tags_dict = self.imdict.ImageTags
         is_scanning = "DigiScan" in image_tags_dict.keys()
-        # check if instrument is SEM or TEM
-        if (
-            "Microscope Info" in self.imdict.ImageTags
-            and "Illumination Mode" in self.imdict.ImageTags["Microscope Info"]
-        ):
-            microscope = (
-                "SEM"
-                if self._get_mode(
-                    self.imdict.ImageTags["Microscope Info"]["Illumination Mode"]
-                )
-                == "SEM"
-                else "TEM"
-            )
-        else:
-            microscope = "TEM"
+        microscope = self._get_illumination_mode()
         mapping = {
             "{}.DataBar.Acquisition Date".format(tags_path): (
                 "General.date",
@@ -1063,18 +1143,6 @@ class ImageObject(object):
                     "{}.EDS.Solid_angle".format(tags_path): (
                         "Acquisition_instrument.TEM.Detector.EDS.solid_angle",
                         None,
-                    ),
-                    "{}.EDS.Images.Count rate".format(tags_path): (
-                        "EDS.Count_rate_map",
-                        lambda x: np.array(x).reshape(self.shape[1:]),
-                    ),
-                    "{}.EDS.Images.Live time".format(tags_path): (
-                        "EDS.Live_time_map",
-                        lambda x: np.array(x).reshape(self.shape[1:])
-                    ),
-                    "{}.EDS.Images.Real time".format(tags_path): (
-                        "EDS.Real_time_map",
-                        lambda x: np.array(x).reshape(self.shape[1:])
                     ),
                     "{}.EDS.Live_time".format(tags_path): (
                         "Acquisition_instrument.TEM.Detector.EDS.live_time",
@@ -1291,8 +1359,9 @@ def file_reader(filename, lazy=False, order=None, optimize=True, **kwargs):
         for image in images:
             dm.tags_dict["ImageList"]["TagGroup0"] = image.imdict.to_dict()
             axes = image.get_axes_dict()
-            mp = image.get_metadata()
+            mp = image.new_metadata()
             mp["General"]["original_filename"] = os.path.split(filename)[1]
+            image.get_EDS_pixel_time(mp, dm.tags_dict["ImageList"]["TagGroup0"])
             post_process = []
             if image.to_spectrum is True:
                 post_process.append(lambda s: s.to_signal1D(optimize=optimize))


### PR DESCRIPTION
# Draft
Not ready to merge

# Description of the change
- Add suport for pixel-wise live time / real time for EDS image
- Should these maps be converted to images or not?

## ToDo:
- sum / average of pixel-wise live-time and real-time.
-  What is EDS.Acquisition.Live-time multiplier ?

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
s = hs.load("eds-si.dm4")
print(s.metadata.EDS.Real_time_map)
print(s.metadata.EDS.Live_time_map)
print(s.metadata.EDS.Count_rate_map)
```


