### PR TITLE
Fix setting beam energy for XRF maps

### DIFF
--- a/rsciio/bruker/_api.py
+++ b/rsciio/bruker/_api.py
@@ -619,6 +619,10 @@ class HyperHeader(object):
             det = gen_detector_node(eds_metadata)
             det["EDS"]["real_time"] = self.calc_real_time()
             acq_inst["Detector"] = det
+            # In case of XRF, the primary energy is only defined in
+            # the spectrum metadata
+            acq_inst["beam_energy"] = eds_metadata.hv
+
         return acq_inst
 
     def _parse_image(self, xml_node, overview=False):
@@ -1409,7 +1413,7 @@ def bcf_hyperspectra(
 ):
     """Returns list of dict with eds hyperspectra and metadata."""
     global warn_once
-    if (fast_unbcf == False) and warn_once:
+    if (fast_unbcf is False) and warn_once:
         _logger.warning(
             """unbcf_fast library is not present...
 Parsing BCF with Python-only backend, which is slow... please wait.

--- a/upcoming_changes/231.bugfix.rst
+++ b/upcoming_changes/231.bugfix.rst
@@ -1,0 +1,1 @@
+Fix setting beam energy for XRF maps in ``bcf`` files.


### PR DESCRIPTION
Fix https://github.com/hyperspy/exspy/issues/29.

### Progress of the PR
- [x] Fix setting beam energy for XRF maps - XRF single spectrum already have the energy set properly,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.


