### PR TITLE
Add T20 rules (flake8-print) to ruff configuration

### DIFF
--- a/prepare_release.py
+++ b/prepare_release.py
@@ -30,7 +30,7 @@ def update_fallback_version_in_pyproject(tag, fname="pyproject.toml"):
     with open(fname, "w") as file:
         file.writelines(lines)
 
-    print(
+    print(  # noqa: T201
         f"\nNew (fallback) dev version ({new_version}) written to `pyproject.toml`.\n"
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,9 @@ select = [
     "E",
     "W",
     # isort
-    "I001"
+    "I001",
+    # flake8-print
+    "T20",
 ]
 exclude = [
     "examples",

--- a/rsciio/digitalsurf/_api.py
+++ b/rsciio/digitalsurf/_api.py
@@ -1229,7 +1229,6 @@ class DigitalSurfHandler(object):
     def _read_single_sur_object(self, file):
         for key, val in self._work_dict.items():
             self._work_dict[key]["value"] = val["b_unpack_fn"](file)
-            # print(f"{key}: {self._work_dict[key]['value']}")
 
     def _append_work_dict_to_content(self):
         """Save the values stored in the work dict in the surface file list"""

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -295,7 +295,7 @@ def load_mib_data(
     mib_prop.frame_number_in_file = frame_number_in_file
 
     if print_info:
-        print(mib_prop)
+        print(mib_prop)  # noqa: T201
 
     if mib_prop.raw:  # pragma: no cover
         raise NotImplementedError("RAW MIB data not supported.")

--- a/rsciio/renishaw/_api.py
+++ b/rsciio/renishaw/_api.py
@@ -622,9 +622,6 @@ class WDFReader(object):
     def _pset_match_keys_and_values(self, id, key_dict, value_dict):
         result = {}
         ## TODO: debug setup, remove once it is understood why there are unmatched keys/values
-        ## print(f"{id}(keys, {len(list(key_dict))}): {list(key_dict)}")
-        ## print(f"{id}(values, {len(list(value_dict))}): {list(value_dict)}")
-        ## print()
         for key in list(key_dict.keys()):
             ## keep mismatched keys for debugging
             try:

--- a/rsciio/tests/conftest.py
+++ b/rsciio/tests/conftest.py
@@ -43,9 +43,9 @@ def session_data(request, tmp_path_factory, worker_id):
         from rsciio.tests.registry_utils import download_all
 
         with capmanager.global_and_fixture_disabled():
-            print("Checking if test data need downloading...")
+            print("Checking if test data need downloading...")  # noqa: T201
             download_all()
-            print("All test data available.")
+            print("All test data available.")  # noqa: T201
 
         return "Test data available"
 

--- a/rsciio/tests/registry_utils.py
+++ b/rsciio/tests/registry_utils.py
@@ -136,7 +136,7 @@ def download_all(pooch_object=None, ignore_hash=None, show_progressbar=True):
 
             pbar = tqdm(total=len(pooch_object.registry_files))
         except ImportError:
-            print("Using progresbar requires the `tqdm` library.")
+            print("Using progresbar requires the `tqdm` library.")  # noqa: T201
             show_progressbar = False
 
     for i, file in enumerate(pooch_object.registry_files):

--- a/rsciio/tests/registry_utils.py
+++ b/rsciio/tests/registry_utils.py
@@ -136,7 +136,7 @@ def download_all(pooch_object=None, ignore_hash=None, show_progressbar=True):
 
             pbar = tqdm(total=len(pooch_object.registry_files))
         except ImportError:
-            print("Using progresbar requires the `tqdm` library.")  # noqa: T201
+            print("Using progressbar requires the `tqdm` library.")  # noqa: T201
             show_progressbar = False
 
     for i, file in enumerate(pooch_object.registry_files):

--- a/rsciio/tests/test_bruker.py
+++ b/rsciio/tests/test_bruker.py
@@ -31,7 +31,7 @@ def test_load_16bit():
     # some of functions can be not covered
     # it cant use cython parsing implementation, as it is not compiled
     filename = TEST_DATA_DIR / test_files[0]
-    print("testing bcf instructively packed 16bit...")
+    print("testing bcf instructively packed 16bit...")  # noqa: T201
     s = hs.load(filename)
     bse, hype = s
     # Bruker saves all images in true 16bit:
@@ -48,7 +48,7 @@ def test_load_16bit():
 
 def test_load_16bit_reduced():
     filename = TEST_DATA_DIR / test_files[0]
-    print("testing downsampled 16bit bcf...")
+    print("testing downsampled 16bit bcf...")  # noqa: T201
     s = hs.load(filename, downsample=4, cutoff_at_kV=10)
     bse, hype = s
     # sem images are never downsampled
@@ -68,7 +68,7 @@ def test_load_16bit_reduced():
 
 def test_load_16bit_cutoff_zealous():
     filename = TEST_DATA_DIR / test_files[0]
-    print("testing downsampled 16bit bcf with cutoff_at_kV=zealous...")
+    print("testing downsampled 16bit bcf with cutoff_at_kV=zealous...")  # noqa: T201
     hype = hs.load(filename, cutoff_at_kV="zealous", select_type="spectrum_image")
     assert hype.data.shape == (30, 30, 2048)
     assert hype.axes_manager.navigation_shape == (30, 30)
@@ -77,7 +77,7 @@ def test_load_16bit_cutoff_zealous():
 
 def test_load_16bit_cutoff_auto():
     filename = TEST_DATA_DIR / test_files[0]
-    print("testing downsampled 16bit bcf with cutoff_at_kV=auto...")
+    print("testing downsampled 16bit bcf with cutoff_at_kV=auto...")  # noqa: T201
     hype = hs.load(filename, cutoff_at_kV="auto", select_type="spectrum_image")
     assert hype.data.shape == (30, 30, 2048)
     assert hype.axes_manager.navigation_shape == (30, 30)
@@ -89,7 +89,7 @@ def test_load_8bit():
     hype_sig_shapes = [(2048,), (2048,)]
     for i, bcffile in enumerate(test_files[1:3]):
         filename = TEST_DATA_DIR / bcffile
-        print("testing simple 8bit bcf...")
+        print("testing simple 8bit bcf...")  # noqa: T201
         s = hs.load(filename)
         bse, hype = s[0], s[-1]
         # Bruker saves all images in true 16bit:
@@ -105,7 +105,7 @@ def test_load_8bit():
 def test_hyperspy_wrap():
     pytest.importorskip("exspy", reason="exspy not installed.")
     filename = TEST_DATA_DIR / test_files[0]
-    print("testing bcf wrap to hyperspy signal...")
+    print("testing bcf wrap to hyperspy signal...")  # noqa: T201
 
     hype = hs.load(filename, select_type="spectrum_image")
     np.testing.assert_allclose(hype.axes_manager[0].scale, 1.66740910949362, atol=1e-12)
@@ -217,7 +217,7 @@ def test_hyperspy_wrap():
 
 def test_hyperspy_wrap_downsampled():
     filename = TEST_DATA_DIR / test_files[0]
-    print("testing bcf wrap to hyperspy signal...")
+    print("testing bcf wrap to hyperspy signal...")  # noqa: T201
     hype = hs.load(filename, select_type="spectrum_image", downsample=5)
     np.testing.assert_allclose(
         hype.axes_manager[0].scale, 8.337045547468101, atol=1e-12
@@ -264,7 +264,7 @@ def test_fast_bcf():
         filename = TEST_DATA_DIR / bcffile
         thingy = _api.BCF_reader(filename)
         for j in range(2, 5, 1):
-            print("downsampling:", j)
+            print("downsampling:", j)  # noqa: T201
             _api.fast_unbcf = True  # manually enabling fast parsing
             hmap1 = thingy.parse_hypermap(downsample=j)  # using cython
             _api.fast_unbcf = False  # manually disabling fast parsing

--- a/rsciio/tests/test_digitalmicrograph.py
+++ b/rsciio/tests/test_digitalmicrograph.py
@@ -652,7 +652,7 @@ def test_data_and_axes(pdict, lazy):
     key = pdict["key"]
     assert s.data.dtype == np.dtype(dm4_data_types[key])
     subfolder = pdict["subfolder"]
-    print(pdict["subfolder"])
+    print(pdict["subfolder"])  # noqa: T201
     if subfolder == "1D":
         dat = np.arange(1, 3)
         assert s.axes_manager.signal_shape == (2,)

--- a/rsciio/tests/test_emd_velox.py
+++ b/rsciio/tests/test_emd_velox.py
@@ -458,7 +458,7 @@ class TestFeiEMD:
         time_data = np.zeros_like(frame_offsets)
         path = Path("path to large dataset")
         for i, frame_offset in enumerate(frame_offsets):
-            print(frame_offset + frame_number)
+            print(frame_offset + frame_number)  # noqa: T201
             t0 = time.time()
             hs.load(
                 path / "large dataset.emd",

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -419,7 +419,7 @@ def test_none_metadata():
 
 
 def test_rgba16():
-    print(TEST_DATA_PATH)
+    print(TEST_DATA_PATH)  # noqa: T201
     with pytest.warns(VisibleDeprecationWarning):
         #  The binned attribute has been moved from metadata.Signal
         s = hs.load(TEST_DATA_PATH / "test_rgba16.hdf5", reader="HSPY")
@@ -468,7 +468,7 @@ def test_nonuniformFDA(tmp_path, file, lazy):
     s = hs.signals.Signal1D(data, axes=(axis.get_axis_dictionary(),))
     if lazy:
         s = s.as_lazy()
-    print(axis.get_axis_dictionary())
+    print(axis.get_axis_dictionary())  # noqa: T201
     s.save(fname, overwrite=True)
     s2 = hs.load(fname)
     np.testing.assert_array_almost_equal(

--- a/rsciio/tests/test_image.py
+++ b/rsciio/tests/test_image.py
@@ -43,7 +43,7 @@ def test_save_load_cycle_grayscale(dtype, ext, tmp_path):
     if dtype == "int32" and ext in ["bmp", "jpg"]:
         # BMP and JPG does not support uint32.
         return
-    print(f"Saving-loading cycle for the extension `{ext}` with dtype `{dtype}`")
+    print(f"Saving-loading cycle for the extension `{ext}` with dtype `{dtype}`")  # noqa: T201
     filename = tmp_path / f"test_image.{ext}"
     s.save(filename)
     hs.load(filename)
@@ -58,13 +58,13 @@ def test_save_load_cycle_color(color, ext, tmp_path):
     if dim == 4 and ext == "jpeg":
         # JPEG does not support alpha channel.
         return
-    print("color:", color, "; dim:", dim, "; dtype:", dtype)
+    print("color:", color, "; dim:", dim, "; dtype:", dtype)  # noqa: T201
     s = hs.signals.Signal1D(
         np.arange(128 * 128 * dim).reshape(128, 128, dim).astype(dtype)
     )
     s.change_dtype(color)
 
-    print("Saving-loading cycle for the extension:", ext)
+    print("Saving-loading cycle for the extension:", ext)  # noqa: T201
     filename = tmp_path / f"test_image.{ext}"
     s.save(filename)
     hs.load(filename)
@@ -84,7 +84,7 @@ def test_save_load_cycle_kwds(dtype, ext, tmp_path):
         # BMP and JPG does not support uint32.
         return
 
-    print(f"Saving-loading cycle for the extension `{ext}` with dtype `{dtype}`")
+    print(f"Saving-loading cycle for the extension `{ext}` with dtype `{dtype}`")  # noqa: T201
     filename = tmp_path / f"test_image.{ext}"
     if ext == "png":
         kwds = {"optimize": True}

--- a/rsciio/tests/test_io.py
+++ b/rsciio/tests/test_io.py
@@ -111,7 +111,7 @@ class TestNonUniformAxisCheck:
     def test_nonuniform_writer_characteristic(self):
         for plugin in IO_PLUGINS:
             if "non_uniform_axis" not in plugin:
-                print(
+                print(  # noqa: T201
                     f"{plugin.name} IO-plugin is missing the "
                     "characteristic `non_uniform_axis`"
                 )

--- a/rsciio/tests/test_mrcz.py
+++ b/rsciio/tests/test_mrcz.py
@@ -133,7 +133,7 @@ class TestPythonMrcz:
                     break
                 except IOError:
                     sleep(0.001)
-            print(
+            print(  # noqa: T201
                 "Time to save file: {} s".format(
                     perf_counter() - (t_stop - MAX_ASYNC_TIME)
                 )
@@ -144,7 +144,7 @@ class TestPythonMrcz:
         try:
             os.remove(mrcName)
         except IOError:
-            print("Warning: file {} left on disk".format(mrcName))
+            print("Warning: file {} left on disk".format(mrcName))  # noqa: T201
 
         # change file timestamp to make the metadata of both signals equal
         testSignal.metadata.General.FileIO.Number_0.timestamp = (
@@ -218,4 +218,4 @@ class TestPythonMrcz:
         self.compareSaveLoad(
             [2, 64, 32], dtype=dtype, compressor="zstd", clevel=1, do_async=True
         )
-        print("MRCZ Asychronous test finished in {} s".format(perf_counter() - t_start))
+        print("MRCZ Asychronous test finished in {} s".format(perf_counter() - t_start))  # noqa: T201

--- a/rsciio/utils/hdf5.py
+++ b/rsciio/utils/hdf5.py
@@ -146,7 +146,7 @@ def list_datasets_in_file(
             for hdfd in hdf_dataset_paths:
                 print(hdfd, fin[hdfd].shape)  # noqa: T201
         else:
-            print("No HDF datasets not found or data is captured by NXdata")  # noqa: T201
+            print("No HDF datasets found or data is captured by NXdata")  # noqa: T201
     fin.close()
     return nexus_data_paths, hdf_dataset_paths
 

--- a/rsciio/utils/hdf5.py
+++ b/rsciio/utils/hdf5.py
@@ -82,7 +82,7 @@ def read_metadata_from_file(
         stripped_metadata, search_keys=search_keys
     )
     if verbose:
-        pprint.pprint(stripped_metadata)
+        pprint.pprint(stripped_metadata)  # noqa: T203
 
     fin.close()
     return stripped_metadata
@@ -136,17 +136,17 @@ def list_datasets_in_file(
     )
     if verbose:
         if nexus_data_paths:
-            print("NXdata found")
+            print("NXdata found")  # noqa: T201
             for nxd in nexus_data_paths:
-                print(nxd)
+                print(nxd)  # noqa: T201
         else:
-            print("NXdata not found")
+            print("NXdata not found")  # noqa: T201
         if hdf_dataset_paths:
-            print("Unique HDF datasets found")
+            print("Unique HDF datasets found")  # noqa: T201
             for hdfd in hdf_dataset_paths:
-                print(hdfd, fin[hdfd].shape)
+                print(hdfd, fin[hdfd].shape)  # noqa: T201
         else:
-            print("No HDF datasets not found or data is captured by NXdata")
+            print("No HDF datasets not found or data is captured by NXdata")  # noqa: T201
     fin.close()
     return nexus_data_paths, hdf_dataset_paths
 

--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -164,7 +164,7 @@ def overwrite(filename):
             answer = input(message)
             answer = answer.lower()
             while (answer != "y") and (answer != "n"):
-                print("Please answer y or n.")
+                print("Please answer y or n.")  # noqa: T201
                 answer = input(message)
             if answer.lower() == "y":
                 return True

--- a/upcoming_changes/378.maintenance.rst
+++ b/upcoming_changes/378.maintenance.rst
@@ -1,0 +1,1 @@
+Add T20 rules (flake8-print) to ruff configuration.


### PR DESCRIPTION
Make sure we don't commit debugging print call, such as in https://github.com/hyperspy/rosettasciio/pull/372#discussion_r1989400738!

### Progress of the PR
- [x] Add T20 rules (flake8-print) to ruff configuration
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.
