### PR TITLE
Add osx arm64 GitHub ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,19 @@ jobs:
         name: Install Python
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
-
+        
+      - name: Get the number of CPUs
+        id: cpus
+        run: |
+          import os, platform
+          num_cpus = os.cpu_count()
+          print(f"Number of CPU: {num_cpus}")
+          print(f"Architecture: {platform.machine()}")
+          output_file = os.environ["GITHUB_OUTPUT"]
+          with open(output_file, "a", encoding="utf-8") as output_stream:
+              output_stream.write(f"count={num_cpus}\n")
+        shell: python
+          
       - name: Set Environment Variable
         shell: bash
         # Set PIP_SELECTOR environment variable according to matrix.LABEL
@@ -113,7 +125,7 @@ jobs:
 
       - name: Run test suite
         run: |
-          pytest --pyargs rsciio --reruns 3 -n 2 --cov=. --cov-report=xml
+          pytest --pyargs rsciio --reruns 3 -n ${{ steps.cpus.outputs.count }} --cov=. --cov-report=xml
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,8 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run_test_site:
-    name: ${{ matrix.os }}-py${{ matrix.PYTHON_VERSION }}${{ matrix.LABEL }}
-    runs-on: ${{ matrix.os }}-latest
+    name: ${{ matrix.os }}-${{ matrix.os_version }}-py${{ matrix.PYTHON_VERSION }}${{ matrix.LABEL }}
+    runs-on: ${{ matrix.os }}-${{ matrix.os_version }}
     timeout-minutes: 30
     env:
       MPLBACKEND: agg
@@ -13,11 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
+        os_version: [latest]
         PYTHON_VERSION: ['3.9', '3.10']
         LABEL: ['']
         include:
           # test oldest supported version of main dependencies on python 3.8
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.8'
             # Set pillow and scikit-image version to be compatible with imageio and scipy
             # matplotlib needs 3.5 to support markers in hyperspy 2.0 (requires `collection.set_offset_transform`)
@@ -25,17 +27,25 @@ jobs:
             LABEL: '-oldest'
           # test minimum requirement
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.9'
             LABEL: '-minimum'
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.12'
             LABEL: '-minimum-without-hyperspy'
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.9'
             LABEL: '-without-hyperspy'
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.8'
           - os: ubuntu
+            os_version: latest
+            PYTHON_VERSION: '3.11'
+          - os: macos
+            os_version: '14'
             PYTHON_VERSION: '3.11'
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
             LABEL: '-minimum-without-hyperspy'
           - os: ubuntu
             os_version: latest
+            PYTHON_VERSION: '3.11'
+            LABEL: '-hyperspy-dev'
+          - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.9'
             LABEL: '-without-hyperspy'
           - os: ubuntu
@@ -103,15 +107,15 @@ jobs:
         run: |
           pip install ${{ matrix.DEPENDENCIES }}
 
-      - name: Install (HyperSpy dev)
+      - name: Install hyperspy and exspy
         if: ${{ ! contains(matrix.LABEL, 'without-hyperspy') }}
-        # Need to install hyperspy dev until hyperspy 2.0 is released
         run: |
-          pip install git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_major
+          pip install hyperspy exspy
 
-      - name: Install (exspy)
-        if: ${{ ! contains(matrix.LABEL, '-minimum') && ! contains(matrix.LABEL, 'without-hyperspy') }}
+      - name: Install hyperspy and exspy (dev)
+        if: ${{ contains(matrix.LABEL, 'hyperspy-dev') }}
         run: |
+          pip install git+https://github.com/hyperspy/hyperspy.git
           pip install git+https://github.com/hyperspy/exspy.git
 
       - name: Install

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -935,7 +935,7 @@ def test_save_ragged_array(tmp_path, file):
 
 
 @zspy_marker
-@pytest.mark.parametrize("nav_dim", [1, 2, 3])
+@pytest.mark.parametrize("nav_dim", [1, 2])
 @pytest.mark.parametrize("lazy", [True, False])
 def test_save_ragged_dim(tmp_path, file, nav_dim, lazy):
     file = f"nav{nav_dim}_" + file

--- a/upcoming_changes/222.maintenance.rst
+++ b/upcoming_changes/222.maintenance.rst
@@ -1,0 +1,1 @@
+Run test suite on osx arm64 on GitHub CI and speed running test suite using all available CPUs (3 or 4) instead of only 2.


### PR DESCRIPTION
Similar as https://github.com/hyperspy/hyperspy/pull/3305.

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

### Progress of the PR
- [x] Add osx arm64 build to GitHub CI,
- [x] Speed running test suite using all available CPUs (3 or 4) instead of only 2,
- [x] Remove unnecessary  parametrisation of hspy/zspy ragged signal test which was slowing down the test suite,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


