### PR TITLE
Fix parsing elements from EDS data from velox emd file v11

### DIFF
--- a/rsciio/emd/_emd_velox.py
+++ b/rsciio/emd/_emd_velox.py
@@ -121,6 +121,7 @@ class FeiEMDReader(object):
     def read_file(self, f):
         self.filename = f.filename
         self.version = _parse_json(f["Version"][0])["version"]
+        _logger.info(f"EMD file version: {self.version}")
         self.d_grp = f.get("Data")
         self._check_im_type()
         for key in ["Displays", "Operations", "SharedProperties", "Features"]:
@@ -841,14 +842,11 @@ class FeiEMDReader(object):
 
         # Add selected element
         if map_selected_element:
-            mapping.update(
-                {
-                    "Operations.ImageQuantificationOperation": (
-                        "Sample.elements",
-                        self._convert_element_list,
-                    ),
-                }
-            )
+            if int(self.version) >= 11:
+                key = "SharedProperties.EDSSpectrumQuantificationSettings"
+            else:
+                key = "Operations.ImageQuantificationOperation"
+            mapping[key] = ("Sample.elements", self._convert_element_list)
 
         return mapping
 

--- a/rsciio/tests/test_emd_velox.py
+++ b/rsciio/tests/test_emd_velox.py
@@ -524,6 +524,7 @@ class TestVeloxEMDv11:
     @pytest.mark.parametrize("lazy", (True, False))
     def test_spectrum_images(self, lazy):
         s = hs.load(self.fei_files_path / "Test SI 16x16 215 kx.emd", lazy=lazy)
+        assert s[-1].metadata.Sample.elements == ["C", "O", "Ca", "Cu"]
         assert len(s) == 10
         for i, v in enumerate(["C", "Ca", "O", "Cu", "HAADF", "EDS"]):
             assert s[i + 4].metadata.General.title == v

--- a/upcoming_changes/274.bugfix.rst
+++ b/upcoming_changes/274.bugfix.rst
@@ -1,0 +1,1 @@
+:ref:`emd_fei-format`: Fix parsing elements from EDS data from velox emd file v11.


### PR DESCRIPTION
Fix #273.
xref #226.

### Progress of the PR
- [x] Fix parsing elements from EDS data from velox emd file v11,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.
