### PR TITLE
Exclude python-box 7.3.1

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - dask-core >=2021.3.1
 - numpy >=1.20.0
 - pint >=0.8
-- python-box >=6.0
+- python-box >=6.0,<8,!=7.3.1
 - python-dateutil
 - pyyaml
 - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "pint >=0.8",
   # python-box API changed on major release
   # and compatibility needs to be checked
-  "python-box >=6,<8",
+  "python-box >=6,<8,!=7.3.1",
   "pyyaml",
 ]
 dynamic = ["version"]

--- a/upcoming_changes/357.maintenance.rst
+++ b/upcoming_changes/357.maintenance.rst
@@ -1,0 +1,1 @@
+Specfiy python-box!=7.3.1 from dependency requirement as a workaround for https://github.com/cdgriffith/Box/issues/288.


### PR DESCRIPTION
Fix for https://github.com/hyperspy/rosettasciio/issues/355.

### Progress of the PR
- [x] Exclude python-box 7.3.1 because of https://github.com/cdgriffith/Box/issues/288, fixed in 7.3.2,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.
