### PR TITLE
Fix passing `show_progressbar` argument when saving `hspy` file

### DIFF
--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -212,6 +212,7 @@ def file_writer(
         chunks=chunks,
         compression=compression,
         write_dataset=write_dataset,
+        show_progressbar=show_progressbar,
         **kwds,
     )
     writer.write()


### PR DESCRIPTION
Missing from #170.
