### PR TITLE
Build and test linux-arm wheels natively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
       CIBW_TEST_EXTRAS: "tests"
       # No need to build wheels for pypy because the pure python wheels can be used
       # PyPy documentation recommends no to build the C extension
-      # CPython 3.13 not supported yet because of pint
       CIBW_SKIP: "{pp*,*-musllinux*,*win32,*-manylinux_i686}"
     strategy:
       fail-fast: false
@@ -29,7 +28,7 @@ jobs:
         include:
           - os: "ubuntu-latest"
             CIBW_ARCHS: "x86_64"
-          - os: "ubuntu-latest"
+          - os: "ubuntu-24.04-arm"
             CIBW_ARCHS: "aarch64"
           - os: "windows-latest"
             CIBW_ARCHS: "AMD64"
@@ -39,16 +38,10 @@ jobs:
             CIBW_ARCHS: "arm64"
 
     steps:
-      - name: Set up QEMU
-        if: contains(matrix.CIBW_ARCHS, 'aarch64')
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - uses: actions/checkout@v4
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v2.22
         env:
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
 
@@ -135,6 +128,7 @@ jobs:
     # TODO: once we are happy with the workflow
     # setup zenodo to create a DOI automatically
     needs: upload_to_pypi
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     permissions:
       contents: write
     name: Create Release

--- a/upcoming_changes/358.maintenance.rst
+++ b/upcoming_changes/358.maintenance.rst
@@ -1,0 +1,1 @@
+Build and tests linux-arm wheels natively.


### PR DESCRIPTION
Linux arm runner are now available on GitHub CI: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview.
We can use these natively instead of using emulation to build the aarch64 wheels, as it speeds up significantly the release workflow.

### Progress of the PR
- [x] Use native linux arm runner instead of using emulation,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] release workflow tested at https://github.com/ericpre/rosettasciio/actions/runs/12846212893.,
- [x] ready for review.
