### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Documentation
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/*'
+      - 'pre-commit-ci-update-config'
+  workflow_dispatch:
 
 jobs:
   Build:

--- a/.github/workflows/package_and_test.yml
+++ b/.github/workflows/package_and_test.yml
@@ -1,6 +1,12 @@
 name: Package & Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/*'
+      - 'pre-commit-ci-update-config'
+  workflow_dispatch:
 
 jobs:
   package_and_test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,11 +102,6 @@ jobs:
           python --version
           pip --version
 
-      - name: Install oldest supported version
-        if: contains(matrix.LABEL, 'oldest')
-        run: |
-          pip install ${{ matrix.DEPENDENCIES }}
-
       - name: Install hyperspy and exspy
         if: ${{ ! contains(matrix.LABEL, 'without-hyperspy') }}
         run: |
@@ -138,6 +133,11 @@ jobs:
         run: |
           pip uninstall -y pyUSID
 
+      - name: Install oldest supported version
+        if: contains(matrix.LABEL, 'oldest')
+        run: |
+          pip install ${{ matrix.DEPENDENCIES }}
+  
       - name: Install numpy 2.0 
         if: ${{ ! contains(matrix.LABEL, 'oldest') && matrix.PYTHON_VERSION != '3.8' }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/*'
+      - 'pre-commit-ci-update-config'
+  workflow_dispatch:
 
 jobs:
   run_test_site:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
             PYTHON_VERSION: '3.8'
             # Set pillow and scikit-image version to be compatible with imageio and scipy
             # matplotlib needs 3.5 to support markers in hyperspy 2.0 (requires `collection.set_offset_transform`)
-            DEPENDENCIES: matplotlib==3.5 numpy==1.20.0 tifffile==2022.7.28 dask[array]==2021.3.1 numba==0.52 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0 python-box==6.0.0
+            DEPENDENCIES: matplotlib==3.5 numpy==1.20.0 tifffile==2022.7.28 dask[array]==2021.5.1 distributed==2021.5.1 numba==0.52 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0 python-box==6.0.0
             LABEL: '-oldest'
           # test minimum requirement
           - os: ubuntu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "dask[array] >=2021.3.1",
+  "dask[array] >=2021.5.1",
   "python-dateutil",
   "numpy >=1.20",
   "pint >=0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,8 @@ doc = [
   "sphinx",
   "sphinx-favicon",
   "sphinxcontrib-towncrier",
-  "towncrier",
+  # unpin when sphinxcontrib-towncrier supports towncrier >=24
+  "towncrier<24",
 ]
 all = [
   "rosettasciio[blockfile]",

--- a/rsciio/tiff/_api.py
+++ b/rsciio/tiff/_api.py
@@ -154,7 +154,7 @@ def file_reader(
         Force read image resolution using the ``x_resolution``, ``y_resolution``
         and ``resolution_unit`` tiff tags. Beware: most software don't (properly)
         use these tags when saving ``.tiff`` files.
-        See `<https://www.awaresystems.be/imaging/tiff/tifftags/resolutionunit.html>`_.
+        See `<https://www.loc.gov/preservation/digital/formats/content/tiff_tags.shtml>`_.
     multipage_as_list : bool, default=False
         Read multipage tiff and return list with full content of every page. This
         utilises ``tifffile``s ``pages`` instead of ``series`` way of data access,


### PR DESCRIPTION
### Progress of the PR
- [x] Pin towncrier to <24 until sphinxcontrib-towncrier supports towncrier >=24,
- [x] fix broken link, 
- [x] make the oldest supported version are correctly installed, 
- [x] bump dask mininum requirement to align with hyperspy - convenience to simplify CI
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


