### PR TITLE
Unpin pillow now that imageio supports pillow>=10.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ file = "COPYING.txt"
 blockfile = ["scikit-image>=0.18"]
 eds-stream = ["sparse"]
 hdf5 = ["h5py>=2.3"]
-# Remove pillow pinning when https://github.com/imageio/imageio/issues/1044 is fixed
-image = ["imageio>=2.16", "pillow<10.1.0"]
+image = ["imageio>=2.16"]
 mrcz = ["blosc>=1.5", "mrcz>=0.3.6"]
 scalebar_export = ["matplotlib-scalebar", "matplotlib>=3.5"]
 speed = ["numba>=0.52"]

--- a/upcoming_changes/188.maintenance.rst
+++ b/upcoming_changes/188.maintenance.rst
@@ -1,0 +1,1 @@
+Unpin pillow now that imageio supports pillow>=10.1.0


### PR DESCRIPTION
See https://github.com/hyperspy/rosettasciio/pull/175 for context.