### PR TITLE
Pin zarr >=2,<3

### DIFF
--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -15,4 +15,4 @@ dependencies:
 - setuptools-scm
 - sparse
 - tifffile>=2022.7.28
-- zarr
+- zarr <3

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,7 @@ intersphinx_mapping = {
     "pooch": ("https://www.fatiando.org/pooch/latest", None),
     "python": ("https://docs.python.org/3", None),
     "pyusid": ("https://pycroscopy.github.io/pyUSID/", None),
-    "zarr": ("https://zarr.readthedocs.io/en/stable", None),
+    "zarr": ("https://zarr.readthedocs.io/en/v2.18.4", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ scalebar_export = ["matplotlib-scalebar", "matplotlib>=3.6"]
 speed = ["numba>=0.53"]
 tiff = ["tifffile>=2022.7.28", "imagecodecs"]
 usid = ["pyUSID>=0.0.11"]
-zspy = ["zarr", "msgpack"]
+zspy = ["zarr>=2,<3", "msgpack"]
 tests = [
   "filelock",
   "pooch",

--- a/upcoming_changes/351.maintenance.rst
+++ b/upcoming_changes/351.maintenance.rst
@@ -1,0 +1,1 @@
+Pin zarr to version 2 until zarr version 3 is supported.


### PR DESCRIPTION
Zarr 3.0 has been released yesterday and has breaking changes. See https://zarr.readthedocs.io/en/v3.0.0/user-guide/v3_migration.html for more context. Until we support zarr 3, we need to make a release with zarr pin to <3.

@CSSFrancis, @jlaehne, we should merge this PR and make a release ASAP.

### Progress of the PR
- [x] Pin zarr to `>=2, <3`,
- [n/a] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


