### PR TITLE
Fix docs build caused by pyusid import issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,9 @@ blockfile = ["scikit-image>=0.18"]
 mrcz = ["blosc>=1.5", "mrcz>=0.3.6"]
 scalebar_export = ["matplotlib-scalebar", "matplotlib>=3.1.3"]
 tiff = ["tifffile>=2020.2.16", "imagecodecs>=2020.1.31"]
-usid = ["pyUSID"]
+# Add sidpy dependency and pinning as workaround to fix pyUSID import
+# Remove sidpy dependency once https://github.com/pycroscopy/pyUSID/issues/85 is fixed.
+usid = ["pyUSID", "sidpy<=0.12.0"]
 zspy = ["zarr"]
 tests = [
   "pooch",


### PR DESCRIPTION
Add sidpy dependency and pin it to <0.12.1 as a workaround to fix pyusid import, see https://github.com/pycroscopy/pyUSID/issues/85

### Progress of the PR
- [x] pin sidpy to a version that is compatible with pyusid,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [ ] ready for review.

