### PR TITLE
Add `POOCH_BASE_URL` to specify the base url used by pooch to download test data

### DIFF
--- a/.github/workflows/package_and_test.yml
+++ b/.github/workflows/package_and_test.yml
@@ -9,3 +9,5 @@ jobs:
     uses: hyperspy/.github/.github/workflows/package_and_test.yml@main
     with:
       module_name: rsciio
+      # github.head_ref is for pull request event while github.ref_name is for push event
+      POOCH_BASE_URL: https://github.com/${{ github.repository }}/raw/${{ github.head_ref || github.ref_name }}/rsciio/tests/data/

--- a/.github/workflows/package_and_test.yml
+++ b/.github/workflows/package_and_test.yml
@@ -9,5 +9,6 @@ jobs:
     uses: hyperspy/.github/.github/workflows/package_and_test.yml@main
     with:
       module_name: rsciio
-      # github.head_ref is for pull request event while github.ref_name is for push event
-      POOCH_BASE_URL: https://github.com/${{ github.repository }}/raw/${{ github.head_ref || github.ref_name }}/rsciio/tests/data/
+      # "github.event.pull_request.head.repo.full_name" is for "pull request" event while github.repository is for "push" event 
+      # "github.event.pull_request.head.ref" is for "pull request" event while "github.ref_name" is for "push" event
+      POOCH_BASE_URL: https://github.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/raw/${{ github.event.pull_request.head.ref || github.ref_name }}/rsciio/tests/data/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }} ${{ matrix.CIBW_ARCHS }}
     runs-on: ${{ matrix.os }}-latest
     env:
+      CIBW_ENVIRONMENT: POOCH_BASE_URL=https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/rsciio/tests/data/
       CIBW_TEST_COMMAND: "pytest --pyargs rsciio"
       CIBW_TEST_EXTRAS: "tests"
       # No need to build wheels for pypy because the pure python wheels can be used

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,15 +44,16 @@ source code or by using :ref:`pre-commit hooks <pre-commit-hooks>`.
 Adding and Updating Test Data
 -----------------------------
 The test data are located in the corresponding subfolder of the ``rsciio/tests/data`` folder.
+The test data are not packaged in the distribution files (wheel, sdist) to keep the packages
+as small as possible in size. When running the test suite, the test data will be downloaded
+from GitHub using pooch. When adding or updating test data, it is necessary to update the test
+data registry.
+
 To add or update test data:
 
 #. use git as usual to add files to the repository.
-#. Update ``rsciio.tests.registry.txt``.  The test data are not packaged in RosettaSciIO to
-   keep the packages as small as possible in size. However, to be able to run the test suite
-   of RosettaSciIO after installation or when packaging on conda-forge, pooch is used to
-   download the data when necessary. It means that when adding and updating test files, it
-   is necessary to update the registry ``rsciio.tests.registry.txt``, which can be done by
-   running :py:func:`~.tests.registry_utils.update_registry` (Unix only):
+#. Update ``rsciio.tests.registry.txt`` by running
+   :py:func:`~.tests.registry_utils.update_registry` (Unix only):
 
    .. code-block:: python
 
@@ -62,6 +63,12 @@ To add or update test data:
 
    On windows, you can use :ref:`pre-commit.ci <pre-commit-hooks>` by adding a message to
    the pull request to update the registry.
+
+.. note::
+
+  The url used by pooch to download the test data can be set by the environment variable
+  ``POOCH_BASE_URL``, otherwise, the default is to download the data from the
+  `hyperspy/rosettasciio <https://github.com/hyperspy/rosettasciio>`_ GitHub repository.
 
 Review
 ------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,8 @@ pool:
 
 steps:
 - checkout: self
-  fetchDepth: 1 # Fetch only one commit
+  fetchDepth: 0 # Fetch all commits for setuptools_scm 
+  fetchTags: true #  tags necessary for setuptools_scm
 - template: azure_pipelines/clone_ci-scripts_repo.yml@templates
 - template: azure_pipelines/install_mambaforge.yml@templates
 - template: azure_pipelines/activate_conda.yml@templates
@@ -65,17 +66,10 @@ steps:
 
 - bash: |
     source activate $ENV_NAME
+    pip install "hyperspy>=2.0rc0"
     pip install --no-deps -e .
     conda list
   displayName: Install package
-
-# Need to install hyperspy dev until hyperspy 2.0 is released
-- bash: |
-    source activate $ENV_NAME
-    pip install https://github.com/hyperspy/hyperspy/archive/refs/heads/RELEASE_next_major.zip
-    conda list
-  displayName: Install (HyperSpy dev)
-
 
 # Note we must use `-n 2` argument for pytest-xdist due to
 # https://github.com/pytest-dev/pytest-xdist/issues/9.

--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - cython
+- pooch
 - pytest
 - pytest-xdist
 - pytest-rerunfailures

--- a/rsciio/tests/registry.py
+++ b/rsciio/tests/registry.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import os
 from packaging.version import Version
 from pathlib import Path
 
@@ -36,9 +37,20 @@ else:
 TESTS_PATH = Path(__file__).parent
 
 
+# This environment variable can be used to specify a base url other than the one
+# from the hyperspy/rosettasciio repository.
+# This is used in workflow when the test suite is run from the packages (test files
+# not included), such as the "package and test" and "release" workflow on GitHub,
+# other workflows use local files (available from the git repository)
+BASE_URL = os.environ.get(
+    "POOCH_BASE_URL",
+    f"https://github.com/hyperspy/rosettasciio/raw/{version}/rsciio/tests/data/",
+)
+
+
 TEST_DATA_REGISTRY = pooch.create(
     path=TESTS_PATH / "data",
-    base_url=f"https://github.com/hyperspy/rosettasciio/raw/{version}/rsciio/tests/data/",
+    base_url=BASE_URL,
     # We don't use the version functionality of pooch because we want to use the
     # local test folder (rsciio.tests.data)
     version=None,

--- a/upcoming_changes/200.maintenance.rst
+++ b/upcoming_changes/200.maintenance.rst
@@ -1,0 +1,1 @@
+Add `POOCH_BASE_URL` to specify the base url used by pooch to download test data. This fixes the failure of the ``package_and_test.yml`` workflow in pull requests where test data are added or updated.


### PR DESCRIPTION
This will fix the `package_and_test.yml` workflow after adding some files in a PR (see for example https://github.com/hyperspy/rosettasciio/pull/162#issuecomment-1830089213) and also the `release.yml` workflow when running from a fork for testing the workflow (it is current working fine for a "real" run because the tag is then available in the `hyperspy/rosettasciio` repository).
I though it would be more complicated to fix and possibly not worth making something complicated but this solution is actually very simple.

### Progress of the PR
- [x] Add `POOCH_BASE_URL` to specify the base url used by pooch to download test data,
- [n/a] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

