### PR TITLE
bugfix: included the "Out" case for the EELS aperture size

### DIFF
--- a/rsciio/pantarhei/_api.py
+++ b/rsciio/pantarhei/_api.py
@@ -349,9 +349,13 @@ def _metadata_converter_in(meta_data, axes, filename):
         if "mm" in aperture:
             aperture = aperture.split("mm")[0]
             aperture = aperture.rstrip()
-        mapped.set_item(
-            "Acquisition_instrument.TEM.Detector.EELS.aperture_size", float(aperture)
-        )
+            mapped.set_item(
+                "Acquisition_instrument.TEM.Detector.EELS.aperture_size", float(aperture)
+            )
+        else:
+            mapped.set_item(
+            "Acquisition_instrument.TEM.Detector.EELS.aperture_size", aperture
+            )
 
     source_type = meta_data.get("source.type")
 

--- a/rsciio/pantarhei/_api.py
+++ b/rsciio/pantarhei/_api.py
@@ -350,11 +350,11 @@ def _metadata_converter_in(meta_data, axes, filename):
             aperture = aperture.split("mm")[0]
             aperture = aperture.rstrip()
             mapped.set_item(
-                "Acquisition_instrument.TEM.Detector.EELS.aperture_size", float(aperture)
+                "Acquisition_instrument.TEM.Detector.EELS.aperture", float(aperture)
             )
         else:
             mapped.set_item(
-            "Acquisition_instrument.TEM.Detector.EELS.aperture_size", aperture
+                "Acquisition_instrument.TEM.Detector.EELS.aperture", aperture
             )
 
     source_type = meta_data.get("source.type")
@@ -423,13 +423,13 @@ def _metadata_converter_out(metadata, original_metadata=None):
             beam_energy = md_TEM.get("beam_energy")
             convergence_angle = md_TEM.get("convergence_angle")
             collection_angle = md_TEM.get("Detector.EELS.collection_angle")
-            aperture = md_TEM.get("Detector.EELS.aperture_size")
+            aperture = md_TEM.get("Detector.EELS.aperture")
             acquisition_mode = md_TEM.get("acquisition_mode")
             magnification = md_TEM.get("magnification")
             camera_length = md_TEM.get("camera_length")
 
             if aperture is not None:
-                if type(aperture) in (float, int):
+                if isinstance(aperture, (float, int)):
                     aperture = str(aperture) + " mm"
                 meta_data["filter.aperture"] = aperture
             if beam_energy is not None:

--- a/rsciio/tests/test_pantarhei.py
+++ b/rsciio/tests/test_pantarhei.py
@@ -139,6 +139,20 @@ def test_save_load_cycle_new_signal_EELS(tmp_path):
     assert isinstance(s2, s.__class__)
 
 
+def test_save_load_cycle_new_signal_EELS_aperture_out(tmp_path):
+    fname = tmp_path / "test_file_new_signal2D_aperture_out.prz"
+    data = np.arange(100).reshape(2, 5, 10)
+    s = exspy.signals.EELSSpectrum(data)
+    s.metadata.set_item("Acquisition_instrument.TEM.Detector.EELS.aperture", "Out")
+    s.save(fname)
+    assert fname.is_file()
+
+    s2 = hs.load(fname)
+    np.testing.assert_allclose(s2.data, s.data)
+    assert isinstance(s2, s.__class__)
+    assert s2.metadata.Acquisition_instrument.TEM.Detector.EELS.aperture == "Out"
+
+
 def test_metadata_STEM(tmp_path):
     fname = tmp_path / "test_file_new_signal_metadata_STEM.prz"
     data = np.arange(20).reshape(2, 10)
@@ -153,7 +167,7 @@ def test_metadata_STEM(tmp_path):
                 "camera_length": 200,
                 "convergence_angle": 20,
                 "Detector": {
-                    "EELS": {"collection_angle": 60, "aperture_size": 5},
+                    "EELS": {"collection_angle": 60, "aperture": 5},
                 },
             },
         },
@@ -187,7 +201,7 @@ def test_metadata_TEM(tmp_path):
                 "magnification": 500000,
                 "camera_length": 200,
                 "Detector": {
-                    "EELS": {"collection_angle": 60, "aperture_size": 5},
+                    "EELS": {"collection_angle": 60, "aperture": 5},
                 },
             },
         },

--- a/upcoming_changes/173.bugfix.rst
+++ b/upcoming_changes/173.bugfix.rst
@@ -1,0 +1,1 @@
+Fix error when reading :ref:`pantarhei-format` file with aperture ``"Out"``


### PR DESCRIPTION
The previous code did not account for Acquisition_instrument.TEM.Detector.EELS.aperture_size being "Out" therefore running into a problem upon trying to convert this string into a float.

It has now been altered such that if "mm" is not in aperture, the string will be added to the meta data unchanged (as "Out").