### PR TITLE
EMD Velox: update error msg for missing sparse module

### DIFF
--- a/rsciio/emd/_api.py
+++ b/rsciio/emd/_api.py
@@ -173,7 +173,6 @@ def file_reader(
     try:
         if is_EMD_Velox(file):
             from ._emd_velox import FeiEMDReader
-
             _logger.debug("EMD file is a Velox variant.")
             emd_reader = FeiEMDReader(
                 lazy=lazy,
@@ -186,7 +185,10 @@ def file_reader(
                 SI_dtype=SI_dtype,
                 load_SI_image_stack=load_SI_image_stack,
             )
-            emd_reader.read_file(file)
+            try:
+                emd_reader.read_file(file)
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError("The 'sparse' library was not found. To load EDS spectrum image data from Velox EMD files, 'sparse' must be installed")
         elif is_EMD_NCEM(file):
             from ._emd_ncem import EMD_NCEM
 

--- a/rsciio/emd/_api.py
+++ b/rsciio/emd/_api.py
@@ -171,7 +171,7 @@ def file_reader(
     Raises
     ------
     ModuleNotFoundError
-        When reading spectrum image from Velox EMD file and the sparse is missing.
+        When reading spectrum image from Velox EMD file and the ``sparse`` library is missing.
     """
     file = h5py.File(filename, "r")
     dictionaries = []

--- a/rsciio/emd/_api.py
+++ b/rsciio/emd/_api.py
@@ -167,12 +167,18 @@ def file_reader(
         spatial drift in the spectrum image by using the STEM images.
 
     %s
+
+    Raises
+    ------
+    ModuleNotFoundError
+        When reading spectrum image from Velox EMD file and the sparse is missing.
     """
     file = h5py.File(filename, "r")
     dictionaries = []
     try:
         if is_EMD_Velox(file):
             from ._emd_velox import FeiEMDReader
+
             _logger.debug("EMD file is a Velox variant.")
             emd_reader = FeiEMDReader(
                 lazy=lazy,
@@ -185,10 +191,7 @@ def file_reader(
                 SI_dtype=SI_dtype,
                 load_SI_image_stack=load_SI_image_stack,
             )
-            try:
-                emd_reader.read_file(file)
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError("The 'sparse' library was not found. To load EDS spectrum image data from Velox EMD files, 'sparse' must be installed")
+            emd_reader.read_file(file)
         elif is_EMD_NCEM(file):
             from ._emd_ncem import EMD_NCEM
 

--- a/rsciio/emd/_emd_velox.py
+++ b/rsciio/emd/_emd_velox.py
@@ -24,6 +24,7 @@
 # Writing file is only supported for EMD Berkeley file.
 
 
+import importlib
 import json
 import logging
 import os
@@ -163,7 +164,14 @@ class FeiEMDReader(object):
             t0 = time.time()
             self._read_images()
             t1 = time.time()
+            if importlib.util.find_spec("sparse") is None:  # pragma: no cover
+                raise ModuleNotFoundError(
+                    "The 'sparse' library was not found. "
+                    "To load EDS spectrum image data from Velox EMD files, "
+                    "'sparse' must be installed."
+                )
             self._read_spectrum_stream()
+
             t2 = time.time()
             _logger.info("Time to load images: {} s.".format(t1 - t0))
             _logger.info("Time to load spectrum image: {} s.".format(t2 - t1))

--- a/rsciio/tests/test_emd_velox.py
+++ b/rsciio/tests/test_emd_velox.py
@@ -22,6 +22,7 @@
 # NOT to be confused with the FEI EMD format which was developed later.
 
 import gc
+import importlib
 import logging
 import shutil
 from datetime import datetime
@@ -32,9 +33,9 @@ import pytest
 from dateutil import tz
 
 from rsciio.utils.tests import assert_deep_almost_equal
+from rsciio.utils.tools import dummy_context_manager
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
-pytest.importorskip("sparse")
 
 
 TEST_DATA_PATH = Path(__file__).parent / "data" / "emd"
@@ -146,6 +147,7 @@ class TestFeiEMD:
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si(self, lazy):
+        pytest.importorskip("sparse")
         signal = hs.load(self.fei_files_path / "fei_emd_si.emd", lazy=lazy)
         if lazy:
             assert signal[1]._lazy
@@ -154,8 +156,18 @@ class TestFeiEMD:
         np.testing.assert_equal(signal[1].data, fei_si)
         assert isinstance(signal[1], hs.signals.Signal1D)
 
+    def test_fei_emd_si_missing_sparse(self):
+        cm = (
+            pytest.raises(ModuleNotFoundError)
+            if importlib.util.find_spec("sparse") is None
+            else dummy_context_manager()
+        )
+        with cm:
+            _ = hs.load(self.fei_files_path / "fei_emd_si.emd")
+
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_10frames(self, lazy):
+        pytest.importorskip("sparse")
         s = hs.load(
             self.fei_files_path / "fei_SI_SuperX-HAADF_10frames_10x50.emd",
             lazy=lazy,
@@ -329,6 +341,7 @@ class TestFeiEMD:
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_20frames(self, lazy):
+        pytest.importorskip("sparse")
         s = hs.load(
             self.fei_files_path / "fei_SI_SuperX-HAADF_20frames_10x50.emd",
             lazy=lazy,
@@ -354,6 +367,7 @@ class TestFeiEMD:
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_20frames_2eV(self, lazy):
+        pytest.importorskip("sparse")
         s = hs.load(
             self.fei_files_path / "fei_SI_SuperX-HAADF_20frames_10x50_2ev.emd",
             lazy=lazy,
@@ -379,6 +393,7 @@ class TestFeiEMD:
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_frame_range(self, lazy):
+        pytest.importorskip("sparse")
         signal = hs.load(
             self.fei_files_path / "fei_emd_si.emd",
             first_frame=2,
@@ -394,6 +409,7 @@ class TestFeiEMD:
 
     @pytest.mark.parametrize(["lazy", "sum_EDS_detectors"], _generate_parameters())
     def test_fei_si_4detectors(self, lazy, sum_EDS_detectors):
+        pytest.importorskip("sparse")
         fname = self.fei_files_path / "fei_SI_EDS-HAADF-4detectors_2frames.emd"
         signal = hs.load(fname, sum_EDS_detectors=sum_EDS_detectors, lazy=lazy)
         if lazy:
@@ -408,6 +424,7 @@ class TestFeiEMD:
     @pytest.mark.parametrize("lazy", (False, True))
     @pytest.mark.parametrize("sum_frames", (False, True))
     def test_fei_si_4detectors_compare(self, lazy, sum_frames):
+        pytest.importorskip("sparse")
         fname = self.fei_files_path / "fei_SI_EDS-HAADF-4detectors_2frames.emd"
         kwargs = dict(lazy=lazy, sum_frames=sum_frames)
         s_sum_EDS = hs.load(fname, sum_EDS_detectors=True, **kwargs)[-1]
@@ -544,6 +561,7 @@ class TestVeloxEMDv11:
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_spectrum_images(self, lazy):
+        pytest.importorskip("sparse")
         s = hs.load(self.fei_files_path / "Test SI 16x16 215 kx.emd", lazy=lazy)
         assert s[-1].metadata.Sample.elements == ["C", "O", "Ca", "Cu"]
         assert len(s) == 10
@@ -553,6 +571,7 @@ class TestVeloxEMDv11:
         assert s[-1].data.shape == (16, 16, 4096)
 
     def test_prune_data(self, caplog):
+        pytest.importorskip("sparse")
         with caplog.at_level(logging.WARNING):
             _ = hs.load(self.fei_files_path / "Test SI 16x16 ReducedData 215 kx.emd")
 

--- a/upcoming_changes/305.enhancements.rst
+++ b/upcoming_changes/305.enhancements.rst
@@ -1,0 +1,1 @@
+Improve error message when loading spectrum image from :ref:`EMD Velox <emd_fei-format>` file and the ``sparse`` library is not installed.


### PR DESCRIPTION
### Description of the change
This is an update in response to Issue #296 "emd reader Velox ModuleNotFoundError." When attempting to load EDS Spectrum Image data from a Velox EMD file without the optional "sparse" dependency installed, a ModuleNotFoundError is raised which is confusing to some users. To clarify the issue, a try except statement was added around running the Velox EMD file reader and a new error message is printed. 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

