### PR TITLE
Fix reading of dwell time in QuantumDetectors reader

### DIFF
--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -571,7 +571,7 @@ def file_reader(
         },
         "Signal": {"signal_type": "electron_diffraction"},
         "Acquisition_instrument": {
-            "dwell_time": mib_prop.exposure * 1e-3, # ms to s
+            "dwell_time": mib_prop.exposure * 1e-3,  # ms to s
         },
     }
     if time_zone:

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -571,7 +571,7 @@ def file_reader(
         },
         "Signal": {"signal_type": "electron_diffraction"},
         "Acquisition_instrument": {
-            "dwell_time": mib_prop.exposure * 1e-6,
+            "dwell_time": mib_prop.exposure * 1e-3, # ms to s
         },
     }
     if time_zone:

--- a/rsciio/tests/test_quantumdetector.py
+++ b/rsciio/tests/test_quantumdetector.py
@@ -336,7 +336,7 @@ def test_metadata():
     assert md_gen.date == "2021-05-07"
     assert md_gen.time == "16:51:10.905800928"
     assert md_gen.time_zone == "UTC"
-    np.testing.assert_allclose(s.metadata.Acquisition_instrument.dwell_time, 1e-4)
+    np.testing.assert_allclose(s.metadata.Acquisition_instrument.dwell_time, 1e-1)
 
 
 def test_print_info():

--- a/upcoming_changes/189.bugfix.rst
+++ b/upcoming_changes/189.bugfix.rst
@@ -1,0 +1,3 @@
+Fix `dwell_time` reading in QuantumDetectors reader (`.mib` file). The
+`dwell_time` is stored in milliseconds, not microseconds as the previous code
+assumed.

--- a/upcoming_changes/189.bugfix.rst
+++ b/upcoming_changes/189.bugfix.rst
@@ -1,3 +1,3 @@
-Fix `dwell_time` reading in QuantumDetectors reader (`.mib` file). The
-`dwell_time` is stored in milliseconds, not microseconds as the previous code
+Fix ``dwell_time`` reading in :ref:`QuantumDetectors <quantumdetector-format>` reader (``.mib`` file). The
+``dwell_time`` is stored in milliseconds, not microseconds as the previous code
 assumed.


### PR DESCRIPTION
### Description of the change

Currently the reader assumes that the dwell time is stored in microseconds. However, the dwell time is stored in ms. This PR fixes it.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


