### PR TITLE
Add saving of ragged lazy vectors

### DIFF
--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -39,6 +39,15 @@ not_valid_format = "The file is not a valid HyperSpy hdf5 file"
 _logger = logging.getLogger(__name__)
 
 
+def ravel_data(x):
+    new_data = np.empty(shape=x.shape, dtype=object)
+    shapes = np.empty(shape=x.shape, dtype=object)
+    for i in np.ndindex(x.shape):
+        new_data[i] = x[i].ravel()
+        shapes[i] = np.array(x[i].shape)
+    return new_data, shapes
+
+
 def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
     """
     Function that calculates chunks for the signal, preferably at least one
@@ -243,10 +252,11 @@ class HierarchicalReader:
             # if the data is chunked saved array we must first
             # cast to a numpy array to avoid multiple calls to
             # _decode_chunk in zarr (or h5py)
-            ragged_shape = np.array(ragged_shape)
             new_data = np.empty(shape=data.shape, dtype=object)
             # cast to numpy array to stop multiple calls to _decode_chunk in zarr
             data = np.array(data)
+            ragged_shape = np.array(ragged_shape)
+
             for i in np.ndindex(data.shape):
                 new_data[i] = np.reshape(data[i], ragged_shape[i])
             data = new_data
@@ -724,28 +734,30 @@ class HierarchicalWriter:
 
         _logger.info(f"Chunks used for saving: {chunks}")
         if data.dtype == np.dtype("O"):
-            new_data = np.empty(shape=data.shape, dtype=object)
-            shapes = np.empty(shape=data.shape, dtype=object)
-            for i in np.ndindex(data.shape):
-                new_data[i] = data[i].ravel()
-                shapes[i] = np.array(data[i].shape)
+            if isinstance(data, da.Array):
+                new_data, shapes = da.apply_gufunc(
+                    ravel_data,
+                    "()->(),()",
+                    data,
+                    dtype=object,
+                    output_dtypes=[object, object],
+                    allow_rechunk=False,
+                )
+            else:
+                new_data = np.empty(shape=data.shape, dtype=object)
+                shapes = np.empty(shape=data.shape, dtype=object)
+                for i in np.ndindex(data.shape):
+                    new_data[i] = data[i].ravel()
+                    shapes[i] = np.array(data[i].shape)
             shape_dset = cls._get_object_dset(
                 group, shapes, f"_ragged_shapes_{key}", shapes.shape, **kwds
             )
             cls._store_data(
-                shapes,
-                shape_dset,
+                (new_data, shapes),
+                (dset, shape_dset),
                 group,
-                f"_ragged_shapes_{key}",
-                chunks=shapes.shape,
-                show_progressbar=show_progressbar,
-            )
-            cls._store_data(
-                new_data,
-                dset,
-                group,
-                key,
-                chunks,
+                (key, f"_ragged_shapes_{key}"),
+                (chunks, shapes.shape),
                 show_progressbar,
             )
         else:

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -91,7 +91,7 @@ class HyperspyWriter(HierarchicalWriter):
             if isinstance(data_, da.Array):
                 if data_.chunks != dset_.chunks:
                     data[i] = data_.rechunk(dset_.chunks)
-                if data_.ndim == 1:
+                if data_.ndim == 1 and data_.dtype == object:
                     raise ValueError(
                         "Saving a 1-D ragged dask array to hspy is not supported"
                         " yet. Please open an issue on GitHub if you need this feature."

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -93,8 +93,7 @@ class HyperspyWriter(HierarchicalWriter):
                     data[i] = data_.rechunk(dset_.chunks)
                 if data_.ndim == 1 and data_.dtype == object:
                     raise ValueError(
-                        "Saving a 1-D ragged dask array to hspy is not supported"
-                        " yet. Please open an issue on GitHub if you need this feature."
+                        "Saving a 1-D ragged dask array to hspy is not supported yet. "
                         "Please use the .zspy extension."
                     )
                 # for performance reason, we write the data later, with all data

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -903,7 +903,8 @@ def test_save_ragged_dim_lazy(tmp_path, file, nav_dim):
 
     filename = tmp_path / file
     s.save(filename)
-    s2 = hs.load(filename)
+    s2 = hs.load(filename, lazy=True)
+    assert isinstance(s2.data, da.Array)
     assert s.axes_manager.navigation_shape == s2.axes_manager.navigation_shape
     assert s.data.shape == s2.data.shape
 

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -857,7 +857,8 @@ def test_save_ragged_array(tmp_path, file):
 
 @zspy_marker
 @pytest.mark.parametrize("nav_dim", [1, 2, 3])
-def test_save_ragged_dim(tmp_path, file, nav_dim):
+@pytest.mark.parametrize("lazy", [True, False])
+def test_save_ragged_dim(tmp_path, file, nav_dim, lazy):
     file = f"nav{nav_dim}_" + file
     rng = np.random.default_rng(0)
     nav_shape = np.arange(10, 10 * (nav_dim + 1), step=10)
@@ -867,19 +868,28 @@ def test_save_ragged_dim(tmp_path, file, nav_dim):
         data[ind] = rng.random((num, 2)) * 100
 
     s = hs.signals.BaseSignal(data, ragged=True)
+    if lazy:
+        s = s.as_lazy()
     assert s.axes_manager.navigation_dimension == nav_dim
     np.testing.assert_allclose(s.axes_manager.navigation_shape, nav_shape[::-1])
     assert s.data.ndim == nav_dim
     np.testing.assert_allclose(s.data.shape, nav_shape)
 
     filename = tmp_path / file
-    s.save(filename)
-    s2 = hs.load(filename)
-    assert s.axes_manager.navigation_shape == s2.axes_manager.navigation_shape
-    assert s.data.shape == s2.data.shape
+    if ".hspy" in file and nav_dim == 1 and lazy:
+        with pytest.raises(ValueError):
+            s.save(filename)
 
-    for indices in np.ndindex(s.data.shape):
-        np.testing.assert_allclose(s.data[indices], s2.data[indices])
+    else:
+        s.save(filename)
+        s2 = hs.load(filename, lazy=lazy)
+        assert s.axes_manager.navigation_shape == s2.axes_manager.navigation_shape
+        assert s.data.shape == s2.data.shape
+        if lazy:
+            assert isinstance(s2.data, da.Array)
+
+        for indices in np.ndindex(s.data.shape):
+            np.testing.assert_allclose(s.data[indices], s2.data[indices])
 
 
 @zspy_marker
@@ -902,14 +912,19 @@ def test_save_ragged_dim_lazy(tmp_path, file, nav_dim):
     np.testing.assert_allclose(s.data.shape, nav_shape)
 
     filename = tmp_path / file
-    s.save(filename)
-    s2 = hs.load(filename, lazy=True)
-    assert isinstance(s2.data, da.Array)
-    assert s.axes_manager.navigation_shape == s2.axes_manager.navigation_shape
-    assert s.data.shape == s2.data.shape
+    if ".hspy" in file and nav_dim == 1:
+        with pytest.raises(ValueError):
+            s.save(filename)
 
-    for indices in np.ndindex(s.data.shape):
-        np.testing.assert_allclose(s.data[indices], s2.data[indices])
+    else:
+        s.save(filename)
+        s2 = hs.load(filename, lazy=True)
+        assert isinstance(s2.data, da.Array)
+        assert s.axes_manager.navigation_shape == s2.axes_manager.navigation_shape
+        assert s.data.shape == s2.data.shape
+
+        for indices in np.ndindex(s.data.shape):
+            np.testing.assert_allclose(s.data[indices], s2.data[indices])
 
 
 def test_load_missing_extension(caplog):

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -882,6 +882,35 @@ def test_save_ragged_dim(tmp_path, file, nav_dim):
         np.testing.assert_allclose(s.data[indices], s2.data[indices])
 
 
+@zspy_marker
+@pytest.mark.parametrize("nav_dim", [1, 2, 3])
+def test_save_ragged_dim_lazy(tmp_path, file, nav_dim):
+    file = f"nav{nav_dim}_" + file
+    rng = np.random.default_rng(0)
+    nav_shape = np.arange(10, 10 * (nav_dim + 1), step=10)
+    data = np.empty(nav_shape, dtype=object)
+    for ind in np.ndindex(data.shape):
+        num = rng.integers(3, 10)
+        data[ind] = rng.random((num, 2)) * 100
+    data = da.from_array(data, chunks=2)
+
+    s = hs.signals.BaseSignal(data, ragged=True)
+    s.as_lazy()
+    assert s.axes_manager.navigation_dimension == nav_dim
+    np.testing.assert_allclose(s.axes_manager.navigation_shape, nav_shape[::-1])
+    assert s.data.ndim == nav_dim
+    np.testing.assert_allclose(s.data.shape, nav_shape)
+
+    filename = tmp_path / file
+    s.save(filename)
+    s2 = hs.load(filename)
+    assert s.axes_manager.navigation_shape == s2.axes_manager.navigation_shape
+    assert s.data.shape == s2.data.shape
+
+    for indices in np.ndindex(s.data.shape):
+        np.testing.assert_allclose(s.data[indices], s2.data[indices])
+
+
 def test_load_missing_extension(caplog):
     path = TEST_DATA_PATH / "hspy_ext_missing.hspy"
     with pytest.warns(UserWarning):


### PR DESCRIPTION
### Description of the change
Currently Ragged Lazy arrays aren't saved properly because the underlying dtype isn't properly accessed.  Hdf5 and zarr only support 1 layer of object arrays so you can't have an object array of object arrays as serializing that would be quite difficult.  

In addition there are some small points here that have performance implications.  For example we need the shape size at each navigation position in order to unwrap things.  We want to make sure that this runs in the same task graph so that they are merged/ simplified so that things don't run twice when saving :).

Thus passing a tuple to da.store.



### Progress of the PR
- [ ] Fix Storing hspy ragged lazy
- [ ] Fix Storing zspy ragged lazy
- [ ] Add tests (passing?)
- [ ] Make sure that loading doesn't load everything into memory
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import numpy as np
import hyperspy.api as hs
nav_shape = np.arange(10, 10 * (nav_dim + 1), step=10)
data = np.empty(nav_shape, dtype=object)
for ind in np.ndindex(data.shape):
   num = rng.integers(3, 10)
   data[ind] = rng.random((num, 2)) * 100
data = da.from_array(data, chunks=2)

s = hs.signals.BaseSignal(data, ragged=True)
s.as_lazy()
s.save("test.zspy")
```

The 1D hspy case is still failing for some reason but I wanted to just create this PR to see if people had suggestions?
