### PR TITLE
Fix hyperspy installation for python3.13 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           # speed up installing scikit-image using pre-release with python 3.13 wheels
           pip install scikit-image --pre 
-          pip install git+https://github.com/ericpre/hyperspy.git@python313
+          pip install git+https://github.com/hyperspy/hyperspy.git
           pip install git+https://github.com/hyperspy/exspy.git
 
       - name: Install python-mrcz dev


### PR DESCRIPTION
Now that the `python313` branch is merged in hyperspy https://github.com/hyperspy/hyperspy/pull/3468, the test interface has to be updated.