### PR TITLE
Fix saving ragged array string hspy

### DIFF
--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -45,7 +45,7 @@ not_valid_format = "The file is not a valid HyperSpy hdf5 file"
 
 current_file_version = None  # Format version of the file being read
 default_version = Version(version)
-VLEN_STR_DTYPE = h5py.special_dtype(vlen=str)
+VLEN_STR_DTYPE = h5py.string_dtype()
 
 
 class HyperspyReader(HierarchicalReader):
@@ -55,7 +55,6 @@ class HyperspyReader(HierarchicalReader):
         super().__init__(file)
         self.Dataset = h5py.Dataset
         self.Group = h5py.Group
-        self.unicode_kwds = {"dtype": h5py.special_dtype(vlen=str)}
 
 
 class HyperspyWriter(HierarchicalWriter):
@@ -70,11 +69,7 @@ class HyperspyWriter(HierarchicalWriter):
         super().__init__(file, signal, expg, **kwds)
         self.Dataset = h5py.Dataset
         self.Group = h5py.Group
-        self.unicode_kwds = {"dtype": h5py.special_dtype(vlen=str)}
-        if len(signal["data"]) > 0:
-            self.ragged_kwds = {
-                "dtype": h5py.special_dtype(vlen=signal["data"][0].dtype)
-            }
+        self.unicode_kwds = {"dtype": h5py.string_dtype()}
 
     @staticmethod
     def _store_data(data, dset, group, key, chunks, show_progressbar=True):

--- a/rsciio/zspy/_api.py
+++ b/rsciio/zspy/_api.py
@@ -22,6 +22,7 @@ from collections.abc import MutableMapping
 import dask.array as da
 from dask.diagnostics import ProgressBar
 import numcodecs
+import numpy as np
 import zarr
 
 from rsciio._docstrings import (
@@ -104,6 +105,12 @@ class ZspyWriter(HierarchicalWriter):
             dtype = data[test_ind].compute().dtype
         else:
             dtype = data[test_ind].dtype
+        if np.issubdtype(dtype, str):
+            size_of_char = np.dtype("U1").itemsize
+            # Go through the whole array to find the largest string type
+            for index in np.ndindex(data.shape):
+                if data[index].dtype.itemsize // size_of_char > dtype.itemsize:
+                    dtype = data[index].dtype
         dset = group.require_dataset(
             key,
             data.shape,

--- a/rsciio/zspy/_api.py
+++ b/rsciio/zspy/_api.py
@@ -84,11 +84,6 @@ class ZspyWriter(HierarchicalWriter):
         super().__init__(file, signal, expg, **kwargs)
         self.Dataset = zarr.Array
         self.unicode_kwds = {"dtype": object, "object_codec": numcodecs.JSON()}
-        self.ragged_kwds = {
-            "dtype": object,
-            "object_codec": numcodecs.VLenArray(signal["data"][0].dtype),
-            "exact": True,
-        }
 
     @staticmethod
     def _get_object_dset(group, data, key, chunks, **kwds):


### PR DESCRIPTION
Fix for #212.

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
"""
import numpy as np
import hyperspy.api as hs
import h5py

fname = "test.hspy"

rng = np.random.default_rng(0)
data = np.ones((5, 100, 100))
s = hs.signals.Signal2D(data)

# Create an navigation dependent (ragged) Texts marker
offsets = np.empty(s.axes_manager.navigation_shape, dtype=object)
texts = np.empty(s.axes_manager.navigation_shape, dtype=object)

for index in np.ndindex(offsets.shape):
    i = index[0]
    offsets[index] = rng.random((5, 2))[: i + 2] * 100
    texts[index] = np.array(
        ["a" * (i + 1), "b", "c", "d", "e"][: i + 2]
    )

m = hs.plot.markers.Texts(
    offsets=offsets,
    texts=texts,
    sizes=3,
    facecolor="black",
)

s.add_marker(m, permanent=True)
s.plot()
s.save(fname, overwrite=True)

s2 = hs.load(fname)

m_texts = m.kwargs['texts']
m2_texts = s2.metadata.Markers.Texts.kwargs['texts']


for index in np.ndindex(m_texts.shape):
    np.testing.assert_equal(m_texts[index], m2_texts[index])

```

