### PR TITLE
Bump dask version requirement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu, windows, macos]
         os_version: [latest]
-        PYTHON_VERSION: ['3.9', '3.10']
+        PYTHON_VERSION: ['3.9', '3.10', '3.13']
         LABEL: ['']
         include:
           # test oldest supported version of main dependencies on python 3.8
@@ -50,21 +50,6 @@ jobs:
           - os: ubuntu
             os_version: latest
             PYTHON_VERSION: '3.12'
-          - os: ubuntu
-            os_version: latest
-            PYTHON_VERSION: '3.13'
-            # can remove minimum dependencies when numba supports 3.13
-            LABEL: '-minimum'
-          - os: macos
-            os_version: latest
-            PYTHON_VERSION: '3.13'
-            # can remove minimum dependencies when numba supports 3.13
-            LABEL: '-minimum'
-          - os: windows
-            os_version: latest
-            PYTHON_VERSION: '3.13'
-            # can remove minimum dependencies when numba supports 3.13
-            LABEL: '-minimum'
           - os: macos
             os_version: '13'
             PYTHON_VERSION: '3.12'
@@ -131,14 +116,6 @@ jobs:
           pip install git+https://github.com/hyperspy/hyperspy.git
           pip install git+https://github.com/hyperspy/exspy.git
 
-      - name: Install hyperspy (python 3.13) and exspy (dev)
-        if: ${{ matrix.PYTHON_VERSION == '3.13' }}
-        run: |
-          # speed up installing scikit-image using pre-release with python 3.13 wheels
-          pip install scikit-image --pre 
-          pip install git+https://github.com/hyperspy/hyperspy.git
-          pip install git+https://github.com/hyperspy/exspy.git
-
       - name: Install python-mrcz dev
         # for numpy 2.0 support for python >= 3.9
         # https://github.com/em-MRCZ/python-mrcz/pull/15
@@ -153,7 +130,7 @@ jobs:
 
       - name: Uninstall pyUSID
         # remove when pyUSID supports numpy 2 
-        if: ${{ ! contains(matrix.LABEL, 'oldest') && matrix.PYTHON_VERSION != '3.8' }}
+        if: ${{ ! contains(matrix.LABEL, 'oldest') }}
         run: |
           pip uninstall -y pyUSID
 
@@ -161,11 +138,6 @@ jobs:
         if: contains(matrix.LABEL, 'oldest')
         run: |
           pip install ${{ matrix.DEPENDENCIES }}
-  
-      - name: Install numpy 2.0 
-        if: ${{ ! contains(matrix.LABEL, 'oldest') && matrix.PYTHON_VERSION != '3.8' }}
-        run: |
-          pip install numpy>=2
 
       - name: Pip list
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ jobs:
             os_version: latest
             PYTHON_VERSION: '3.9'
             # Set pillow and scikit-image version to be compatible with imageio and scipy
-            # align matplotlib dependency with hyperspy
-            DEPENDENCIES: matplotlib==3.6 numpy==1.20.0 tifffile==2022.7.28 dask[array]==2021.5.1 distributed==2021.5.1 numba==0.53 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0 python-box==6.0.0
+            # align matplotlib and dask dependency with hyperspy
+            DEPENDENCIES: matplotlib==3.6 numpy==1.20.0 tifffile==2022.7.28 dask[array]==2022.9.2 distributed==2022.9.2 numba==0.53 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0 python-box==6.0.0
             LABEL: '-oldest'
           # test minimum requirement
           - os: ubuntu

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -2,7 +2,7 @@ name: test_env
 channels:
 - conda-forge
 dependencies:
-- dask-core >=2021.3.1
+- dask-core >=2022.9.2
 - numpy >=1.20.0
 - pint >=0.8
 - python-box >=6.0,<8,!=7.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "dask[array] >=2021.5.1",
+  "dask[array] >=2022.9.2", # aligned with hyperspy for convenience
   "python-dateutil",
   "numpy >=1.20",
   "pint >=0.8",

--- a/upcoming_changes/374.maintenance.rst
+++ b/upcoming_changes/374.maintenance.rst
@@ -1,0 +1,1 @@
+Bump dask version requirement to 2022.9.2.


### PR DESCRIPTION
Bump dask version requirement to be able to use `dask.widgets` which is imported in hyperspy and is convenient to keep it aligned with hyperspy requirement to run the test suite. It is not a strict requirement but at the same time, I don't think that there is a point to support 4 years old version of dask!

### Progress of the PR
- [x] Bump dask version requirement to 2022.9.2,
- [x] tidy up/simplify tests workflow since hyperspy release supports 3.13, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

