### PR TITLE
Fix saving hspy file with empty array

### DIFF
--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -841,6 +841,7 @@ class HierarchicalWriter:
         "Recursive writer of dicts and signals"
 
         for key, value in dictionary.items():
+            _logger.debug("Saving item: {}".format(key))
             if isinstance(value, dict):
                 self.dict2group(value, group.require_group(key), **kwds)
             elif isinstance(value, (np.ndarray, self.Dataset, da.Array)):

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -79,8 +79,9 @@ def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
         The target number of bytes for one chunk
     """
     typesize = np.dtype(dtype).itemsize
-    if signal_axes is None:
-        return h5py._hl.filters.guess_chunk(shape, None, typesize)
+    if shape == (0,) or signal_axes is None:
+        # enable autochunking from h5py
+        return True
 
     # largely based on the guess_chunk in h5py
     bytes_per_signal = np.prod([shape[i] for i in signal_axes]) * typesize
@@ -839,7 +840,6 @@ class HierarchicalWriter:
 
     def dict2group(self, dictionary, group, **kwds):
         "Recursive writer of dicts and signals"
-
         for key, value in dictionary.items():
             _logger.debug("Saving item: {}".format(key))
             if isinstance(value, dict):

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -69,7 +69,10 @@ class HyperspyWriter(HierarchicalWriter):
         self.Dataset = h5py.Dataset
         self.Group = h5py.Group
         self.unicode_kwds = {"dtype": h5py.special_dtype(vlen=str)}
-        self.ragged_kwds = {"dtype": h5py.special_dtype(vlen=signal["data"][0].dtype)}
+        if len(signal["data"]) > 0:
+            self.ragged_kwds = {
+                "dtype": h5py.special_dtype(vlen=signal["data"][0].dtype)
+            }
 
     @staticmethod
     def _store_data(data, dset, group, key, chunks, show_progressbar=True):
@@ -98,7 +101,8 @@ class HyperspyWriter(HierarchicalWriter):
                     )
                 # for performance reason, we write the data later, with all data
                 # at the same time in a single `da.store` call
-            elif data_.flags.c_contiguous:
+            # "write_direct" doesn't play well with empty array
+            elif data_.flags.c_contiguous and data_.shape != (0,):
                 dset_.write_direct(data_)
             else:
                 dset_[:] = data_

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -148,9 +148,14 @@ def file_reader(filename, lazy=False, **kwds):
     f = h5py.File(filename, mode=mode, **kwds)
 
     reader = HyperspyReader(f)
-    exp_dict_list = reader.read(lazy=lazy)
-    if not lazy:
-        f.close()
+    # Use try, except, finally to close file when an error is raised
+    try:
+        exp_dict_list = reader.read(lazy=lazy)
+    except BaseException as err:
+        raise err
+    finally:
+        if not lazy:
+            f.close()
 
     return exp_dict_list
 
@@ -244,10 +249,14 @@ def file_writer(
         show_progressbar=show_progressbar,
         **kwds,
     )
-    writer.write()
-
-    if close_file:
-        f.close()
+    # Use try, except, finally to close file when an error is raised
+    try:
+        writer.write()
+    except BaseException as err:
+        raise err
+    finally:
+        if close_file:
+            f.close()
 
 
 file_writer.__doc__ %= (

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -1069,3 +1069,31 @@ def test_more_recent_version_warning(tmp_path):
     with pytest.warns(UserWarning):
         s2 = hs.load(filename)
     np.testing.assert_allclose(s.data, s2.data)
+
+
+@zspy_marker
+def test_save_metadata_empty_array(tmp_path, file):
+    filename = tmp_path / "test.hspy"
+
+    s = hs.signals.Signal1D(np.arange(100 * 1024).reshape(100, 1024))
+    s.metadata.set_item("Sample.xray_lines", np.array([]))
+
+    s.save(filename)
+    s2 = hs.load(filename)
+
+    np.testing.assert_allclose(
+        s.metadata.Sample.xray_lines, s2.metadata.Sample.xray_lines
+    )
+    np.testing.assert_allclose(s.data, s2.data)
+
+
+@zspy_marker
+def test_save_empty_signal(tmp_path, file):
+    filename = tmp_path / "test.hspy"
+
+    s = hs.signals.Signal1D([])
+
+    s.save(filename)
+    s2 = hs.load(filename)
+
+    np.testing.assert_allclose(s.data, s2.data)

--- a/upcoming_changes/206.bugfix.rst
+++ b/upcoming_changes/206.bugfix.rst
@@ -1,0 +1,1 @@
+Fix saving ``hspy`` file with empty array (signal or metadata) and fix closing ``hspy`` file when a error occurs during reading or writing.


### PR DESCRIPTION
Fix #205

### Progress of the PR
- [x] Add support for saving empty array,
- [x] fix closing `hspy` file when an error occurs, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


