### PR TITLE
EMD Velox: fix reading EDS stream detector lazily with `sum_EDS_detectors=True`

### DIFF
--- a/rsciio/emd/_emd_velox.py
+++ b/rsciio/emd/_emd_velox.py
@@ -950,7 +950,6 @@ class FeiSpectrumStream(object):
         """
         # Here we load the stream data into memory, which is fine is the
         # arrays are small. We could load them lazily when lazy.
-        stream_data = self.stream_group["Data"][:].T[0]
         sparse_array = stream_readers.stream_to_sparse_COO_array(
             stream_data=stream_data,
             spatial_shape=self.reader.spatial_shape,
@@ -967,8 +966,8 @@ class FeiSpectrumStream(object):
 
         Parameters
         ----------
-        stream_data: array
-        spectrum_image: array or None
+        stream_data : numpy.ndarray
+        spectrum_image : numpy.ndarray or None
             If array, the data from the stream are added to the array.
             Otherwise it creates a new array and returns it.
 

--- a/rsciio/tests/test_emd_velox.py
+++ b/rsciio/tests/test_emd_velox.py
@@ -406,10 +406,12 @@ class TestFeiEMD:
         # TODO: add parsing azimuth_angle
 
     @pytest.mark.parametrize("lazy", (False, True))
-    def test_fei_si_4detectors_compare(self, lazy):
+    @pytest.mark.parametrize("sum_frames", (False, True))
+    def test_fei_si_4detectors_compare(self, lazy, sum_frames):
         fname = self.fei_files_path / "fei_SI_EDS-HAADF-4detectors_2frames.emd"
-        s_sum_EDS = hs.load(fname, sum_EDS_detectors=True, lazy=lazy)[-1]
-        s = hs.load(fname, sum_EDS_detectors=False, lazy=lazy)[-4:]
+        kwargs = dict(lazy=lazy, sum_frames=sum_frames)
+        s_sum_EDS = hs.load(fname, sum_EDS_detectors=True, **kwargs)[-1]
+        s = hs.load(fname, sum_EDS_detectors=False, **kwargs)[-4:]
         if lazy:
             s_sum_EDS.compute()
             for s_ in s:

--- a/rsciio/utils/fei_stream_readers.py
+++ b/rsciio/utils/fei_stream_readers.py
@@ -363,13 +363,13 @@ def stream_to_array(
                 dtype=dtype,
             )
 
-            _fill_array_with_stream(
-                spectrum_image=spectrum_image,
-                stream=stream,
-                first_frame=first_frame,
-                last_frame=last_frame,
-                rebin_energy=rebin_energy,
-            )
+        _fill_array_with_stream(
+            spectrum_image=spectrum_image,
+            stream=stream,
+            first_frame=first_frame,
+            last_frame=last_frame,
+            rebin_energy=rebin_energy,
+        )
     else:
         if spectrum_image is None:
             spectrum_image = np.zeros(

--- a/upcoming_changes/287.bugfix.rst
+++ b/upcoming_changes/287.bugfix.rst
@@ -1,0 +1,4 @@
+:ref:`EMD Velox <emd_fei-format>` fixes for reading files containing multiple EDS streams:
+
+- fix reading multiple EDS streams lazily with ``sum_EDS_detectors=True``,
+- fix reading separate EDS stream and individual frames when using ``sum_EDS_detectors=False`` and ``sum_frames=False``.


### PR DESCRIPTION
When summing the stream, the same stream was used several times

Fix #286.

### Progress of the PR
- [x] Fix reading sum when reading multiple EDS detector lazily,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

