### PR TITLE
Update GitHub CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
             os_version: latest
             PYTHON_VERSION: '3.11'
           - os: macos
-            os_version: '14'
+            os_version: '13'
             PYTHON_VERSION: '3.11'
 
     steps:


### PR DESCRIPTION
Reference: https://github.com/actions/runner-images/issues/9255

### Progress of the PR
- [x] macos-latest is now macos-14 with arm architecture; keep one build with macos-13 and intel architecture
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [ ] ready for review.


