### PR TITLE
Tidy up tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,12 +120,6 @@ jobs:
           python --version
           pip --version
 
-      - name: Install traits dev for python 3.13
-        if: ${{ matrix.PYTHON_VERSION == '3.13' }}
-        run: |
-          # traits release with python 3.13 pending
-          pip install git+https://github.com/enthought/traits.git
-
       - name: Install hyperspy and exspy
         if: ${{ ! contains(matrix.LABEL, 'without-hyperspy') && matrix.PYTHON_VERSION != '3.13'}}
         run: |


### PR DESCRIPTION
Remove installing `traits` development version when testing python 3.13, now that the `traits` release supports python 3.13.

