### PR TITLE
Fix `tifffile` deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
             PYTHON_VERSION: '3.8'
             # Set pillow and scikit-image version to be compatible with imageio and scipy
             # matplotlib needs 3.5 to support markers in hyperspy 2.0 (requires `collection.set_offset_transform`)
-            DEPENDENCIES: matplotlib==3.5 numpy==1.20.0 imagecodecs==2020.1.31 tifffile==2020.2.16 dask[array]==2021.3.1 numba==0.52 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0
+            DEPENDENCIES: matplotlib==3.5 numpy==1.20.0 tifffile==2022.7.28 dask[array]==2021.3.1 numba==0.52 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0
             LABEL: '-oldest'
           # test minimum requirement
           - os: ubuntu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,8 +57,13 @@ pool:
 
 steps:
 - checkout: self
-  fetchDepth: 0 # Fetch all commits for setuptools_scm 
-  fetchTags: true #  tags necessary for setuptools_scm
+  fetchDepth: '0' # Fetch all commits for setuptools_scm 
+  fetchTags: 'true' #  tags necessary for setuptools_scm
+- bash: |
+    git remote add upstream https://github.com/hyperspy/rosettasciio.git
+    git fetch upstream --tags
+  condition: ne(variables['Build.Repository.Name'], 'hyperspy/rosettasciio')
+  displayName: Fetch tags from hyperspy/rosettasciio
 - template: azure_pipelines/clone_ci-scripts_repo.yml@templates
 - template: azure_pipelines/install_mambaforge.yml@templates
 - template: azure_pipelines/activate_conda.yml@templates
@@ -66,7 +71,6 @@ steps:
 
 - bash: |
     source activate $ENV_NAME
-    pip install "hyperspy>=2.0rc0"
     pip install --no-deps -e .
     conda list
   displayName: Install package

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -2,12 +2,9 @@ name: test_env
 channels:
 - conda-forge
 dependencies:
-- dask-core >=2.11
-- h5py
-- imageio
-- numba >=0.52
-- numpy
-- pint
+- dask-core >=2021.3.1
+- numpy >=1.20.0
+- pint >=0.8
 - python-box >=6.0,<7.0
 - python-dateutil
 - pyyaml

--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -3,10 +3,16 @@ channels:
 - conda-forge
 dependencies:
 - cython
+- filelock
+- h5py >=2.3
+- imageio >=2.16
+- numba >=0.52
 - pooch
 - pytest
 - pytest-xdist
 - pytest-rerunfailures
-- hyperspy-base
+- hyperspy-base >=2.0
 - setuptools-scm
-- filelock
+- sparse
+- tifffile>=2022.7.28
+- zarr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ image = ["imageio>=2.16"]
 mrcz = ["blosc>=1.5", "mrcz>=0.3.6"]
 scalebar_export = ["matplotlib-scalebar", "matplotlib>=3.5"]
 speed = ["numba>=0.52"]
-tiff = ["tifffile>=2020.2.16", "imagecodecs>=2020.1.31"]
+tiff = ["tifffile>=2022.7.28", "imagecodecs"]
 # Add sidpy dependency and pinning as workaround to fix pyUSID import
 # Remove sidpy dependency once https://github.com/pycroscopy/pyUSID/issues/85 is fixed.
 usid = ["pyUSID", "sidpy<=0.12.0"]

--- a/rsciio/tiff/_api.py
+++ b/rsciio/tiff/_api.py
@@ -24,8 +24,9 @@ import warnings
 from datetime import datetime, timedelta
 
 import numpy as np
+import tifffile
 from dateutil import parser
-from tifffile import TIFF, TiffFile, TiffPage, imwrite
+from tifffile import TiffFile, TiffPage, imwrite
 
 from rsciio._docstrings import (
     FILENAME_DOC,
@@ -284,7 +285,7 @@ def _read_tiff(
     shape = handle.shape
     dtype = handle.dtype
 
-    is_rgb = page.photometric == TIFF.PHOTOMETRIC.RGB and RGB_as_structured_array
+    is_rgb = page.photometric == tifffile.PHOTOMETRIC.RGB and RGB_as_structured_array
     _logger.debug("Is RGB: %s" % is_rgb)
     if is_rgb:
         axes = axes[:-1]
@@ -420,15 +421,15 @@ def _is_force_readable(op, force_read_resolution) -> bool:
 def _axes_force_read(op, shape, names):
     scales, offsets, units = _axes_defaults()
     res_unit_tag = op["ResolutionUnit"]
-    if res_unit_tag != TIFF.RESUNIT.NONE:
+    if res_unit_tag != tifffile.RESUNIT.NONE:
         _logger.debug("Resolution unit: %s" % res_unit_tag)
         scales["x"], scales["y"] = _get_scales_from_x_y_resolution(op)
         # conversion to µm:
-        if res_unit_tag == TIFF.RESUNIT.INCH:
+        if res_unit_tag == tifffile.RESUNIT.INCH:
             for key in ["x", "y"]:
                 units[key] = "µm"
                 scales[key] = scales[key] * 25400
-        elif res_unit_tag == TIFF.RESUNIT.CENTIMETER:
+        elif res_unit_tag == tifffile.RESUNIT.CENTIMETER:
             for key in ["x", "y"]:
                 units[key] = "µm"
                 scales[key] = scales[key] * 10000
@@ -601,7 +602,7 @@ def _axes_jeol_sightx(tiff, op, shape, names):
     op["SightX_Notes"] = ", ".join(mode_strs)
 
     res_unit_tag = op["ResolutionUnit"]
-    if res_unit_tag == TIFF.RESUNIT.INCH:
+    if res_unit_tag == tifffile.RESUNIT.INCH:
         scale = 0.0254  # inch/m
     else:
         scale = 0.01  # tiff scaling, cm/m

--- a/upcoming_changes/262.maintenance.rst
+++ b/upcoming_changes/262.maintenance.rst
@@ -1,0 +1,1 @@
+Fix ``tifffile`` deprecation.


### PR DESCRIPTION
Deprecation failure in https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/9231889542 with latest version for `tifffile`.

### Progress of the PR
- [x] Fix deprecation `tifffile`,
- [x] Update `tifffile` requirement, 
- [x] Fetch tags when running azure pipelines CI on forks, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


