### PR TITLE
Fix saving ragged array string hspy - take 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ tiff = ["tifffile>=2020.2.16", "imagecodecs>=2020.1.31"]
 # Add sidpy dependency and pinning as workaround to fix pyUSID import
 # Remove sidpy dependency once https://github.com/pycroscopy/pyUSID/issues/85 is fixed.
 usid = ["pyUSID", "sidpy<=0.12.0"]
-zspy = ["zarr"]
+zspy = ["zarr", "msgpack"]
 tests = [
   "pooch",
   "pytest>=3.6",

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -46,8 +46,8 @@ def flatten_data(x, is_hdf5=False):
     new_data = np.empty(shape=x.shape, dtype=object)
     shapes = np.empty(shape=x.shape, dtype=object)
     for i in np.ndindex(x.shape):
-        data_ = x[i].ravel()
-        if np.issubdtype(x[i].dtype, np.dtype("U")):
+        data_ = np.array(x[i]).ravel()
+        if np.issubdtype(data_.dtype, np.dtype("U")):
             if is_hdf5:
                 # h5py doesn't support numpy unicode dtype, convert to
                 # compatible dtype
@@ -57,7 +57,7 @@ def flatten_data(x, is_hdf5=False):
                 new_data[i] = data_.tolist()
         else:
             new_data[i] = data_
-        shapes[i] = np.array(x[i].shape)
+        shapes[i] = np.array(np.array(x[i]).shape)
     return new_data, shapes
 
 

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -53,7 +53,6 @@ class HyperspyReader(HierarchicalReader):
         super().__init__(file)
         self.Dataset = h5py.Dataset
         self.Group = h5py.Group
-        self.unicode_kwds = {"dtype": h5py.special_dtype(vlen=str)}
 
 
 class HyperspyWriter(HierarchicalWriter):
@@ -63,16 +62,12 @@ class HyperspyWriter(HierarchicalWriter):
     """
 
     target_size = 1e6
+    _unicode_kwds = {"dtype": h5py.string_dtype()}
 
     def __init__(self, file, signal, expg, **kwds):
         super().__init__(file, signal, expg, **kwds)
         self.Dataset = h5py.Dataset
         self.Group = h5py.Group
-        self.unicode_kwds = {"dtype": h5py.special_dtype(vlen=str)}
-        if len(signal["data"]) > 0:
-            self.ragged_kwds = {
-                "dtype": h5py.special_dtype(vlen=signal["data"][0].dtype)
-            }
 
     @staticmethod
     def _store_data(data, dset, group, key, chunks, show_progressbar=True):

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -48,6 +48,7 @@ default_version = Version(version)
 
 class HyperspyReader(HierarchicalReader):
     _file_type = "hspy"
+    _is_hdf5 = True
 
     def __init__(self, file):
         super().__init__(file)
@@ -63,6 +64,7 @@ class HyperspyWriter(HierarchicalWriter):
 
     target_size = 1e6
     _unicode_kwds = {"dtype": h5py.string_dtype()}
+    _is_hdf5 = True
 
     def __init__(self, file, signal, expg, **kwds):
         super().__init__(file, signal, expg, **kwds)
@@ -85,11 +87,13 @@ class HyperspyWriter(HierarchicalWriter):
             dset = [
                 dset,
             ]
+
         for i, (data_, dset_) in enumerate(zip(data, dset)):
             if isinstance(data_, da.Array):
                 if data_.chunks != dset_.chunks:
                     data[i] = data_.rechunk(dset_.chunks)
                 if data_.ndim == 1 and data_.dtype == object:
+                    # https://github.com/hyperspy/rosettasciio/issues/198
                     raise ValueError(
                         "Saving a 1-D ragged dask array to hspy is not supported yet. "
                         "Please use the .zspy extension."
@@ -108,18 +112,19 @@ class HyperspyWriter(HierarchicalWriter):
                 da.store(data, dset)
 
     @staticmethod
-    def _get_object_dset(group, data, key, chunks, **kwds):
+    def _get_object_dset(group, data, key, chunks, dtype=None, **kwds):
         """Creates a h5py dataset object for saving ragged data"""
-        # For saving ragged array
-        if chunks is None:
+        if chunks is None:  # pragma: no cover
             chunks = 1
-        test_ind = data.ndim * (0,)
-        if isinstance(data, da.Array):
-            dtype = data[test_ind].compute().dtype
-        else:
-            dtype = data[test_ind].dtype
+
+        if dtype is None:
+            test_data = data[data.ndim * (0,)]
+            if isinstance(test_data, da.Array):
+                test_data = test_data.compute()
+            dtype = test_data.dtype
+
         dset = group.require_dataset(
-            key, data.shape, dtype=h5py.special_dtype(vlen=dtype), chunks=chunks, **kwds
+            key, data.shape, dtype=h5py.vlen_dtype(dtype), chunks=chunks, **kwds
         )
         return dset
 

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -849,7 +849,8 @@ class TestPermanentMarkersIO:
 
 
 @zspy_marker
-def test_saving_ragged_array_string(tmp_path, file):
+@pytest.mark.parametrize("use_list", [True, False])
+def test_saving_ragged_array_string(tmp_path, file, use_list):
     # h5py doesn't support numpy unicode dtype and when saving ragged
     # array, we need to change the array dtype
     fname = tmp_path / file
@@ -857,7 +858,10 @@ def test_saving_ragged_array_string(tmp_path, file):
     string_data = np.empty((5,), dtype=object)
     for index in np.ndindex(string_data.shape):
         i = index[0]
-        string_data[index] = np.array(["a" * (i + 1), "b", "c", "d", "e"][: i + 2])
+        data = np.array(["a" * (i + 1), "b", "c", "d", "e"][: i + 2])
+        if use_list:
+            data = data.tolist()
+        string_data[index] = data
 
     s = hs.signals.BaseSignal(string_data, ragged=True)
     s.save(fname)

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -810,6 +810,25 @@ class TestPermanentMarkersIO:
 
 
 @zspy_marker
+def test_saving_ragged_array_string(tmp_path, file):
+    # h5py doesn't support numpy unicode dtype and when saving ragged
+    # array, we need to change the array dtype
+    fname = tmp_path / file
+
+    string_data = np.empty((5,), dtype=object)
+    for index in np.ndindex(string_data.shape):
+        i = index[0]
+        string_data[index] = np.array(["a" * (i + 1), "b", "c", "d", "e"][: i + 2])
+
+    s = hs.signals.BaseSignal(string_data, ragged=True)
+    s.save(fname)
+
+    s2 = hs.load(fname)
+    for index in np.ndindex(s.data.shape):
+        np.testing.assert_equal(s.data[index], s2.data[index])
+
+
+@zspy_marker
 @pytest.mark.parametrize("lazy", [True, False])
 def test_save_load_model(tmp_path, file, lazy):
     from hyperspy._components.gaussian import Gaussian

--- a/rsciio/zspy/_api.py
+++ b/rsciio/zspy/_api.py
@@ -79,16 +79,11 @@ class ZspyReader(HierarchicalReader):
 class ZspyWriter(HierarchicalWriter):
     target_size = 1e8
     _file_type = "zspy"
+    _unicode_kwds = {"dtype": object, "object_codec": numcodecs.JSON()}
 
     def __init__(self, file, signal, expg, **kwargs):
         super().__init__(file, signal, expg, **kwargs)
         self.Dataset = zarr.Array
-        self.unicode_kwds = {"dtype": object, "object_codec": numcodecs.JSON()}
-        self.ragged_kwds = {
-            "dtype": object,
-            "object_codec": numcodecs.VLenArray(signal["data"][0].dtype),
-            "exact": True,
-        }
 
     @staticmethod
     def _get_object_dset(group, data, key, chunks, **kwds):

--- a/rsciio/zspy/_api.py
+++ b/rsciio/zspy/_api.py
@@ -22,6 +22,7 @@ from collections.abc import MutableMapping
 import dask.array as da
 from dask.diagnostics import ProgressBar
 import numcodecs
+import numpy as np
 import zarr
 
 from rsciio._docstrings import (
@@ -79,14 +80,14 @@ class ZspyReader(HierarchicalReader):
 class ZspyWriter(HierarchicalWriter):
     target_size = 1e8
     _file_type = "zspy"
-    _unicode_kwds = {"dtype": object, "object_codec": numcodecs.JSON()}
+    _unicode_kwds = dict(dtype=str)
 
     def __init__(self, file, signal, expg, **kwargs):
         super().__init__(file, signal, expg, **kwargs)
         self.Dataset = zarr.Array
 
     @staticmethod
-    def _get_object_dset(group, data, key, chunks, **kwds):
+    def _get_object_dset(group, data, key, chunks, dtype=None, **kwds):
         """Creates a Zarr Array object for saving ragged data
 
         Forces the number of chunks span the array if not a dask array as
@@ -97,17 +98,32 @@ class ZspyWriter(HierarchicalWriter):
             chunks = data.shape
         these_kwds = kwds.copy()
         these_kwds.update(dict(dtype=object, exact=True, chunks=chunks))
-        test_ind = data.ndim * (0,)
-        # Need to know the underlying dtype for the codec
-        # Note this can't be an object array
-        if isinstance(data, da.Array):
-            dtype = data[test_ind].compute().dtype
+
+        if dtype is None:
+            test_data = data[data.ndim * (0,)]
+            if isinstance(test_data, da.Array):
+                test_data = test_data.compute()
+            if hasattr(test_data, "dtype"):
+                # this is a numpy array
+                dtype = test_data.dtype
+            else:
+                dtype = type(test_data)
+
+        # For python type, JSON / MsgPack codecs, otherwise
+        # use VLenArray with specific numpy dtype
+        if (
+            np.issubdtype(dtype, str)
+            or np.issubdtype(dtype, list)
+            or np.issubdtype(dtype, tuple)
+        ):
+            object_codec = numcodecs.MsgPack()
         else:
-            dtype = data[test_ind].dtype
+            object_codec = numcodecs.VLenArray(dtype)
+
         dset = group.require_dataset(
             key,
             data.shape,
-            object_codec=numcodecs.VLenArray(dtype),
+            object_codec=object_codec,
             **these_kwds,
         )
         return dset

--- a/upcoming_changes/217.bugfix.rst
+++ b/upcoming_changes/217.bugfix.rst
@@ -1,0 +1,1 @@
+Fix saving ragged array of strings in ``hspy`` and ``zspy`` format.


### PR DESCRIPTION
Fix for #212 with small variations of #213: for zspy, use the msgpack encoder that can more deal with strings.

### Progress of the PR
- [x] Fix saving ragged array of strings in `hspy` and `zspy` format,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import numpy as np
import hyperspy.api as hs

fname = "test.hspy"

rng = np.random.default_rng(0)
data = np.ones((5, 100, 100))
s = hs.signals.Signal2D(data)

# Create an navigation dependent (ragged) Texts marker
offsets = np.empty(s.axes_manager.navigation_shape, dtype=object)
texts = np.empty(s.axes_manager.navigation_shape, dtype=object)

for index in np.ndindex(offsets.shape):
    i = index[0]
    offsets[index] = rng.random((5, 2))[: i + 2] * 100
    texts[index] = np.array(
        ["a" * (i + 1), "b", "c", "d", "e"][: i + 2]
    )

m = hs.plot.markers.Texts(
    offsets=offsets,
    texts=texts,
    sizes=3,
    facecolor="black",
)

s.add_marker(m, permanent=True)
s.plot()
s.save(fname, overwrite=True)

s2 = hs.load(fname)

m_texts = m.kwargs['texts']
m2_texts = s2.metadata.Markers.Texts.kwargs['texts']


for index in np.ndindex(m_texts.shape):
    np.testing.assert_equal(m_texts[index], m2_texts[index])
```
