### PR TITLE
Fix loading tiff file lazily

### DIFF
--- a/doc/api/utils.rst
+++ b/doc/api/utils.rst
@@ -14,12 +14,12 @@ HDF5 utility functions
 .. automodule:: rsciio.utils.hdf5
    :members:
 
+Generic utility functions
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Test utility functions
-^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: rsciio.utils.tools
+   :members: get_file_handle
 
-.. automodule:: rsciio.tests.registry_utils
-   :members:
 
 Distributed utility functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,3 +32,10 @@ Logging
 
 .. automodule:: rsciio
    :members: set_log_level
+
+
+Test utility functions
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: rsciio.tests.registry_utils
+   :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,7 +108,7 @@ nitpick_ignore_regex = [(r"py:.*", r"hyperspy.api.*")]
 # -- Options for numpydoc extension -----------------------------------
 
 numpydoc_xref_param_type = True
-numpydoc_xref_ignore = {"type", "optional", "default", "of"}
+numpydoc_xref_ignore = {"type", "optional", "default", "of", "File", "handle"}
 
 if Version(numpydoc.__version__) >= Version("1.6.0rc0"):
     numpydoc_validation_checks = {"all", "ES01", "EX01", "GL02", "GL03", "SA01", "SS06"}

--- a/rsciio/_docstrings.py
+++ b/rsciio/_docstrings.py
@@ -35,7 +35,10 @@ SIGNAL_DOC = """signal : dict
 
 
 LAZY_DOC = """lazy : bool, default=False
-        Whether to open the file lazily or not.
+        Whether to open the file lazily or not. The file will stay open
+        until closed in :meth:`~hyperspy._signals.lazy.LazySignal.compute`
+        or closed manually. :func:`~.utils.tools.get_file_handle`
+        can be used to access the file handler and close it manually.
     """
 
 

--- a/rsciio/tiff/_api.py
+++ b/rsciio/tiff/_api.py
@@ -93,6 +93,7 @@ def file_writer(filename, signal, export_scale=True, extratags=None, **kwds):
     """
 
     data = signal["data"]
+    metadata = signal.get("metadata", {})
     photometric = "MINISBLACK"
     # HyperSpy uses struct arrays to store RGBA data
     from rsciio.utils import rgb_tools
@@ -110,7 +111,7 @@ def file_writer(filename, signal, export_scale=True, extratags=None, **kwds):
             "Description and export scale cannot be used at the same time, "
             "because it is incompability with the 'ImageJ' tiff format"
         )
-    if export_scale:
+    if export_scale and "axes" in signal.keys():
         kwds.update(_get_tags_dict(signal, extratags=extratags))
         _logger.debug(f"kwargs passed to tifffile.py imsave: {kwds}")
 
@@ -121,7 +122,7 @@ def file_writer(filename, signal, export_scale=True, extratags=None, **kwds):
             # (https://github.com/cgohlke/tifffile/issues/21)
             kwds["metadata"] = None
 
-    if signal["metadata"]["General"].get("date"):
+    if "General" in metadata.keys() and metadata["General"].get("date"):
         dt = get_date_time_from_metadata(signal["metadata"], formatting="datetime")
         kwds["datetime"] = dt
 
@@ -190,23 +191,28 @@ def file_reader(
     >>> # Load a non-uniform axis from a hamamatsu streak file:
     >>> s = file_reader('file.tif', hamamatsu_streak_axis_type='data')
     """
-    with TiffFile(filename, **kwds) as tiff:
-        if multipage_as_list:
-            handles = tiff.pages  # use full access with pages interface
-        else:
-            handles = tiff.series  # use fast access with series interface
-        dict_list = [
-            _read_tiff(
-                tiff,
-                handle,
-                filename,
-                force_read_resolution,
-                lazy=lazy,
-                hamamatsu_streak_axis_type=hamamatsu_streak_axis_type,
-                **kwds,
-            )
-            for handle in handles
-        ]
+    # We can't use context manager, because it closes the file on exit
+    # and the file needs to stay open when loading lazily
+    # close the file manually
+    tiff = TiffFile(filename, **kwds)
+    if multipage_as_list:
+        handles = tiff.pages  # use full access with pages interface
+    else:
+        handles = tiff.series  # use fast access with series interface
+    dict_list = [
+        _read_tiff(
+            tiff,
+            handle,
+            filename,
+            force_read_resolution,
+            lazy=lazy,
+            hamamatsu_streak_axis_type=hamamatsu_streak_axis_type,
+            **kwds,
+        )
+        for handle in handles
+    ]
+    if not lazy:
+        tiff.close()
 
     return dict_list
 

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -503,27 +503,59 @@ def ensure_unicode(stuff, encoding="utf8", encoding2="latin-1"):
 
 
 def get_file_handle(data, warn=True):
-    """Return file handle of a dask array when possible; currently only hdf5 file are
-    supported.
     """
-    arrkey = None
+    Return file handle of a dask array when possible.
+    Currently only hdf5 and tiff file are supported.
+
+    Parameters
+    ----------
+    data : dask.array.Array
+        The dask array from which the file handle
+        will be retrieved.
+    warn : bool
+        Whether to warn or not when the file handle
+        can't be retrieved. Default is True.
+
+    Returns
+    -------
+    File handle or None
+        The file handle of the file when possible.
+    """
+    arrkey_hdf5 = None
+    arrkey_tifffile = None
     for key in data.dask.keys():
         # The if statement with both "array-original" and "original-array"
         # is due to dask changing the name of this key. After dask-2022.1.1
         # the key is "original-array", before it is "array-original"
         if ("array-original" in key) or ("original-array" in key):
-            arrkey = key
+            arrkey_hdf5 = key
             break
-    if arrkey:
+        # For tiff files, use _load_data key
+        if "_load_data" in key:
+            arrkey_tifffile = key
+    if arrkey_hdf5:
         try:
-            return data.dask[arrkey].file
-        except (AttributeError, ValueError):
+            return data.dask[arrkey_hdf5].file
+        except (AttributeError, ValueError):  # pragma: no cover
             if warn:
                 _logger.warning(
-                    "Failed to retrieve file handle, either "
-                    "the file is already closed or it is not "
-                    "an hdf5 file."
+                    "Failed to retrieve file handle, either the file is "
+                    "already closed or it is not an hdf5 file."
                 )
+    if arrkey_tifffile:
+        try:
+            # access the filehandle through the pages or series
+            # interfaces of tifffile
+            # this may be brittle and may need maintenance as
+            # dask or tifffile evolve
+            return data.dask[arrkey_tifffile][2][0].parent.filehandle._fh
+        except IndexError:  # pragma: no cover
+            if warn:
+                _logger.warning(
+                    "Failed to retrieve file handle, either the file is "
+                    "already closed or it is not a supported tiff file."
+                )
+
     return None
 
 

--- a/upcoming_changes/317.bugfix.rst
+++ b/upcoming_changes/317.bugfix.rst
@@ -1,0 +1,1 @@
+Fix lazy reading of some tiff files - fix for `#316 <https://github.com/hyperspy/rosettasciio/issues/316>`_.

--- a/upcoming_changes/317.enhancements.rst
+++ b/upcoming_changes/317.enhancements.rst
@@ -1,0 +1,1 @@
+Add support for tiff file in :func:`~.utils.tools.get_file_handle`.


### PR DESCRIPTION
Fix for https://github.com/hyperspy/rosettasciio/issues/316: using the context manager to load tiff files was closing the file. Some tiff were still loading lazily (for example the file used to test lazy loading in the test suite before this PR) because a different code path was being used.

### Progress of the PR
- [x] Fix loading tifffile lazily,
- [x] add support for tiff file in `get_file_handle` 
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

