### PR TITLE
Fix `signal_type` test failure when lumispy is installed

### DIFF
--- a/rsciio/tests/test_hamamatsu.py
+++ b/rsciio/tests/test_hamamatsu.py
@@ -287,7 +287,13 @@ class TestOperate:
         assert metadata.General.title == metadata.General.original_filename[:-4]
 
         assert metadata.Signal.quantity == "Intensity (Counts)"
-        assert metadata.Signal.signal_type == ""
+        try:
+            import lumispy
+
+            signal_type = "Luminescence"
+        except ImportError:
+            signal_type = ""
+        assert metadata.Signal.signal_type == signal_type
 
         assert isinstance(detector.binning, tuple)
         assert len(detector.binning) == 2


### PR DESCRIPTION
Fix test failure in https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/5958276812/job/16162274648 introduced in #87.
