### PR TITLE
fix for issue #243 (EMD axes data)

### DIFF
--- a/rsciio/emd/_emd_velox.py
+++ b/rsciio/emd/_emd_velox.py
@@ -358,14 +358,14 @@ class FeiEMDReader(object):
         scale_x = self._convert_scale_units(
             pix_scale["width"], original_units, data.shape[i + 1]
         )
-        scale_y = self._convert_scale_units(
-            pix_scale["height"], original_units, data.shape[i]
+        scale_y = self._convert_scale_units_to(
+            pix_scale["height"], original_units, scale_x[1]
         )
-        offset_x = self._convert_scale_units(
-            offsets["x"], original_units, data.shape[i + 1]
+        offset_x = self._convert_scale_units_to(
+            offsets["x"], original_units, scale_x[1]
         )
-        offset_y = self._convert_scale_units(
-            offsets["y"], original_units, data.shape[i]
+        offset_y = self._convert_scale_units_to(
+            offsets["y"], original_units, scale_x[1]
         )
         axes.extend(
             [
@@ -616,14 +616,14 @@ class FeiEMDReader(object):
         scale_x = self._convert_scale_units(
             pixel_size["width"], original_units, spectrum_image_shape[1]
         )
-        scale_y = self._convert_scale_units(
-            pixel_size["height"], original_units, spectrum_image_shape[0]
+        scale_y = self._convert_scale_units_to(
+            pixel_size["height"], original_units, scale_x[1]
         )
-        offset_x = self._convert_scale_units(
-            offsets["x"], original_units, spectrum_image_shape[1]
+        offset_x = self._convert_scale_units_to(
+            offsets["x"], original_units, scale_x[1]
         )
-        offset_y = self._convert_scale_units(
-            offsets["y"], original_units, spectrum_image_shape[0]
+        offset_y = self._convert_scale_units_to(
+            offsets["y"], original_units, scale_x[1]
         )
 
         i = 0
@@ -719,6 +719,15 @@ class FeiEMDReader(object):
         v = float(value) * _UREG(units)
         converted_v = (factor * v).to_compact()
         converted_value = float(converted_v.magnitude / factor)
+        converted_units = "{:~}".format(converted_v.units)
+        return converted_value, converted_units
+
+    def _convert_scale_units_to(self, value, units, to_units):
+        if units is None:
+            return value, units
+        converted_v = float(value) * _UREG(units)
+        converted_v = converted_v.to(_UREG(to_units))
+        converted_value = float(converted_v.magnitude)
         converted_units = "{:~}".format(converted_v.units)
         return converted_value, converted_units
 

--- a/rsciio/emd/_emd_velox.py
+++ b/rsciio/emd/_emd_velox.py
@@ -356,46 +356,36 @@ class FeiEMDReader(object):
                 }
             )
             i = 1
-        scale_x = self._convert_scale_units(
+        scale_x, x_unit = self._convert_scale_units(
             pix_scale["width"], original_units, data.shape[i + 1]
         )
         # to avoid mismatching units between x and y axis, use the same unit as x
         # x is chosen as reference, because scalebar used (usually) the horizonal axis
         # and the units conversion is tuned to get decent scale bar
-        scale_y = [
-            convert_units(
-                float(pix_scale["height"]), original_units, scale_x[1]
-            ),
-            scale_x[1]
-        ]
+        scale_y = convert_units(float(pix_scale["height"]), original_units, x_unit)
         # Because "axes" only allows one common unit for offset and scale,
-        # offset_x is converted to the same unit as scale_x
-        offset_x = convert_units(
-                float(offsets["x"]), original_units, scale_x[1]
-        )
-        # Because "axes" only allows one common unit for offset and scale,
-        # offset_y is converted to the same unit as scale_y
-        offset_y = convert_units(
-                float(offsets["y"]), original_units, scale_y[1]
-        )
+        # offset_x, offset_y is converted to the same unit as x_unit
+        offset_x = convert_units(float(offsets["x"]), original_units, x_unit)
+        offset_y = convert_units(float(offsets["y"]), original_units, x_unit)
+
         axes.extend(
             [
                 {
                     "index_in_array": i,
                     "name": "y",
                     "offset": offset_y,
-                    "scale": scale_y[0],
+                    "scale": scale_y,
                     "size": data.shape[i],
-                    "units": scale_y[1],
+                    "units": x_unit,
                     "navigate": False,
                 },
                 {
                     "index_in_array": i + 1,
                     "name": "x",
                     "offset": offset_x,
-                    "scale": scale_x[0],
+                    "scale": scale_x,
                     "size": data.shape[i + 1],
-                    "units": scale_x[1],
+                    "units": x_unit,
                     "navigate": False,
                 },
             ]
@@ -624,28 +614,17 @@ class FeiEMDReader(object):
         pixel_size, offsets, original_units = streams[0].get_pixelsize_offset_unit()
         dispersion, offset, unit = self._get_dispersion_offset(original_metadata)
 
-        scale_x = self._convert_scale_units(
+        scale_x, x_unit = self._convert_scale_units(
             pixel_size["width"], original_units, spectrum_image_shape[1]
         )
         # to avoid mismatching units between x and y axis, use the same unit as x
         # x is chosen as reference, because scalebar used (usually) the horizonal axis
         # and the units conversion is tuned to get decent scale bar
-        scale_y = [
-            convert_units(
-                float(pixel_size["height"]), original_units, scale_x[1]
-            ),
-            scale_x[1]
-        ]
+        scale_y = convert_units(float(pixel_size["height"]), original_units, x_unit)
         # Because "axes" only allows one common unit for offset and scale,
-        # offset_x is converted to the same unit as scale_x
-        offset_x = convert_units(
-                float(offsets["x"]), original_units, scale_x[1]
-        )
-        # Because "axes" only allows one common unit for offset and scale,
-        # offset_y is converted to the same unit as scale_y
-        offset_y =  convert_units(
-                float(offsets["y"]), original_units, scale_y[1]
-        )
+        # offset_x, offset_y is converted to the same unit as x_unit
+        offset_x = convert_units(float(offsets["x"]), original_units, x_unit)
+        offset_y = convert_units(float(offsets["y"]), original_units, x_unit)
 
         i = 0
         axes = []
@@ -672,18 +651,18 @@ class FeiEMDReader(object):
                     "index_in_array": i,
                     "name": "y",
                     "offset": offset_y,
-                    "scale": scale_y[0],
+                    "scale": scale_y,
                     "size": spectrum_image_shape[i],
-                    "units": scale_y[1],
+                    "units": x_unit,
                     "navigate": True,
                 },
                 {
                     "index_in_array": i + 1,
                     "name": "x",
                     "offset": offset_x,
-                    "scale": scale_x[0],
+                    "scale": scale_x,
                     "size": spectrum_image_shape[i + 1],
-                    "units": scale_x[1],
+                    "units": x_unit,
                     "navigate": True,
                 },
                 {

--- a/upcoming_changes/243.bugfix.rst
+++ b/upcoming_changes/243.bugfix.rst
@@ -1,0 +1,1 @@
+:ref:`emd_fei-format`: Fix conversion of offset units which can sometimes mismatch the scale units.

--- a/upcoming_changes/243.enhancements.rst
+++ b/upcoming_changes/243.enhancements.rst
@@ -1,0 +1,1 @@
+:ref:`emd_fei-format`: Enforce setting identical units for the ``x`` and ``y`` axes, as convenience to use the scalebar in HyperSpy.


### PR DESCRIPTION
### Description of the change
X and Y could have different units calculated by "_convert_scale_units" now the units itself is only set once and other axe values are set this unit. Different units results in an error of an sanity check of matplotlib sclaebar. And the offsets could be wrong. Changes:
- the units for scale_x are fixed to be used for scale_y and offsets to always have same units for all.
- made a own def to do this:  "_convert_scale_units_to"

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```
import hyperspy.api as hs
import numpy as np

myfile = "_test_SI.emd"
s = hs.load(myfile, select_type='images')

s[0].data -= np.min(s[0].data)
s[0].data /= np.max(s[0].data)
s[0].data *= 255
s[0].data = s[0].data.astype(np.uint8)
s[0].save(((myfile[:-4])+".jpg"), scalebar=True, overwrite=True)
```