### PR TITLE
Fix test failure in empad test when pyxem >=0.19 is installed

### DIFF
--- a/rsciio/tests/test_empad.py
+++ b/rsciio/tests/test_empad.py
@@ -17,10 +17,13 @@
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import gc
+import importlib
+from importlib.metadata import version
 from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 from rsciio.empad._api import _parse_xml
 
@@ -66,7 +69,13 @@ def test_read_stack(lazy):
     assert signal_axes[0].name == "width"
     assert signal_axes[1].name == "height"
     for axis in signal_axes:
-        assert axis.units == t.Undefined
+        if importlib.util.find_spec("pyxem") and Version(version("pyxem")) >= Version(
+            "0.19"
+        ):
+            units = "px"
+        else:
+            units = t.Undefined
+        assert axis.units == units
         assert axis.scale == 1.0
         assert axis.offset == -64
     navigation_axes = s.axes_manager.navigation_axes


### PR DESCRIPTION
From https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/9629835432/job/26559728297:

```python
=================================== FAILURES ===================================
____________________________ test_read_stack[False] ____________________________
[gw1] linux -- Python 3.11.9 /home/runner/miniconda3/envs/test/bin/python

lazy = False

    @pytest.mark.parametrize("lazy", (False, True))
    def test_read_stack(lazy):
        # xml file version 0.51 211118
        s = hs.load(DATA_DIR / "stack_images.xml", lazy=lazy, reader="EMPAD")
        assert s.data.dtype == "float32"
        ref_data = np.arange(166400).reshape((10, 130, 128))[..., :128, :]
        np.testing.assert_allclose(s.data, ref_data.astype("float32"))
        signal_axes = s.axes_manager.signal_axes
        assert signal_axes[0].name == "width"
        assert signal_axes[1].name == "height"
        for axis in signal_axes:
>           assert axis.units == t.Undefined
E           AssertionError: assert 'px' == <undefined>
E            +  where 'px' = <width axis, size: 128>.units
E            +  and   <undefined> = t.Undefined

../../../miniconda3/envs/test/lib/python3.11/site-packages/rsciio/tests/test_empad.py:69: AssertionError
----------------------------- Captured stdout call -----------------------------
WARNING | RosettaSciIO | The scale of the signal axes cannot be read. (rsciio.empad._api:170)
------------------------------ Captured log call -------------------------------
WARNING  rsciio.empad._api:_api.py:170 The scale of the signal axes cannot be read.
____________________________ test_read_stack[True] _____________________________
[gw1] linux -- Python 3.11.9 /home/runner/miniconda3/envs/test/bin/python

lazy = True

    @pytest.mark.parametrize("lazy", (False, True))
    def test_read_stack(lazy):
        # xml file version 0.51 211118
        s = hs.load(DATA_DIR / "stack_images.xml", lazy=lazy, reader="EMPAD")
        assert s.data.dtype == "float32"
        ref_data = np.arange(166400).reshape((10, 130, 128))[..., :128, :]
        np.testing.assert_allclose(s.data, ref_data.astype("float32"))
        signal_axes = s.axes_manager.signal_axes
        assert signal_axes[0].name == "width"
        assert signal_axes[1].name == "height"
        for axis in signal_axes:
>           assert axis.units == t.Undefined
E           AssertionError: assert 'px' == <undefined>
E            +  where 'px' = <width axis, size: 128>.units
E            +  and   <undefined> = t.Undefined

../../../miniconda3/envs/test/lib/python3.11/site-packages/rsciio/tests/test_empad.py:69: AssertionError
----------------------------- Captured stdout call -----------------------------
WARNING | RosettaSciIO | The scale of the signal axes cannot be read. (rsciio.empad._api:170)
------------------------------ Captured log call -------------------------------
WARNING  rsciio.empad._api:_api.py:170 The scale of the signal axes cannot be read.
=============================== warnings summary ===============================
```

### Progress of the PR
- [x] Fix test failure related to a change in pyxem 0.19,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.

