### PR TITLE
Update test suite to work with or without exspy installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,8 @@ jobs:
 
       - name: Install HyperSpy (dev)
         run: |
-          pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
+          pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_major.zip
+          pip install https://github.com/hyperspy/exspy/archive/main.zip
 
       - name: Install distribution
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,10 +68,15 @@ jobs:
           pip install ${{ matrix.DEPENDENCIES }}
 
       - name: Install (HyperSpy dev)
-        if: "!contains(matrix.LABEL, 'wo-hyperspy')"
+        if: ${{ ! contains(matrix.LABEL, 'wo-hyperspy') }}
         # Need to install hyperspy dev until hyperspy 2.0 is released
         run: |
-          pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
+          pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_major.zip
+
+      - name: Install (exspy)
+        if: ${{ ! contains(matrix.LABEL, '-minimum') && ! contains(matrix.LABEL, 'wo-hyperspy') }}
+        run: |
+          pip install https://github.com/hyperspy/exspy/archive/main.zip
 
       - name: Install
         shell: bash

--- a/rsciio/tests/test_bruker.py
+++ b/rsciio/tests/test_bruker.py
@@ -104,6 +104,7 @@ def test_load_8bit():
 
 
 def test_hyperspy_wrap():
+    pytest.importorskip("exspy", reason="exspy not installed.")
     filename = TEST_DATA_DIR / test_files[0]
     print("testing bcf wrap to hyperspy signal...")
 
@@ -232,22 +233,22 @@ def test_get_mode():
     filename = TEST_DATA_DIR / test_files[0]
     s = hs.load(filename, select_type="spectrum_image", instrument="SEM")
     assert s.metadata.Signal.signal_type == "EDS_SEM"
-    assert isinstance(s, hs.signals.EDSSEMSpectrum)
+    assert isinstance(s, hs.signals.Signal1D)
 
     filename = TEST_DATA_DIR / test_files[0]
     s = hs.load(filename, select_type="spectrum_image", instrument="TEM")
     assert s.metadata.Signal.signal_type == "EDS_TEM"
-    assert isinstance(s, hs.signals.EDSTEMSpectrum)
+    assert isinstance(s, hs.signals.Signal1D)
 
     filename = TEST_DATA_DIR / test_files[0]
     s = hs.load(filename, select_type="spectrum_image")
     assert s.metadata.Signal.signal_type == "EDS_SEM"
-    assert isinstance(s, hs.signals.EDSSEMSpectrum)
+    assert isinstance(s, hs.signals.Signal1D)
 
     filename = TEST_DATA_DIR / test_files[3]
     s = hs.load(filename, select_type="spectrum_image")
     assert s.metadata.Signal.signal_type == "EDS_TEM"
-    assert isinstance(s, hs.signals.EDSTEMSpectrum)
+    assert isinstance(s, hs.signals.Signal1D)
 
 
 def test_wrong_file():

--- a/rsciio/tests/test_digitalmicrograph.py
+++ b/rsciio/tests/test_digitalmicrograph.py
@@ -216,6 +216,7 @@ def test_read_SI_metadata():
 
 
 def test_read_EDS_metadata():
+    pytest.importorskip("exspy", reason="exspy not installed.")
     fname = DM_1D_PATH / "test-EDS_spectrum.dm3"
     s = hs.load(fname)
     md = s.metadata

--- a/rsciio/tests/test_edax.py
+++ b/rsciio/tests/test_edax.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 
 from rsciio.edax import file_reader
+from rsciio.utils.tests import expected_is_binned
 
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
@@ -172,7 +173,7 @@ class TestSpcSpectrum_v061_xrf:
 
         # Testing HyperSpy parameters
         assert "EDS_SEM" == signal_dict["signal_type"]
-        assert isinstance(TestSpcSpectrum_v061_xrf.spc, hs.signals.EDSSEMSpectrum)
+        assert isinstance(TestSpcSpectrum_v061_xrf.spc, hs.signals.Signal1D)
 
     def test_axes(self):
         spc_ax_manager = {
@@ -180,7 +181,7 @@ class TestSpcSpectrum_v061_xrf:
                 "_type": "UniformDataAxis",
                 "name": "Energy",
                 "navigate": False,
-                "is_binned": True,
+                "is_binned": expected_is_binned(),
                 "offset": 0.0,
                 "scale": 0.01,
                 "size": 4000,
@@ -274,7 +275,7 @@ class TestSpcSpectrum_v070_eds:
 
         # Testing HyperSpy parameters
         assert "EDS_SEM" == signal_dict["signal_type"]
-        assert isinstance(TestSpcSpectrum_v070_eds.spc, hs.signals.EDSSEMSpectrum)
+        assert isinstance(TestSpcSpectrum_v070_eds.spc, hs.signals.Signal1D)
 
     def test_axes(self):
         spc_ax_manager = {
@@ -282,7 +283,7 @@ class TestSpcSpectrum_v070_eds:
                 "_type": "UniformDataAxis",
                 "name": "Energy",
                 "navigate": False,
-                "is_binned": True,
+                "is_binned": expected_is_binned(),
                 "offset": 0.0,
                 "scale": 0.01,
                 "size": 4096,
@@ -389,7 +390,7 @@ class TestSpdMap_070_eds:
 
         # Testing HyperSpy parameters
         assert "EDS_SEM" == signal_dict["signal_type"]
-        assert isinstance(TestSpdMap_070_eds.spd, hs.signals.EDSSEMSpectrum)
+        assert isinstance(TestSpdMap_070_eds.spd, hs.signals.Signal1D)
 
     def test_axes(self):
         spd_ax_manager = {
@@ -417,7 +418,7 @@ class TestSpdMap_070_eds:
                 "_type": "UniformDataAxis",
                 "name": "Energy",
                 "navigate": False,
-                "is_binned": True,
+                "is_binned": expected_is_binned(),
                 "offset": 0.0,
                 "scale": 0.0050000000000000001,
                 "size": 2500,
@@ -536,7 +537,7 @@ class TestSpdMap_061_xrf:
 
         # Testing HyperSpy parameters
         assert "EDS_SEM" == signal_dict["signal_type"]
-        assert isinstance(TestSpdMap_061_xrf.spd, hs.signals.EDSSEMSpectrum)
+        assert isinstance(TestSpdMap_061_xrf.spd, hs.signals.Signal1D)
 
     def test_axes(self):
         spd_ax_manager = {
@@ -564,7 +565,7 @@ class TestSpdMap_061_xrf:
                 "_type": "UniformDataAxis",
                 "name": "Energy",
                 "navigate": False,
-                "is_binned": True,
+                "is_binned": expected_is_binned(),
                 "offset": 0.0,
                 "scale": 0.01,
                 "size": 2000,

--- a/rsciio/tests/test_emd.py
+++ b/rsciio/tests/test_emd.py
@@ -401,7 +401,8 @@ class TestFeiEMD:
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        assert isinstance(signal, hs.signals.EDSTEMSpectrum)
+        assert signal.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(signal, hs.signals.Signal1D)
         assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == "nm"
@@ -437,7 +438,8 @@ class TestFeiEMD:
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        assert isinstance(signal, hs.signals.EDSTEMSpectrum)
+        assert signal.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(signal, hs.signals.Signal1D)
         assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == "nm"
@@ -478,7 +480,8 @@ class TestFeiEMD:
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        assert isinstance(signal, hs.signals.EDSTEMSpectrum)
+        assert signal.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(signal, hs.signals.Signal1D)
         assert signal.axes_manager.navigation_shape == (10, 50, 10)
         assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
@@ -509,7 +512,8 @@ class TestFeiEMD:
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        assert isinstance(signal, hs.signals.EDSTEMSpectrum)
+        assert signal.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(signal, hs.signals.Signal1D)
         assert signal.axes_manager.navigation_shape == (10, 50, 5)
         assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
@@ -540,7 +544,8 @@ class TestFeiEMD:
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        assert isinstance(signal, hs.signals.EDSTEMSpectrum)
+        assert signal.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(signal, hs.signals.Signal1D)
         assert signal.axes_manager.navigation_shape == (10, 50, 6)
         assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
@@ -569,7 +574,8 @@ class TestFeiEMD:
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        assert isinstance(signal, hs.signals.EDSTEMSpectrum)
+        assert signal.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(signal, hs.signals.Signal1D)
         assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == "nm"
@@ -593,7 +599,8 @@ class TestFeiEMD:
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)
-        assert isinstance(signal, hs.signals.EDSTEMSpectrum)
+        assert signal.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(signal, hs.signals.Signal1D)
         assert signal.axes_manager[0].name == "x"
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == "nm"

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -834,7 +834,8 @@ def test_compression(compression, tmp_path):
 
 
 def test_strings_from_py2():
-    s = hs.datasets.example_signals.EDS_TEM_Spectrum()
+    exspy = pytest.importorskip("exspy", reason="exspy not installed")
+    s = exspy.data.EDS_TEM_FePt_nanoparticles()
     assert isinstance(s.metadata.Sample.elements, list)
 
 

--- a/rsciio/tests/test_jeol.py
+++ b/rsciio/tests/test_jeol.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import zipfile
 
 import numpy as np
-
 import pytest
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
@@ -272,11 +271,13 @@ def test_load_datacube_frames():
 
 @pytest.mark.parametrize("filename_as_string", [True, False])
 def test_load_eds_file(filename_as_string):
+    pytest.importorskip("exspy", reason="exspy not installed.")
     filename = TESTS_FILE_PATH / "met03.EDS"
     if filename_as_string:
         filename = str(filename)
     s = hs.load(filename, reader="JEOL")
-    assert isinstance(s, hs.signals.EDSTEMSpectrum)
+    assert s.metadata.Signal.signal_type == "EDS_TEM"
+    assert isinstance(s, hs.signals.Signal1D)
     assert s.data.shape == (2048,)
     axis = s.axes_manager[0]
     assert axis.name == "Energy"
@@ -606,8 +607,9 @@ def test_seq_eds_files(tmp_path):
             viewdata["PositionMM2"], viewdata_asw[i]["PositionMM2"]
         )
         assert viewdata["Memo"] == memo[i]
-    assert isinstance(s[1], hs.signals.EDSTEMSpectrum)
-    assert isinstance(s[2], hs.signals.EDSTEMSpectrum)
+    for s_ in s[1:3]:
+        assert s_.metadata.Signal.signal_type == "EDS_TEM"
+        assert isinstance(s_, hs.signals.Signal1D)
 
     # test with broken asw file
     fname = tmp_path / "1" / "1.ASW"
@@ -661,7 +663,8 @@ def test_seq_eds_files(tmp_path):
     with open(sub_dir / ("x" + test_files[1]), "wb") as f:
         f.write(data)
     s = hs.load(sub_dir / ("x" + test_files[1]), reader="JEOL")
-    assert isinstance(s, hs.signals.EDSSEMSpectrum)
+    assert s.metadata.Signal.signal_type == "EDS_SEM"
+    assert isinstance(s, hs.signals.Signal1D)
     assert "SEM" in s.metadata["Acquisition_instrument"]
 
 

--- a/rsciio/tests/test_pantarhei.py
+++ b/rsciio/tests/test_pantarhei.py
@@ -23,6 +23,7 @@ import numpy as np
 import pytest
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+exspy = pytest.importorskip("exspy", reason="exspy not installed")
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 
@@ -129,7 +130,7 @@ def test_save_load_cycle_new_signal_2D(tmp_path):
 def test_save_load_cycle_new_signal_EELS(tmp_path):
     fname = tmp_path / "test_file_new_signal2D.prz"
     data = np.arange(100).reshape(2, 5, 10)
-    s = hs.signals.EELSSpectrum(data)
+    s = exspy.signals.EELSSpectrum(data)
     s.save(fname)
     assert fname.is_file()
 
@@ -141,7 +142,7 @@ def test_save_load_cycle_new_signal_EELS(tmp_path):
 def test_metadata_STEM(tmp_path):
     fname = tmp_path / "test_file_new_signal_metadata_STEM.prz"
     data = np.arange(20).reshape(2, 10)
-    s = hs.signals.EELSSpectrum(data)
+    s = exspy.signals.EELSSpectrum(data)
     # Set some metadata
     md = {
         "Acquisition_instrument": {
@@ -176,7 +177,7 @@ def test_metadata_STEM(tmp_path):
 def test_metadata_TEM(tmp_path):
     fname = tmp_path / "test_file_new_signal_metadata_TEM.prz"
     data = np.arange(20).reshape(2, 10)
-    s = hs.signals.EELSSpectrum(data)
+    s = exspy.signals.EELSSpectrum(data)
     # Set some metadata
     md = {
         "Acquisition_instrument": {

--- a/rsciio/tests/test_phenom.py
+++ b/rsciio/tests/test_phenom.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+from rsciio.utils.tests import expected_is_binned
+
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 imagecodecs = pytest.importorskip(
     "imagecodecs", reason="skipping test_phenom tests, requires imagecodecs"
@@ -120,7 +122,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         }
     }
     assert s[1].data.tolist()[0:300] == [
@@ -457,7 +459,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         }
     }
     assert (
@@ -500,7 +502,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         },
     }
     assert (
@@ -533,7 +535,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         },
     }
     assert (
@@ -576,7 +578,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         },
     }
     assert (
@@ -599,7 +601,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         }
     }
 
@@ -640,7 +642,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         }
     }
     assert (
@@ -709,7 +711,7 @@ def test_elid(pathname):
             "size": 2048,
             "units": "keV",
             "navigate": False,
-            "is_binned": True,
+            "is_binned": expected_is_binned(),
         },
     }
     assert (

--- a/rsciio/tests/test_ripple.py
+++ b/rsciio/tests/test_ripple.py
@@ -6,6 +6,7 @@ import numpy.testing as npt
 import pytest
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+exspy = pytest.importorskip("exspy", reason="exspy not installed")
 
 from rsciio.ripple import _api as ripple
 
@@ -104,13 +105,13 @@ def _create_signal(shape, dim, dtype, metadata):
     data = np.arange(np.product(shape)).reshape(shape).astype(dtype)
     if dim == 1:
         if len(shape) > 2:
-            s = hs.signals.EELSSpectrum(data)
+            s = exspy.signals.EELSSpectrum(data)
             if metadata:
                 s.set_microscope_parameters(
                     beam_energy=100.0, convergence_angle=1.0, collection_angle=10.0
                 )
         else:
-            s = hs.signals.EDSTEMSpectrum(data)
+            s = exspy.signals.EDSTEMSpectrum(data)
             if metadata:
                 s.set_microscope_parameters(
                     beam_energy=100.0,

--- a/rsciio/utils/tests.py
+++ b/rsciio/utils/tests.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2023 The HyperSpy developers
+#
+# This file is part of RosettaSciIO.
+#
+# RosettaSciIO is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# RosettaSciIO is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+
+def expected_is_binned():
+    """
+    Convenient function to infer binning. When exspy is installed
+    some signal will be assigned to EDS or EELS class instead of
+    Signal1D class and the binned attribute will change accordingly.
+    """
+    try:
+        import exspy
+
+        binned = True
+    except ImportError:
+        binned = False
+
+    return binned

--- a/upcoming_changes/176.maintenance.rst
+++ b/upcoming_changes/176.maintenance.rst
@@ -1,0 +1,1 @@
+Update the test suite and the CI workflows to work with and without exspy installed


### PR DESCRIPTION
### Progress of the PR
- [x] Update test suite to support testing with or without exspy installed: depending on the situation, either the tests are skipped when exspy is not installed or the assertion are changed to work regardless if exspy is installed,
- [x] Update CI workshop to run the test suite with and without exspy installed,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


