### PR TITLE
Fix failing image scalebar export test

### DIFF
--- a/rsciio/tests/test_image.py
+++ b/rsciio/tests/test_image.py
@@ -106,6 +106,8 @@ def test_save_load_cycle_kwds(dtype, ext, tmp_path):
 def test_export_scalebar(ext, tmp_path):
     hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
     pytest.importorskip("matplotlib_scalebar")
+    import matplotlib.pyplot as plt
+
     # Use np.uint8 to be able to save as BMP
     pixels = 64
     data = np.arange(pixels**2).reshape((pixels, pixels)).astype(np.uint8)
@@ -114,14 +116,16 @@ def test_export_scalebar(ext, tmp_path):
     s.axes_manager[1].units = "nm"
 
     filename = tmp_path / f"test_scalebar_export.{ext}"
-    if ext in ["bmp", "gif"]:
+    if ext in plt.figure().canvas.get_supported_filetypes():
+        s.save(filename, scalebar=True)
+    else:
+        # file format not supported by matplotlib backend
         with pytest.raises(ValueError):
             s.save(filename, scalebar=True)
         with pytest.raises(ValueError):
             s.save(filename, output_size=512)
         s.save(filename)
-    else:
-        s.save(filename, scalebar=True)
+
     s_reload = hs.load(filename)
     assert s.data.shape == s_reload.data.shape
 


### PR DESCRIPTION
Fix for failure with matplotlib development version - from https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/12849344100/job/35838748193:

```python
=================================== FAILURES ===================================
__________________________ test_export_scalebar[gif] ___________________________
[gw0] linux -- Python 3.12.8 /home/runner/miniconda3/envs/test/bin/python

ext = 'gif'
tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-1/popen-gw0/test_export_scalebar_gif_0')

    @pytest.mark.skipif(
        Version(imageio.__version__) < Version("2.23"),
        reason="needs imageio >=2.23",
    )
    @pytest.mark.parametrize(("ext"), ["png", "bmp", "gif", "jpg"])
    def test_export_scalebar(ext, tmp_path):
        hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
        pytest.importorskip("matplotlib_scalebar")
        # Use np.uint8 to be able to save as BMP
        pixels = 64
        data = np.arange(pixels**2).reshape((pixels, pixels)).astype(np.uint8)
        s = hs.signals.Signal2D(data)
        s.axes_manager[0].units = "nm"
        s.axes_manager[1].units = "nm"
    
        filename = tmp_path / f"test_scalebar_export.{ext}"
        if ext in ["bmp", "gif"]:
>           with pytest.raises(ValueError):
E           Failed: DID NOT RAISE <class 'ValueError'>

../../../miniconda3/envs/test/lib/python3.12/site-packages/rsciio/tests/test_image.py:118: Failed
```

### Progress of the PR
- [x] Replace hardcoded list with supported file types from matplotlib,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.

