### PR TITLE
Add support for pixel trigger acquisition in quantumdetector reader

### DIFF
--- a/doc/user_guide/supported_formats/quantumdetector.rst
+++ b/doc/user_guide/supported_formats/quantumdetector.rst
@@ -9,17 +9,6 @@ store a series of diffraction patterns from scanning transmission electron
 diffraction measurements. It supports reading data from camera with one or
 four quadrants.
 
-If a ``hdr`` file with the same file name was saved along the ``mib`` file,
-it will be used to infer the navigation shape of the providing that the option
-"line trigger" was used for the acquisition. Alternatively, the navigation
-shape can be specified as an argument:
-
-.. code-block:: python
-
-    >>> from rsciio.quantumdetector import file_reader
-    >>> s_dict = file_reader("file.mib", navigation_shape=(256, 256))
-
-
 API functions
 ^^^^^^^^^^^^^
 

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -268,9 +268,9 @@ def load_mib_data(
             # Reshape only when the slice from zeros
             if first_frame == 0 and len(navigation_shape) > 1:
                 navigation_shape = (
-                    navigation_shape[1],
-                    frame_number_in_file // navigation_shape[1],
-                )
+                    navigation_shape[0],
+                    frame_number_in_file // navigation_shape[0],
+                )[::-1]
             else:
                 navigation_shape = (number_of_frames_to_load,)
         elif number_of_frames_to_load < frame_number:

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -574,7 +574,13 @@ def file_reader(
                 if len(indices) > 0 and len(indices[0]) > 0:
                     frame_per_trigger = indices[0][0] + 1
 
-        navigation_shape = (frame_per_trigger, frames_number // frame_per_trigger)
+        if frames_number == 0:
+            # Some hdf files have the "Frames per Trigger (Number)": 0
+            # in this case, we don't reshape
+            # Possibly for "continuous and indefinite" acquisition
+            navigation_shape = None
+        else:
+            navigation_shape = (frame_per_trigger, frames_number // frame_per_trigger)
 
     data = load_mib_data(
         filename,

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -219,7 +219,7 @@ def load_mib_data(
     print_info : bool, default=False
         If True, display information when loading the file.
     return_mmap : bool
-        If True, return the py:func:`numpy.memmap` object. Default is True.
+        If True, return the :class:`numpy.memmap` object. Default is True.
 
     Returns
     -------
@@ -495,6 +495,9 @@ def file_reader(
     """
     Read a Quantum Detectors ``mib`` file.
 
+    If a ``hdr`` file with the same file name was saved along the ``mib`` file,
+    it will be used to read the metadata.
+
     Parameters
     ----------
     %s
@@ -512,6 +515,20 @@ def file_reader(
     -----
     In case of interrupted acquisition, only the completed lines are read and
     the incomplete line are discarded.
+
+    When the scanning shape (i. e. navigation shape) is not available from the
+    metadata (for example with acquisition using pixel trigger), the timestamps
+    will be used to guess the navigation shape.
+
+    Examples
+    --------
+    In case, the navigation shape can't read from the data itself (for example,
+    type of acquisition unsupported), the ``navigation_shape`` can be specified:
+
+    .. code-block:: python
+
+        >>> from rsciio.quantumdetector import file_reader
+        >>> s_dict = file_reader("file.mib", navigation_shape=(256, 256))
 
     """
     mib_prop = MIBProperties()

--- a/rsciio/tests/test_quantumdetector.py
+++ b/rsciio/tests/test_quantumdetector.py
@@ -120,7 +120,12 @@ def test_single_chip(fname, reshape):
 def test_quad_chip(fname):
     s = hs.load(TEST_DATA_DIR_UNZIPPED / fname)
     if "9_Frame" in fname:
-        navigation_shape = (9,)
+        if "24_Rows_256" in fname:
+            # Unknow why the timestamps of this file are not consistent
+            # with others
+            navigation_shape = (3, 3)
+        else:
+            navigation_shape = (9,)
     else:
         navigation_shape = ()
     assert s.data.shape == navigation_shape + (512, 512)
@@ -180,11 +185,14 @@ def test_interrupted_acquisition_first_frame():
     assert s.axes_manager.navigation_shape == (7,)
 
 
-def test_non_square():
+@pytest.mark.parametrize("navigation_shape", (None, (8,), (4, 2)))
+def test_non_square(navigation_shape):
     fname = TEST_DATA_DIR_UNZIPPED / "001_4x2_6bit.mib"
-    s = hs.load(fname, navigation_shape=(4, 2))
+    s = hs.load(fname, navigation_shape=navigation_shape)
     assert s.axes_manager.signal_shape == (256, 256)
-    assert s.axes_manager.navigation_shape == (4, 2)
+    if navigation_shape is None:
+        navigation_shape = (4, 2)
+    assert s.axes_manager.navigation_shape == navigation_shape
 
 
 def test_no_hdr():

--- a/rsciio/tests/test_quantumdetector.py
+++ b/rsciio/tests/test_quantumdetector.py
@@ -167,7 +167,7 @@ def test_mib_properties_quad__repr__():
 def test_interrupted_acquisition():
     fname = TEST_DATA_DIR_UNZIPPED / "Single_9_Frame_CounterDepth_1_Rows_256.mib"
     # There is only 9 frames, simulate interrupted acquisition using 10 lines
-    s = hs.load(fname, navigation_shape=(10, 2))
+    s = hs.load(fname, navigation_shape=(4, 3))
     assert s.axes_manager.signal_shape == (256, 256)
     assert s.axes_manager.navigation_shape == (4, 2)
 

--- a/rsciio/tests/test_quantumdetector.py
+++ b/rsciio/tests/test_quantumdetector.py
@@ -139,7 +139,9 @@ def test_quad_chip(fname):
         assert axis.units == ""
 
 
-@pytest.mark.parametrize("chunks", ("auto", (9, 128, 128), ("auto", 128, 128)))
+@pytest.mark.parametrize(
+    "chunks", ("auto", (3, 3, 128, 128), ("auto", "auto", 128, 128))
+)
 def test_chunks(chunks):
     fname = TEST_DATA_DIR_UNZIPPED / "Quad_9_Frame_CounterDepth_24_Rows_256.mib"
     s = hs.load(fname, lazy=True, chunks=chunks)
@@ -201,7 +203,7 @@ def test_no_hdr():
     shutil.copyfile(fname, fname2)
     s = hs.load(fname2)
     assert s.axes_manager.signal_shape == (256, 256)
-    assert s.axes_manager.navigation_shape == (8,)
+    assert s.axes_manager.navigation_shape == (4, 2)
 
 
 @pytest.mark.parametrize(

--- a/upcoming_changes/235.bugfix.rst
+++ b/upcoming_changes/235.bugfix.rst
@@ -1,0 +1,1 @@
+:ref:`Quantum Detector <quantumdetector-format>` reader: fix setting chunks.

--- a/upcoming_changes/235.enhancements.rst
+++ b/upcoming_changes/235.enhancements.rst
@@ -1,0 +1,1 @@
+:ref:`Quantum Detector <quantumdetector-format>` reader: use timestamps to get navigation shape when the navigation shape is not available - for example, acquisition with pixel trigger or scan shape not in metadata.


### PR DESCRIPTION
Fix first item of https://github.com/hyperspy/rosettasciio/issues/219.

### Progress of the PR
- [x] Use timestamps to get navigation shape when the navigation shape is not available otherwise (acquisition with pixel trigger and scanshape not in metadata),
- [x] update docstring,
- [x] update user guide,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


