### PR TITLE
Bugfix: Set equal chunking for shapes and dataset

### DIFF
--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -764,7 +764,7 @@ class HierarchicalWriter:
                     shapes[i] = np.array(data[i].shape)
 
             shape_dset = cls._get_object_dset(
-                group, shapes, f"_ragged_shapes_{key}", shapes.shape, **kwds
+                group, shapes, f"_ragged_shapes_{key}", chunks, **kwds
             )
 
             cls._store_data(
@@ -772,7 +772,7 @@ class HierarchicalWriter:
                 (dset, shape_dset),
                 group,
                 (key, f"_ragged_shapes_{key}"),
-                (chunks, shapes.shape),
+                (chunks, chunks),
                 show_progressbar,
             )
         else:

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -263,13 +263,12 @@ class HierarchicalReader:
             key = "ragged_shapes"
         if key in group:
             ragged_shape = group[key]
-            # if the data is chunked saved array we must first
-            # cast to a numpy array to avoid multiple calls to
-            # _decode_chunk in zarr (or h5py)
+            # Use same chunks as data so that apply_gufunc doesn't rechunk
+            # Reduces the transfer of data between workers which
+            # significantly improves performance for distributed loading
             data = da.from_array(data, chunks=data.chunks)
-            shape = da.from_array(
-                ragged_shape, chunks=data.chunks
-            )  # same chunks as data
+            shape = da.from_array(ragged_shape, chunks=data.chunks)
+
             data = da.apply_gufunc(unflatten_data, "(),()->()", data, shape)
         return data
 

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -267,8 +267,9 @@ class HierarchicalReader:
             # cast to a numpy array to avoid multiple calls to
             # _decode_chunk in zarr (or h5py)
             data = da.from_array(data, chunks=data.chunks)
-            shape = da.from_array(ragged_shape, chunks=ragged_shape.chunks)
-            shape = shape.rechunk(data.chunks)
+            shape = da.from_array(
+                ragged_shape, chunks=data.chunks
+            )  # same chunks as data
             data = da.apply_gufunc(unflatten_data, "(),()->()", data, shape)
         return data
 

--- a/upcoming_changes/211.bugfix.rst
+++ b/upcoming_changes/211.bugfix.rst
@@ -1,0 +1,1 @@
+Fix saving ragged arrays of vectors from/to a chunked ``hspy`` and ``zspy`` store.  Greatly increases the speed of saving and loading ragged arrays from chunked datasets.


### PR DESCRIPTION
### Description of the change
I noticed this morning that I was having issues loading larger arrays of vectors using the distributed-dask backend.

The problem is that the shape array is not saved with the same chunking scheme so when you try to load the shape array you have to split the memory between all of the different cores.  This is slow, probably partially because dask doesn't know the size of the array which 

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
pks = s.find_peaks()
pks.save("ragged.zspy")
pks = hs.load("radded.zspy", lazy=True)
pks.compute() 
```

For a 1024x1024 array of peak positions the old saving scheme took 1 minute to load with the new scheme that becomes ~1 second with the new scheme.
