### PR TITLE
Fix scale in white field image in renishaw reader

### DIFF
--- a/doc/user_guide/supported_formats/renishaw.rst
+++ b/doc/user_guide/supported_formats/renishaw.rst
@@ -20,6 +20,17 @@ used as the ``signal_type``.
    the signal axes and `X`, `Y`, `Z`, `FocusTrackZ` and `Time` for navigation axes.
    Reading maps obtained in a serpentine path is not implemented.
 
+.. Note::
+
+   The laser power can be accessed from the ``original_metadata``:
+
+   .. code:: python
+
+      >>> import hyperspy as HyperSpy
+      >>> s = hs.load("raman_map.wdf")
+      >>> s.original_metadata.get_item("WXIS_0.ND Transmission %")
+      10
+      
 
 This reader is based on the `py-wdf-reader <https://github.com/alchem0x2A/py-wdf-reader.git>`_,
 which is inspired by the `matlab reader <https://doi.org/10.5281/zenodo.495477>`_ from Alex Henderson.

--- a/rsciio/tests/test_renishaw.py
+++ b/rsciio/tests/test_renishaw.py
@@ -1219,7 +1219,7 @@ class TestStreamline:
         }
 
         for i, (axis, scale) in enumerate(
-            zip(s.axes_manager._axes, (22.570833, 23.710106))
+            zip(s.axes_manager._axes, (1.1285417, 1.1855053))
         ):
             assert axis.units == "µm"
             np.testing.assert_allclose(axis.scale, scale)

--- a/rsciio/utils/image.py
+++ b/rsciio/utils/image.py
@@ -23,7 +23,7 @@ CustomTAGS = {
     # Customized EXIF TAGS from Renishaw
     0xFEA0: "FocalPlaneXYOrigins",  # 65184
     0xFEA1: "FieldOfViewXY",  # 65185
-    0xFEA2: "Unknown",  # 65186
+    0xFEA2: "Unknown",  # 65186, could it be magnification?
 }
 
 
@@ -50,7 +50,8 @@ def _parse_axes_from_metadata(exif_tags, sizes):
         # Fallback to default value when tag not available
         offsets = exif_tags.get("FocalPlaneXYOrigins", offsets)
         # jpg files made with Renishaw have this tag
-        fields_of_views = exif_tags.get("FieldOfViewXY", fields_of_views)
+        fields_of_views[0] = exif_tags.get("FocalPlaneXResolution", fields_of_views[0])
+        fields_of_views[1] = exif_tags.get("FocalPlaneYResolution", fields_of_views[1])
         unit = FocalPlaneResolutionUnit_mapping[
             exif_tags.get("FocalPlaneResolutionUnit", unit)
         ]

--- a/upcoming_changes/327.bugfix.rst
+++ b/upcoming_changes/327.bugfix.rst
@@ -1,0 +1,1 @@
+Fix scale in white field image in ``renishaw`` reader.


### PR DESCRIPTION
Fix #301.

### Progress of the PR
- [x] Fix scale in white field image in renishaw reader,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.


