### PR TITLE
Fix documentation link to hyperspy 2.0 documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,10 +160,10 @@ Maintenance
 - Fix minimum install, add corresponding tests build and tidy up leftover code (`#13 <https://github.com/hyperspy/rosettasciio/issues/13>`_)
 - Fixes and code consistency improvements based on analysis provided by lgtm.org (`#23 <https://github.com/hyperspy/rosettasciio/issues/23>`_)
 - Added github action for code scanning using the codeQL engine. (`#26 <https://github.com/hyperspy/rosettasciio/issues/26>`_)
-- Following the deprecation cycle announced in `HyperSpy <https://hyperspy.org/hyperspy-doc/current/user_guide/changes.html>`_,
+- Following the deprecation cycle announced in `HyperSpy <https://hyperspy.org/hyperspy-doc/v2.0/changes.html>`_,
   the following keywords and attributes have been removed:
 
-  - :ref:`Bruker composite file (BCF) <bcf-format>`: The ``'spectrum'`` option for the
+  - :ref:`Bruker composite file (BCF) <bruker-format>`: The ``'spectrum'`` option for the
     ``select_type`` parameter was removed. Use 'spectrum_image' instead.
   - :ref:`Electron Microscopy Dataset (EMD) NCEM <emd_ncem-format>`: Using the
     keyword ``'dataset_name'`` was removed, use ``'dataset_path'`` instead.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,6 +45,7 @@ extensions = [
 intersphinx_mapping = {
     "conda": ("https://conda.io/projects/conda/en/latest", None),
     "dask": ("https://docs.dask.org/en/latest", None),
+    "exspy": ("https://hyperspy.org/exspy", None),
     "hyperspy": ("https://hyperspy.org/hyperspy-doc/current/", None),
     "h5py": ("https://docs.h5py.org/en/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable", None),

--- a/doc/user_guide/supported_formats/hspy.rst
+++ b/doc/user_guide/supported_formats/hspy.rst
@@ -40,7 +40,7 @@ filename e.g.:
 
 
 When saving to ``.hspy``, all supported objects in the signal's
-:external+hyperspy:attr:`hyperspy.signal.BaseSignal.metadata` are stored. This includes lists, tuples
+:external+hyperspy:attr:`hyperspy.api.signals.BaseSignal.metadata` are stored. This includes lists, tuples
 and signals. Please note that in order to increase saving efficiency and speed,
 if possible, the inner-most structures are converted to numpy arrays when saved.
 This procedure homogenizes any types of the objects inside, most notably casting
@@ -58,7 +58,7 @@ The change of type is done using numpy "safe" rules, so no information is lost,
 as numbers are represented to full machine precision.
 
 This feature is particularly useful when using
-:external+hyperspy:meth:`hyperspy._signals.eds.EDSSpectrum.get_lines_intensity`:
+:external+exspy:meth:`exspy.signals.EDSSpectrum.get_lines_intensity`:
 
 .. code-block:: python
 

--- a/doc/user_guide/supported_formats/mrc.rst
+++ b/doc/user_guide/supported_formats/mrc.rst
@@ -39,7 +39,7 @@ not be passed (Default is ``None``):
 
     mrcz.file_writer('test.mrc', s_dict)
 
-Alternatively, use :py:meth:`hyperspy.signal.BaseSignal.save`, which will pick the
+Alternatively, use :py:meth:`hyperspy.api.signals.BaseSignal.save`, which will pick the
 ``mrcz`` plugin automatically:
 
 .. code-block:: python

--- a/doc/user_guide/supported_formats/nexus.rst
+++ b/doc/user_guide/supported_formats/nexus.rst
@@ -58,7 +58,7 @@ flexible and can also be used to inspect any hdf5 based file.
 Differences with respect to HSpy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The `HyperSpy metadata structure <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_
+The :external+hyperspy:ref:`HyperSpy metadata structure <metadata_structure>`
 stores arrays as hdf datasets without attributes
 and stores floats, ints and strings as attributes.
 The NeXus format uses hdf dataset attributes to store additional

--- a/upcoming_changes/210.maintenance.rst
+++ b/upcoming_changes/210.maintenance.rst
@@ -1,0 +1,1 @@
+Fix documentation links following release of hyperspy 2.0.


### PR DESCRIPTION
Update web links following hyperspy 2.0 release.

### Progress of the PR
- [n/a] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


