### PR TITLE
Tidy up `record_by` in `hspy`/`zspy`

### DIFF
--- a/docs/supported_formats/hspy.rst
+++ b/docs/supported_formats/hspy.rst
@@ -108,10 +108,71 @@ writing and performance of many HyperSpy algorithms. See the
 
     Also see the :ref:`hdf5-utils` for inspecting HDF5 files.
 
+Format description
+^^^^^^^^^^^^^^^^^^
+The root of the file must contain a group called ``Experiments``. The ``Experiments``
+group can contain any number of subgroups and each subgroup is an experiment or
+signal. Each subgroup must contain at least one dataset called ``data``. The
+data is an array of arbitrary dimension. In addition, a number equal to the
+number of dimensions of the ``data`` dataset of empty groups called ``axis``
+followed by a number must exist with the following attributes:
+
+* ``'name'``
+* ``'offset'``
+* ``'scale'``
+* ``'units'``
+* ``'size'``
+* ``'index_in_array'``
+
+Alternatively to ``'offset'`` and ``'scale'``, the coordinate groups may
+contain an ``'axis'`` vector attribute defining the axis points.
+The experiment group contains a number of attributes that will be
+directly assigned as class attributes of the
+:py:class:`hyperspy.api.signals.BaseSignal` instance. In
+addition the experiment groups may contain ``'original_metadata'`` and
+``'metadata'``-subgroup that will be assigned to the same name attributes
+of the :py:class:`hyperspy.api.signals.BaseSignal` instance as a
+:py:class:`hyperspy.misc.utils.DictionaryTreeBrowser`.
+The ``Experiments`` group can contain attributes that may be common to all
+the experiments and that will be accessible as attributes of the
+``Experiments`` instance.
+
+
+Changelog
+^^^^^^^^^
+
+v3.2
+""""
+- Deprecated ``record_by`` attribute is removed
+
+v3.1
+""""
+- add read support for non-uniform DataAxis defined by ``'axis'`` vector
+- move ``metadata.Signal.binned`` attribute to ``axes.is_binned`` parameter
+
+v3.0
+""""
+- add ``Camera`` and ``Stage`` node
+- move ``tilt_stage`` to ``Stage.tilt_alpha``
+
+v2.2
+""""
+- store more metadata as string: ``date``, ``time``, ``notes``, ``authors`` and ``doi``
+- store ``quantity`` for intensity axis
+
+v2.1
+""""
+- Store the ``navigate`` attribute
+- ``record_by`` is stored only for backward compatibility but the axes ``navigate``
+  attribute takes precendence over ``record_by`` for files with version >= 2.1
+
+v1.3
+""""
+- Added support for lists, tuples and binary strings
+
 
 API functions
 ^^^^^^^^^^^^^
 
 .. automodule:: rsciio.hspy
    :members:
-

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -29,7 +29,7 @@ import numpy as np
 from rsciio.utils.tools import ensure_unicode
 
 
-version = "3.1"
+version = "3.2"
 
 default_version = Version(version)
 

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -35,60 +35,6 @@ from rsciio.utils.tools import get_file_handle
 
 _logger = logging.getLogger(__name__)
 
-
-# -----------------------
-# File format description
-# -----------------------
-# The root must contain a group called Experiments.
-# The experiments group can contain any number of subgroups.
-# Each subgroup is an experiment or signal.
-# Each subgroup must contain at least one dataset called data.
-# The data is an array of arbitrary dimension.
-# In addition, a number equal to the number of dimensions of the data
-# dataset + 1 of empty groups called coordinates followed by a number
-# must exist with the following attributes:
-#    'name'
-#    'offset'
-#    'scale'
-#    'units'
-#    'size'
-#    'index_in_array'
-# Alternatively to 'offset' and 'scale', the coordinate groups may
-# contain an 'axis' vector attribute defining the axis points.
-# The experiment group contains a number of attributes that will be
-# directly assigned as class attributes of the Signal instance. In
-# addition the experiment groups may contain 'original_metadata' and
-# 'metadata'-subgroup that will be assigned to the same name attributes
-# of the Signal instance as a Dictionary Browser.
-# The Experiments group can contain attributes that may be common to all
-# the experiments and that will be accessible as attributes of the
-# Experiments instance.
-#
-# CHANGES
-#
-# v3.2
-# - deprecated record_by attribute is removed
-#
-# v3.1
-# - add read support for non-uniform DataAxis defined by 'axis' vector
-# - move metadata.Signal.binned attribute to axes.is_binned parameter
-#
-# v3.0
-# - add Camera and Stage node
-# - move tilt_stage to Stage.tilt_alpha
-#
-# v2.2
-# - store more metadata as string: date, time, notes, authors and doi
-# - store quantity for intensity axis
-#
-# v2.1
-# - Store the navigate attribute
-# - record_by is stored only for backward compatibility but the axes navigate
-#   attribute takes precendence over record_by for files with version >= 2.1
-#
-# v1.3
-# - Added support for lists, tuples and binary strings
-
 not_valid_format = "The file is not a valid HyperSpy hdf5 file"
 
 current_file_version = None  # Format version of the file being read

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -66,6 +66,9 @@ _logger = logging.getLogger(__name__)
 #
 # CHANGES
 #
+# v3.2
+# - deprecated record_by attribute is removed
+#
 # v3.1
 # - add read support for non-uniform DataAxis defined by 'axis' vector
 # - move metadata.Signal.binned attribute to axes.is_binned parameter
@@ -82,8 +85,8 @@ _logger = logging.getLogger(__name__)
 # - Store the navigate attribute
 # - record_by is stored only for backward compatibility but the axes navigate
 #   attribute takes precendence over record_by for files with version >= 2.1
+#
 # v1.3
-# ----
 # - Added support for lists, tuples and binary strings
 
 not_valid_format = "The file is not a valid HyperSpy hdf5 file"
@@ -257,22 +260,8 @@ def file_writer(filename, signal, close_file=True, **kwds):
         group_name = group_name.replace("/", "-")
     expg = exps.require_group(group_name)
 
-    # Add record_by metadata for backward compatibility
-    signal_dimension = len([axis for axis in signal["axes"] if not axis["navigate"]])
-    smd = signal["metadata"]["Signal"]
-    if signal_dimension == 1:
-        smd["record_by"] = "spectrum"
-    elif signal_dimension == 2:
-        smd["record_by"] = "image"
-    else:
-        smd["record_by"] = ""
-    try:
-        writer = HyperspyWriter(f, signal, expg, **kwds)
-        writer.write()
-    except Exception:
-        raise
-    finally:
-        del smd["record_by"]
+    writer = HyperspyWriter(f, signal, expg, **kwds)
+    writer.write()
 
     if close_file:
         f.close()

--- a/rsciio/zspy/_api.py
+++ b/rsciio/zspy/_api.py
@@ -172,23 +172,8 @@ def file_writer(filename, signal, close_file=True, **kwds):
         group_name = group_name.replace("/", "-")
     expg = exps.require_group(group_name)
 
-    # Add record_by metadata for backward compatibility
-    signal_dimension = len([axis for axis in signal["axes"] if not axis["navigate"]])
-    smd = signal["metadata"]["Signal"]
-    if signal_dimension == 1:
-        smd["record_by"] = "spectrum"
-    elif signal_dimension == 2:
-        smd["record_by"] = "image"
-    else:
-        smd["record_by"] = ""
-
-    try:
-        writer = ZspyWriter(f, signal, expg, **kwds)
-        writer.write()
-    except Exception:
-        raise
-    finally:
-        del smd["record_by"]
+    writer = ZspyWriter(f, signal, expg, **kwds)
+    writer.write()
 
     if isinstance(store, (zarr.ZipStore, zarr.DBMStore, zarr.LMDBStore)):
         if close_file:

--- a/upcoming_changes/143.maintenance.rst
+++ b/upcoming_changes/143.maintenance.rst
@@ -1,0 +1,1 @@
+Remove deprecated ``record_by`` attribute in :ref:`hspy <hspy-format>`/:ref:`zspy <zspy-format>`,


### PR DESCRIPTION
### Progress of the PR
- [x] Remove deprecated `record_by` attribute in `hspy`/`zspy`,
- [x] Bump `hspy`/`zspy` version to 3.2,
- [n/a] update docstring (if appropriate),
- [x] update user guide: move format specification from code to documentation
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


