### PR TITLE
Fix typo and improve error message in ripple writer

### DIFF
--- a/rsciio/ripple/_api.py
+++ b/rsciio/ripple/_api.py
@@ -477,8 +477,10 @@ def file_writer(filename, signal, encoding="latin-1"):
     md = DTBox(signal["metadata"], box_dots=True)
     dtype_name = dc.dtype.name
     if dtype_name not in dtype2keys.keys():
+        supported_dtype = ", ".join(dtype2keys.keys())
         raise IOError(
-            "The ripple format does not support writting data of {dtype_name} type"
+            f"The ripple format does not support writting data of {dtype_name} type. "
+            f"Supported data type are: {supported_dtype}."
         )
     # Check if the dimensions are supported
     dimension = len(dc.shape)

--- a/rsciio/ripple/_api.py
+++ b/rsciio/ripple/_api.py
@@ -479,8 +479,8 @@ def file_writer(filename, signal, encoding="latin-1"):
     if dtype_name not in dtype2keys.keys():
         supported_dtype = ", ".join(dtype2keys.keys())
         raise IOError(
-            f"The ripple format does not support writting data of {dtype_name} type. "
-            f"Supported data type are: {supported_dtype}."
+            f"The ripple format does not support writing data of {dtype_name} type. "
+            f"Supported data types are: {supported_dtype}."
         )
     # Check if the dimensions are supported
     dimension = len(dc.shape)

--- a/upcoming_changes/251.bugfix.rst
+++ b/upcoming_changes/251.bugfix.rst
@@ -1,0 +1,1 @@
+:ref:`ripple-format`: Fix typo and improve error message in writer.

--- a/upcoming_changes/251.bugfix.rst
+++ b/upcoming_changes/251.bugfix.rst
@@ -1,1 +1,1 @@
-:ref:`ripple-format`: Fix typo and improve error message in writer.
+:ref:`ripple-format`: Fix typo and improve error message for unsupported ``dtype`` in writer.


### PR DESCRIPTION
### Progress of the PR
- [x] Fix typo and improve error message in ripple writer,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

