### PR TITLE
Make numba and h5py optional dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
             PYTHON_VERSION: '3.9'
             LABEL: '-minimum'
           - os: ubuntu
-            PYTHON_VERSION: '3.9'
+            PYTHON_VERSION: '3.12'
             LABEL: '-minimum-wo-hyperspy'
           - os: ubuntu
             PYTHON_VERSION: '3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",
   "Operating System :: Unix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,17 +26,14 @@ classifiers = [
 dependencies = [
   "dask[array]>=2021.3.1",
   "python-dateutil",
-  "h5py>=2.3",
   "imageio>=2.16",
   # Remove when https://github.com/imageio/imageio/issues/1044 is fixed
   "pillow<10.1.0",
-  "numba>=0.52",
   "numpy>=1.20.0",
   "pint>=0.8",
   "python-box>=6,<7",
   "pyyaml",
   "scipy>=1.5.0",
-  "sparse",
 ]
 dynamic = ["version"]
 
@@ -50,6 +47,7 @@ file = "COPYING.txt"
 
 [project.optional-dependencies]
 blockfile = ["scikit-image>=0.18"]
+hdf5 = ["h5py>=2.3"]
 mrcz = ["blosc>=1.5", "mrcz>=0.3.6"]
 scalebar_export = ["matplotlib-scalebar", "matplotlib>=3.5"]
 tiff = ["tifffile>=2020.2.16", "imagecodecs>=2020.1.31"]
@@ -74,12 +72,15 @@ docs = [
   "towncrier"
 ]
 all = [
+  "numba>=0.52",
   "rosettasciio[blockfile]",
+  "rosettasciio[hdf5]",
   "rosettasciio[mrcz]",
   "rosettasciio[scalebar_export]",
   "rosettasciio[tiff]",
   "rosettasciio[usid]",
   "rosettasciio[zspy]",
+  "sparse",
 ]
 dev = [
   "black",

--- a/rsciio/jeol/_api.py
+++ b/rsciio/jeol/_api.py
@@ -22,10 +22,9 @@ from datetime import datetime, timedelta
 import logging
 
 import numpy as np
-import numba
 
 from rsciio._docstrings import FILENAME_DOC, LAZY_DOC, RETURNS_DOC
-
+from rsciio.utils.tools import jit_ifnumba
 
 _logger = logging.getLogger(__name__)
 
@@ -984,7 +983,7 @@ def _readcube(
     )
 
 
-@numba.njit(cache=True)
+@jit_ifnumba(cache=True)
 def _readframe_dense(
     rawdata,
     countup,
@@ -1097,7 +1096,7 @@ def _readframe_dense(
     return count, 0, has_em_image, valid, previous_y // height_norm
 
 
-@numba.njit(cache=True)
+@jit_ifnumba(cache=True)
 def _readframe_lazy(
     rawdata,
     _1,
@@ -1198,7 +1197,7 @@ def _readframe_lazy(
     return count, data, has_em_image, valid, previous_y // height_norm
 
 
-@numba.njit(cache=True)
+@jit_ifnumba(cache=True)
 def _skip_frame(rawdata):  # pragma: no cover
     count = 0
     previous_y = 0

--- a/rsciio/tests/test_emd.py
+++ b/rsciio/tests/test_emd.py
@@ -24,17 +24,18 @@
 import os
 from pathlib import Path
 
+import pytest
+
+hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+
 import dask.array as da
 from datetime import datetime
 from dateutil import tz
 import gc
 import h5py
 import numpy as np
-import pytest
 import tempfile
 import shutil
-
-hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 

--- a/rsciio/tests/test_fei_stream_readers.py
+++ b/rsciio/tests/test_fei_stream_readers.py
@@ -27,6 +27,8 @@ in order to mimic the usage in the FEI EMD reader.
 import numpy as np
 import pytest
 
+pytest.importorskip("h5py")
+
 from rsciio.utils.fei_stream_readers import (
     array_to_stream,
     stream_to_array,

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -21,12 +21,13 @@ from pathlib import Path
 import sys
 import time
 
-import dask.array as da
-import h5py
-import numpy as np
 import pytest
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+
+import dask.array as da
+import h5py
+import numpy as np
 
 from hyperspy.axes import DataAxis, UniformDataAxis, FunctionalDataAxis, AxesManager
 from hyperspy.decorators import lazifyTestClass

--- a/rsciio/tests/test_import.py
+++ b/rsciio/tests/test_import.py
@@ -32,6 +32,7 @@ def test_rsciio_dir():
 
 
 def test_rsciio_utils():
+    pytest.importorskip("h5py", reason="h5py not installed")
     from rsciio.utils import hdf5 as utils_hdf5
 
     assert dir(utils_hdf5) == ["list_datasets_in_file", "read_metadata_from_file"]
@@ -43,6 +44,11 @@ def test_import_all():
     plugin_name_to_remove = []
 
     # Remove plugins which require not installed optional dependencies
+    try:
+        import h5py
+    except Exception:
+        plugin_name_to_remove.extend(["EMD", "HSPY", "NeXus"])
+
     try:
         import skimage
     except Exception:

--- a/rsciio/tests/test_usid.py
+++ b/rsciio/tests/test_usid.py
@@ -1,13 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2023 The HyperSpy developers
+#
+# This file is part of RosettaSciIO.
+#
+# RosettaSciIO is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# RosettaSciIO is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
+
 import tempfile
 
-import dask.array as da
-import h5py
-import numpy as np
 import pytest
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 usid = pytest.importorskip("pyUSID", reason="pyUSID not installed")
 sidpy = pytest.importorskip("sidpy", reason="sidpy not installed")
+
+import dask.array as da
+import h5py
+import numpy as np
 
 
 # ##################### HELPER FUNCTIONS ######################################

--- a/rsciio/tvips/_api.py
+++ b/rsciio/tvips/_api.py
@@ -28,7 +28,6 @@ import dask.array as da
 import dask
 from dask.diagnostics import ProgressBar
 import pint
-from numba import njit
 
 from rsciio._docstrings import (
     FILENAME_DOC,
@@ -37,9 +36,13 @@ from rsciio._docstrings import (
     SIGNAL_DOC,
     SHOW_PROGRESSBAR_DOC,
 )
-from rsciio.utils.tools import DTBox, sarray2dict
-from rsciio.utils.tools import dummy_context_manager
-from rsciio.utils.tools import _UREG
+from rsciio.utils.tools import (
+    _UREG,
+    dummy_context_manager,
+    DTBox,
+    jit_ifnumba,
+    sarray2dict,
+)
 
 
 _logger = logging.getLogger(__name__)
@@ -198,7 +201,7 @@ def _find_auto_scan_start_stop(rotidxs):
         return startx, indx[-1] + 1
 
 
-@njit
+@jit_ifnumba
 def _guess_scan_index_grid(rotidx, start, stop):
     indxs = np.zeros(rotidx[stop], dtype=np.int64)
     rotidx = rotidx[start : stop + 1]

--- a/rsciio/utils/fei_stream_readers.py
+++ b/rsciio/utils/fei_stream_readers.py
@@ -20,7 +20,7 @@ import numpy as np
 import dask.array as da
 import sparse
 
-from numba import njit
+from rsciio.utils.tools import jit_ifnumba
 
 
 class DenseSliceCOO(sparse.COO):
@@ -35,7 +35,7 @@ class DenseSliceCOO(sparse.COO):
             return obj
 
 
-@njit(cache=True)
+@jit_ifnumba(cache=True)
 def _stream_to_sparse_COO_array_sum_frames(
     stream_data, last_frame, shape, channels, rebin_energy=1, first_frame=0
 ):  # pragma: no cover
@@ -123,7 +123,7 @@ def _stream_to_sparse_COO_array_sum_frames(
     return coords, data, final_shape
 
 
-@njit(cache=True)
+@jit_ifnumba(cache=True)
 def _stream_to_sparse_COO_array(
     stream_data, last_frame, shape, channels, rebin_energy=1, first_frame=0
 ):  # pragma: no cover
@@ -261,7 +261,7 @@ def stream_to_sparse_COO_array(
     return dask_sparse
 
 
-@njit(cache=True)
+@jit_ifnumba(cache=True)
 def _fill_array_with_stream_sum_frames(
     spectrum_image, stream, first_frame, last_frame, rebin_energy=1
 ):  # pragma: no cover
@@ -289,7 +289,7 @@ def _fill_array_with_stream_sum_frames(
             navigation_index += 1
 
 
-@njit(cache=True)
+@jit_ifnumba(cache=True)
 def _fill_array_with_stream(
     spectrum_image, stream, first_frame, last_frame, rebin_energy=1
 ):  # pragma: no cover
@@ -386,7 +386,7 @@ def stream_to_array(
     return spectrum_image
 
 
-@njit(cache=True)
+@jit_ifnumba(cache=True)
 def array_to_stream(array):  # pragma: no cover
     """Convert an array to a FEI stream
 

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -516,3 +516,21 @@ def get_file_handle(data, warn=True):
                     "an hdf5 file."
                 )
     return None
+
+
+def jit_ifnumba(*args, **kwargs):
+    try:
+        import numba
+
+        if "nopython" not in kwargs:
+            kwargs["nopython"] = True
+        return numba.jit(*args, **kwargs)
+    except ImportError:
+
+        def wrap1(func):
+            def wrap2(*args2, **kwargs2):
+                return func(*args2, **kwargs2)
+
+            return wrap2
+
+        return wrap1


### PR DESCRIPTION
In addition to reducing the number of required dependencies, this also has the advantage of testing the lastest python version before numba supports it but also to run rosettasciio in JupyterLite.

### Progress of the PR
- [x] Make numba and h5py optional dependencies,
- [x] test against python 3.12,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.


