### PR TITLE
Add support for reading `mib` acquired with a given number of frame to skip per line

### DIFF
--- a/upcoming_changes/270.enhancements.rst
+++ b/upcoming_changes/270.enhancements.rst
@@ -1,0 +1,1 @@
+:ref:`quantumdetector-format`: Add support for reading MIB files acquired with lineskips when acquired in "Scan Mode" and with a corresponding HDR file present.


### PR DESCRIPTION
### Description of the change
A few sentences and/or a bulleted list to describe and motivate the change:
- Added a function to read the navigation shape and check for lineskips of a .mib dataset from the corresponding .hdr file. This should help with #270.
- Fixed some typos in various docstrings.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
from rsciio.quantumdetector._api import parse_hdr_file, _get_navigation_shape_from_hdr
hdr = parse_hdr_file("SPEDSTEM_256x256_8cm_100pct.hdr")
# Your new feature...
navigation_shape = _get_navigation_shape_from_hdr(hdr)
print(navigation_shape)
```
[SPEDSTEM_256x256_8cm_100pct.txt](https://github.com/user-attachments/files/15782627/SPEDSTEM_256x256_8cm_100pct.txt)


