### PR TITLE
numpy 2.0 removal

### DIFF
--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -561,7 +561,7 @@ class HierarchicalReader:
         for key, value in group.attrs.items():
             if isinstance(value, bytes):
                 value = value.decode()
-            if isinstance(value, (np.string_, str)):
+            if isinstance(value, (np.bytes_, str)):
                 if value == "_None_":
                     value = None
             elif isinstance(value, np.bool_):

--- a/rsciio/blockfile/_api.py
+++ b/rsciio/blockfile/_api.py
@@ -471,7 +471,7 @@ def file_writer(
         ("IMG", endianess + "u1", pixels),
     ]
     magics = np.full(records, 0x55AA, dtype=endianess + "u2")
-    ids = np.arange(np.product(records), dtype=endianess + "u4").reshape(records)
+    ids = np.arange(np.prod(records), dtype=endianess + "u4").reshape(records)
     file_memmap = np.memmap(
         filename, dtype=record_dtype, mode="r+", offset=file_location, shape=records
     )

--- a/rsciio/edax/_api.py
+++ b/rsciio/edax/_api.py
@@ -860,7 +860,7 @@ def spd_reader(
             # see https://github.com/hyperspy/hyperspy/pull/2007 and
             #     https://github.com/h5py/h5py/issues/289 for context
             original_metadata["ipr_header"]["charText"] = [
-                np.string_(i) for i in original_metadata["ipr_header"]["charText"]
+                np.bytes_(i) for i in original_metadata["ipr_header"]["charText"]
             ]
     else:
         _logger.warning(

--- a/rsciio/nexus/_api.py
+++ b/rsciio/nexus/_api.py
@@ -132,7 +132,7 @@ def _parse_to_file(value):
         toreturn = totest
     if isinstance(totest, str):
         toreturn = totest.encode("utf-8")
-        toreturn = np.string_(toreturn)
+        toreturn = np.bytes_(toreturn)
     return toreturn
 
 

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -242,7 +242,7 @@ def load_mib_data(
     data_dtype = np.dtype(mib_prop.dtype).newbyteorder(">")
     merlin_frame_dtype = np.dtype(
         [
-            ("header", np.string_, mib_prop.head_size),
+            ("header", np.bytes_, mib_prop.head_size),
             ("data", data_dtype, mib_prop.merlin_size),
         ]
     )

--- a/rsciio/tests/test_ripple.py
+++ b/rsciio/tests/test_ripple.py
@@ -102,7 +102,7 @@ def _get_filename(s, metadata):
 
 
 def _create_signal(shape, dim, dtype, metadata):
-    data = np.arange(np.product(shape)).reshape(shape).astype(dtype)
+    data = np.arange(np.prod(shape)).reshape(shape).astype(dtype)
     if dim == 1:
         if len(shape) > 2:
             s = exspy.signals.EELSSpectrum(data)

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -482,7 +482,7 @@ def get_object_package_info(obj):
 
 
 def ensure_unicode(stuff, encoding="utf8", encoding2="latin-1"):
-    if not isinstance(stuff, (bytes, np.string_)):
+    if not isinstance(stuff, (bytes, np.bytes_)):
         return stuff
     else:
         string = stuff

--- a/upcoming_changes/238.maintenance.rst
+++ b/upcoming_changes/238.maintenance.rst
@@ -1,0 +1,1 @@
+Fix numpy 2.0 removal (``np.product`` and ``np.string_``).


### PR DESCRIPTION
Use `ruff check . --select NPY201` to find these.

For reference: https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals.

### Progress of the PR
- [x] Replace deprecated `np.string_` by `np.bytes_`,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

