### PR TITLE
Fix getting version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /dist/*
 /RosettaSciIO.egg-info/*
 *__pycache__*
-*test_compilers.o
+*test_compilers.o*
 *pyd
 .spyproject/*
 .idea

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -20,9 +23,9 @@ formats:
   - htmlzip
 
 python:
-   install:
-      - method: pip
-        path: .
-        extra_requirements:
-           - all
-           - docs
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+          - all
+          - docs

--- a/docs/user_guide/install.rst
+++ b/docs/user_guide/install.rst
@@ -86,8 +86,8 @@ To install with conda, we recommend you install it in a
 `Miniforge distribution <https://github.com/conda-forge/miniforge>`_.
 To create an environment and activate it::
 
-   conda create --name rsciio python=3.11
-   conda activate rsciio
+    conda create --name rsciio python=3.11
+    conda activate rsciio
 
 To install rosettasciio with all dependencies::
 
@@ -132,3 +132,14 @@ To install RosettaSciIO from source, clone the repository from `GitHub
     cd rosettasciio
     pip install --editable .
 
+.. note::
+
+    If `setuptools_scm <https://setuptools-scm.readthedocs.io>`_ is
+    installed, the version will be determined from the git repository
+    at runtime, otherwise, the version will be the one at build time.
+
+To install a development version on CI, it is advised to use
+`pip with vcs support <https://pip.pypa.io/en/stable/topics/vcs-support/>`_
+in order to get the correct development version, e.g. ``0.3.dev14+g706deac``::
+
+    pip install git+https://github.com/hyperspy/rosettasciio.git

--- a/prepare_release.py
+++ b/prepare_release.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import subprocess
+
+
+def run_towncrier(tag):
+    cmd = ("towncrier", "build", "--version", tag.strip("v"))
+
+    return subprocess.call(cmd)
+
+
+def update_fallback_version_in_pyproject(tag, fname="pyproject.toml"):
+    version = tag.strip("v").split(".")
+    # Default to +1 on minor version
+    major, minor = version[0], int(version[1]) + 1
+
+    with open(fname, "r") as file:
+        lines = file.readlines()
+
+    pattern = "fallback_version"
+    new_version = f"{major}.{minor}.dev0"
+    # Iterate through the lines and find the pattern
+    for i, line in enumerate(lines):
+        if re.search(pattern, line):
+            lines[i] = f'{pattern} = "{new_version}"\n'
+            break
+
+    # Write the updated content back to the file
+    with open(fname, "w") as file:
+        file.writelines(lines)
+
+    print(
+        f"\nNew (fallback) dev version ({new_version}) written to `pyproject.toml`.\n"
+    )
+
+
+if __name__ == "__main__":
+    # Get tag argument
+    parser = argparse.ArgumentParser()
+    parser.add_argument("tag")
+    args = parser.parse_args()
+    tag = args.tag
+
+    # Update release notes
+    run_towncrier(tag)
+
+    # Update fallback version for setuptools_scm
+    update_fallback_version_in_pyproject(tag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,8 @@ include = ["rsciio*"]
 
 [tool.setuptools_scm]
 # Presence enables setuptools_scm, the version will be determine at build time from git
-fallback_version = "0.0+UNKNOWN"
+# The version will be updated by the `prepare_release.py` script
+fallback_version = "0.3.dev0"
 
 [tool.towncrier]
 package = "rsciio"
@@ -162,6 +163,7 @@ issue_format = "`#{issue} <https://github.com/hyperspy/rosettasciio/issues/{issu
 branch = true
 source = ["rsciio"]
 omit = [
+  "prepare_release.py",
   "rsciio/tests/*",
   "setup.py",
   "update_registry.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ include = ["rsciio*"]
 
 [tool.setuptools_scm]
 # Presence enables setuptools_scm, the version will be determine at build time from git
+fallback_version = "0.0+UNKNOWN"
 
 [tool.towncrier]
 package = "rsciio"

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -5,7 +5,10 @@ Cut a Release
 Create a PR to the `main` branch and go through the following steps:
 
 **Preparation**
-- Update and check changelog in `CHANGES.rst`: run `towncrier build` (to preview, run `towncrier build --draft`)
+- Prepare the release by running the `prepare_release.py` python script (e.g. `python prepare_release.py 0.2`) , which will do the following:
+  - update the release notes in `CHANGES.rst` by running `towncrier`,
+  - update the `setuptools_scm` fallback version in `pyproject.toml` (for a patch release, this will stay the same).
+- Check release notes
 - (optional) check conda-forge and wheels build. Pushing a tag to a fork will run the release workflow. It will not upload to pypi, because it is only enabled from the `hyperspy` organisation
 - Let that PR collect comments for a day to ensure that other maintainers are comfortable with releasing
 

--- a/rsciio/__init__.py
+++ b/rsciio/__init__.py
@@ -17,22 +17,19 @@
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from importlib.metadata import version
-import logging
 import os
 from pathlib import Path
 import yaml
 
 
-_logger = logging.getLogger(__name__)
 IO_PLUGINS = []
 
 __version__ = version("rosettasciio")
 
-# For development version, `setuptools_scm` will be used at
-# build time to get the dev version:
-# - in case of missing vcs information, it will fallback to the
-#   version defined in pyproject.toml will be used
-# - in case of shallow checkout (pip install git+https://...)
+# For development version, `setuptools_scm` will be used at build time
+# to get the dev version, in case of missing vcs information (git archive,
+# shallow repository), the fallback version defined in pyproject.toml will
+# be used
 
 # if we have a editable install from a git repository try to use
 # `setuptools_scm` to find a more accurate version:

--- a/rsciio/__init__.py
+++ b/rsciio/__init__.py
@@ -16,25 +16,41 @@
 # You should have received a copy of the GNU General Public License
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from importlib.metadata import version
 import logging
 import os
 from pathlib import Path
 import yaml
 
 
-if Path(__file__).parent.parent.name == "site-packages":  # pragma: no cover
-    # Tested in the "build" workflow on GitHub CI
-    from importlib.metadata import version
-
-    __version__ = version("rosettasciio")
-else:
-    # Editable install
-    from setuptools_scm import get_version
-
-    __version__ = get_version(Path(__file__).parent.parent)
-
-IO_PLUGINS = []
 _logger = logging.getLogger(__name__)
+IO_PLUGINS = []
+
+__version__ = version("rosettasciio")
+
+# For development version, `setuptools_scm` will be used at
+# build time to get the dev version:
+# - in case of missing vcs information, it will fallback to the
+#   version defined in pyproject.toml will be used
+# - in case of shallow checkout (pip install git+https://...)
+
+# if we have a editable install from a git repository try to use
+# `setuptools_scm` to find a more accurate version:
+# `importlib.metadata` will provide the version at installation
+# time and for editable version this may be different
+
+# we only do that if we have enough git history, e.g. not shallow checkout
+_root = Path(__file__).resolve().parents[1]
+if (_root / ".git").exists() and not (_root / ".git/shallow").exists():
+    try:
+        # setuptools_scm may not be installed
+        from setuptools_scm import get_version
+
+        __version__ = get_version(_root)
+    except ImportError:  # pragma: no cover
+        # setuptools_scm not install, we keep the existing __version__
+        pass
+
 
 for sub, _, _ in os.walk(os.path.abspath(os.path.dirname(__file__))):
     _specsf = os.path.join(sub, "specifications.yaml")
@@ -44,6 +60,7 @@ for sub, _, _ in os.walk(os.path.abspath(os.path.dirname(__file__))):
             # for testing purposes
             _specs["api"] = "rsciio.%s" % os.path.split(sub)[1]
             IO_PLUGINS.append(_specs)
+
 
 __all__ = [
     "__version__",

--- a/upcoming_changes/187.bugfix.rst
+++ b/upcoming_changes/187.bugfix.rst
@@ -1,0 +1,1 @@
+Fix getting version on debian/ubuntu in system-wide install. Add support for installing from git archive and improve getting development version using setuptools `fallback_version <https://setuptools-scm.readthedocs.io/en/latest/config>`_


### PR DESCRIPTION
Alternative to #185.

### Progress of the PR
- [x] Use `fallback_version` at build time to define version when necessary version control information are missing (git archive or shallow checkout). When making a new release, the `fallback_version` will be updated automatically by the `prepare_release.py` script,
- [x] Use `setuptools_scm` at runtime only when possible, 
- [x] Fix getting version on system wide install on debian/ubuntu 
- [n/a] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests (check version on CI), also tested manually from git archive,
- [x] ready for review.


