### PR TITLE
Handle deprecation warnings from numpy 1.25

### DIFF
--- a/rsciio/blockfile/_api.py
+++ b/rsciio/blockfile/_api.py
@@ -186,7 +186,7 @@ def get_header_from_signal(signal, endianess="<"):
     DP_SZ = DP_SZ[0]
     SDP = 100.0 / sig_axes[1]["scale"]
 
-    offset2 = NX * NY + header["Data_offset_1"]
+    offset2 = NX * NY + header["Data_offset_1"][0]
     # Based on inspected files, the DPs are stored at 16-bit boundary...
     # Normally, you'd expect word alignment (32-bits) ¯\_(°_o)_/¯
     offset2 += offset2 % 16
@@ -409,11 +409,11 @@ def file_writer(
         # Write header
         header.tofile(f)
         # Write header note field:
-        if len(note) > int(header["Data_offset_1"]) - f.tell():
-            note = note[: int(header["Data_offset_1"]) - f.tell() - len(note)]
+        if len(note) > int(header["Data_offset_1"][0]) - f.tell():
+            note = note[: int(header["Data_offset_1"][0]) - f.tell() - len(note)]
         f.write(note.encode())
         # Zero pad until next data block
-        zero_pad = int(header["Data_offset_1"]) - f.tell()
+        zero_pad = int(header["Data_offset_1"][0]) - f.tell()
         np.zeros((zero_pad,), np.byte).tofile(f)
         # Write virtual bright field
         if navigator is None:
@@ -440,11 +440,11 @@ def file_writer(
         navigator = navigator.astype(endianess + "u1")
         np.asanyarray(navigator).tofile(f)
         # Zero pad until next data block
-        if f.tell() > int(header["Data_offset_2"]):
+        if f.tell() > int(header["Data_offset_2"][0]):
             raise ValueError(
                 "Signal navigation size does not match " "data dimensions."
             )
-        zero_pad = int(header["Data_offset_2"]) - f.tell()
+        zero_pad = int(header["Data_offset_2"][0]) - f.tell()
         np.zeros((zero_pad,), np.byte).tofile(f)
         file_location = f.tell()
 

--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -134,7 +134,7 @@ def get_data_type(mode):
         12: np.float16,
     }
 
-    mode = int(mode)
+    mode = int(mode[0])
     if mode in mode_to_dtype:
         return np.dtype(mode_to_dtype[mode])
     else:
@@ -345,25 +345,25 @@ def file_reader(
         # The scale is in Angstroms, we convert it to nm
         scales = [
             (
-                float(std_header["Zlen"] / std_header["MZ"]) / 10
-                if float(std_header["Zlen"]) != 0 and float(std_header["MZ"]) != 0
+                float((std_header["Zlen"] / std_header["MZ"])[0]) / 10
+                if float(std_header["Zlen"][0]) != 0 and float(std_header["MZ"][0]) != 0
                 else 1
             ),
             (
-                float(std_header["Ylen"] / std_header["MY"]) / 10
-                if float(std_header["MY"]) != 0
+                float((std_header["Ylen"] / std_header["MY"])[0]) / 10
+                if float(std_header["MY"][0]) != 0
                 else 1
             ),
             (
-                float(std_header["Xlen"] / std_header["MX"]) / 10
-                if float(std_header["MX"]) != 0
+                float((std_header["Xlen"] / std_header["MX"])[0]) / 10
+                if float(std_header["MX"][0]) != 0
                 else 1
             ),
         ]
         offsets = [
-            float(std_header["ZORIGIN"]) / 10,
-            float(std_header["YORIGIN"]) / 10,
-            float(std_header["XORIGIN"]) / 10,
+            float(std_header["ZORIGIN"][0]) / 10,
+            float(std_header["YORIGIN"][0]) / 10,
+            float(std_header["XORIGIN"][0]) / 10,
         ]
 
     else:

--- a/rsciio/nexus/_api.py
+++ b/rsciio/nexus/_api.py
@@ -227,7 +227,11 @@ def _get_nav_list(data, dataentry):
             if ax != ".":
                 index_name = ax + "_indices"
                 if index_name in dataentry.attrs:
-                    ind_in_array = int(dataentry.attrs[index_name])
+                    ind_in_array = dataentry.attrs[index_name]
+                    if len(ind_in_array.shape) > 0:
+                        ind_in_array = int(ind_in_array[0])
+                    else:
+                        ind_in_array = int(ind_in_array)
                 else:
                     ind_in_array = i
                 axis_index_list.append(ind_in_array)

--- a/rsciio/tia/_api.py
+++ b/rsciio/tia/_api.py
@@ -510,7 +510,7 @@ def ser_reader(filename, objects=None, lazy=False, only_valid_data=True):
     """
     header, data = load_ser_file(filename)
     record_by = guess_record_by(header["DataTypeID"])
-    ndim = int(header["NumberDimensions"])
+    ndim = int(header["NumberDimensions"][0])
     date, time = None, None
     if objects is not None:
         objects_dict = convert_xml_to_dict(objects[0])
@@ -712,7 +712,7 @@ def load_only_data(
     # dimensions we must fill the rest with zeros or (better) nans if the
     # dtype is float
     if np.prod(array_shape) != np.prod(data["Array"].shape):
-        if int(header["NumberDimensions"]) == 1 and only_valid_data:
+        if int(header["NumberDimensions"][0]) == 1 and only_valid_data:
             # No need to fill with zeros if `TotalNumberElements !=
             # ValidNumberElements` for series data.
             # The valid data is always `0:ValidNumberElements`


### PR DESCRIPTION
### Description of the change

This handles instances of deprecated conversion of single-element arrays to Python `Number`s:

    DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is
    deprecated, and will error in future. Ensure you extract a single
    element from your array before performing this operation. (Deprecated
    NumPy 1.25.)

See also: https://numpy.org/doc/stable/release/1.25.0-notes.html#deprecations

To test for these, I ran `pytest` with `'-Werror:Conversion of an array with ndim'`. There are still remaining cases in `mrcz`, but these seem to be in the third-party library and would need to be fixed upstream.

`np.product` deprecation is not included (test with `'-Werror:`product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.'`), but seems to be limited to either test code or third-party libraries.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [N/A] update docstring (if appropriate),
- [N/A] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [N/A] add tests,
- [ ] ready for review.
