### PR TITLE
Build free threaded python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.23
         env:
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
+          CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
 
       - name: List wheels
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_ENVIRONMENT: POOCH_BASE_URL=https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/rsciio/tests/data/
-      CIBW_TEST_COMMAND: "pytest --pyargs rsciio"
-      CIBW_TEST_EXTRAS: "tests"
-      # No need to build wheels for pypy because the pure python wheels can be used
-      # PyPy documentation recommends no to build the C extension
-      CIBW_SKIP: "{pp*,*-musllinux*,*win32,*-manylinux_i686}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,11 +164,10 @@ jobs:
           pip install git+https://github.com/hyperspy/hyperspy.git
           pip install git+https://github.com/hyperspy/exspy.git
 
-      - name: Install hyperspy and exspy (dev & 3.13t)
+      - name: Install hyperspy (dev & 3.13t)
         if: ${{ matrix.HYPERSPY_VERSION == 'dev' && matrix.PYTHON_VERSION == '3.13t'}}
         run: |
           pip install git+https://github.com/hyperspy/hyperspy.git --no-deps
-          pip install git+https://github.com/hyperspy/exspy.git --no-deps
 
       - name: Install python-mrcz dev
         # for numpy 2.0 support for python >= 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,9 @@ jobs:
         os: [ubuntu, windows, macos]
         os_version: [latest]
         PYTHON_VERSION: ['3.9', '3.10', '3.13']
+        HYPERSPY_VERSION: ['release']
         LABEL: ['']
+        PIP_ARGS: ['']
         include:
           # test oldest supported version of main dependencies on python 3.8
           - os: ubuntu
@@ -31,28 +33,44 @@ jobs:
             # align matplotlib and dask dependency with hyperspy
             DEPENDENCIES: matplotlib==3.6 numpy==1.20.0 tifffile==2022.7.28 dask[array]==2022.9.2 distributed==2022.9.2 numba==0.53 imageio==2.16 pillow==8.3.2 scikit-image==0.18.0 python-box==6.0.0
             LABEL: '-oldest'
+            HYPERSPY_VERSION: 'release'
           # test minimum requirement
           - os: ubuntu
             os_version: latest
             PYTHON_VERSION: '3.10'
-            LABEL: '-minimum'
+            LABEL: '-hyperspy-minimum'
+            HYPERSPY_VERSION: 'release'
           - os: ubuntu
             os_version: latest
             PYTHON_VERSION: '3.12'
-            LABEL: '-hyperspy-dev'
+            LABEL: '-hyperspy_dev'
+            HYPERSPY_VERSION: 'dev'
           - os: ubuntu
             os_version: latest
             PYTHON_VERSION: '3.10'
-            LABEL: '-without-hyperspy'
+            LABEL: ''
           - os: ubuntu
             os_version: latest
             PYTHON_VERSION: '3.9'
+            LABEL: '-hyperspy'
+            HYPERSPY_VERSION: 'release'
           - os: ubuntu
             os_version: latest
             PYTHON_VERSION: '3.12'
+            LABEL: '-hyperspy'
+            HYPERSPY_VERSION: 'release'
           - os: macos
             os_version: '13'
             PYTHON_VERSION: '3.12'
+            LABEL: '-hyperspy'
+            HYPERSPY_VERSION: 'release'
+          - os: ubuntu
+            os_version: latest
+            PYTHON_VERSION: '3.13t'
+            # use build isolation until cython 3.1 is released
+            PIP_ARGS: '--no-build-isolation'
+            LABEL: '-hyperspy_dev-minimum'
+            HYPERSPY_VERSION: 'dev'
 
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +94,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           cache: 'pip'
-        
+
       - name: Get the number of CPUs
         id: cpus
         run: |
@@ -105,16 +123,52 @@ jobs:
           python --version
           pip --version
 
-      - name: Install hyperspy and exspy
-        if: ${{ ! contains(matrix.LABEL, 'without-hyperspy') && matrix.PYTHON_VERSION != '3.13'}}
+      - name: Set PYTHON_GIL
+        # make sure the GIL doesn't get enabled
+        # https://py-free-threading.github.io/running-gil-disabled/
+        if: endsWith(matrix.PYTHON_VERSION, 't')
         run: |
-          pip install hyperspy exspy
+          echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
+
+      - name: Display GIL information
+        if: ${{ contains(matrix.PYTHON_VERSION, '3.13') }}
+        run: |
+          # show if free-threaded build
+          python -VV
+          # show if GIL is enable
+          python -c "import sys; print('GIL enabled:', sys._is_gil_enabled())"
+
+      - name: Install build dependency (3.13t)
+        if: ${{ matrix.PYTHON_VERSION == '3.13t'}}
+        run: |
+          pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+          # install build dependencies manually to be able to use `--no-build-isolation`
+          pip install setuptools-scm wheel hatchling numpy pkgconfig
+
+      - name: Install hyperspy dependencies (3.13t)
+        if: ${{ matrix.PYTHON_VERSION == '3.13t'}}
+        run: |
+          # no freethreaded build available for h5py
+          # install other dependencies manually 
+          pip install cloudpickle dask[array] importlib-metadata jinja2 matplotlib natsort numpy packaging pint prettytable pyyaml scikit-image scipy sympy tqdm pooch requests
+          pip install traits ${{ matrix.PIP_ARGS }}
+
+      - name: Install hyperspy and exspy (release)
+        if: ${{ matrix.HYPERSPY_VERSION == 'release'}}
+        run: |
+          pip install hyperspy exspy ${{ matrix.PIP_ARGS }}
 
       - name: Install hyperspy and exspy (dev)
-        if: ${{ contains(matrix.LABEL, 'hyperspy-dev') }}
+        if: ${{ matrix.HYPERSPY_VERSION == 'dev' && matrix.PYTHON_VERSION != '3.13t'}}
         run: |
           pip install git+https://github.com/hyperspy/hyperspy.git
           pip install git+https://github.com/hyperspy/exspy.git
+
+      - name: Install hyperspy and exspy (dev & 3.13t)
+        if: ${{ matrix.HYPERSPY_VERSION == 'dev' && matrix.PYTHON_VERSION == '3.13t'}}
+        run: |
+          pip install git+https://github.com/hyperspy/hyperspy.git --no-deps
+          pip install git+https://github.com/hyperspy/exspy.git --no-deps
 
       - name: Install python-mrcz dev
         # for numpy 2.0 support for python >= 3.9
@@ -126,7 +180,7 @@ jobs:
       - name: Install
         shell: bash
         run: |
-          pip install --upgrade -e .'${{ env.PIP_SELECTOR }}'
+          pip install --upgrade -e .'${{ env.PIP_SELECTOR }}' ${{ matrix.PIP_ARGS }}
 
       - name: Uninstall pyUSID
         # remove when pyUSID supports numpy 2 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ dev = [
 
 [tool.cibuildwheel]
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp313t-*"]
+enable = ["cpython-freethreading"]
 # No need to build wheels for pypy because the pure python wheels can be used
 # PyPy documentation recommends no to build the C extension
 skip = ["pp*", "*-musllinux*", "*win32", "*-manylinux_i686"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,14 @@ dev = [
   "rosettasciio[tests]"
 ]
 
+[tool.cibuildwheel]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp313t-*"]
+# No need to build wheels for pypy because the pure python wheels can be used
+# PyPy documentation recommends no to build the C extension
+skip = ["pp*", "*-musllinux*", "*win32", "*-manylinux_i686"]
+test-command = "pytest --pyargs rsciio"
+test-extras = ["tests"]
+
 [tool.pytest.ini_options]
 # Note we may need to use `-n 2` argument for pytest-xdist on CI
 # due to https://github.com/pytest-dev/pytest-xdist/issues/9.

--- a/rsciio/bruker/unbcf_fast.pyx
+++ b/rsciio/bruker/unbcf_fast.pyx
@@ -1,3 +1,6 @@
+# declate the module as thread safe for free-threaded python
+# cython: freethreading_compatible=True
+
 import cython
 import numpy as np
 import sys

--- a/rsciio/tests/test_delmic.py
+++ b/rsciio/tests/test_delmic.py
@@ -3,10 +3,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-# import gc
-# import os
-
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+pytest.importorskip("h5py", reason="h5py not installed")
 
 testfile_dir = (Path(__file__).parent / "data" / "delmic").resolve()
 testfile_hyperspectral_path = (testfile_dir / "test_hyperspectral.h5").resolve()

--- a/rsciio/tests/test_emd_prismatic.py
+++ b/rsciio/tests/test_emd_prismatic.py
@@ -23,6 +23,7 @@ import pytest
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 t = pytest.importorskip("traits.api", reason="traits not installed")
+pytest.importorskip("h5py", reason="h5py not installed")
 
 TEST_DATA_PATH = Path(__file__).parent / "data" / "emd"
 

--- a/rsciio/tests/test_emd_velox.py
+++ b/rsciio/tests/test_emd_velox.py
@@ -36,6 +36,7 @@ from rsciio.utils.tests import assert_deep_almost_equal
 from rsciio.utils.tools import dummy_context_manager
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+pytest.importorskip("h5py", reason="h5py not installed")
 
 
 TEST_DATA_PATH = Path(__file__).parent / "data" / "emd"

--- a/rsciio/tests/test_io.py
+++ b/rsciio/tests/test_io.py
@@ -29,7 +29,7 @@ import pytest
 from rsciio import IO_PLUGINS
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
-pytest.importorskip("h5py")
+pytest.importorskip("h5py", reason="h5py not installed")
 
 from hyperspy.axes import DataAxis  # noqa: E402
 

--- a/rsciio/tests/test_io.py
+++ b/rsciio/tests/test_io.py
@@ -29,6 +29,7 @@ import pytest
 from rsciio import IO_PLUGINS
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+pytest.importorskip("h5py")
 
 from hyperspy.axes import DataAxis  # noqa: E402
 

--- a/upcoming_changes/379.maintenance.rst
+++ b/upcoming_changes/379.maintenance.rst
@@ -1,0 +1,1 @@
+Add free-threaded python build.


### PR DESCRIPTION
Build free threaded python 3.13 to make easier to install in free threaded environment.
There are a few workaround because h5py doesn't have a free threaded wheel yet and a pre-release of cython needs to be used.

### Progress of the PR
- [x] Setup free threaded on CI following https://py-free-threading.github.io/ci guidance,
- [x] declare bruker c extension as compatible with free threading to avoid enabling the GIL when loading extension, 
- [x] add to release workflow 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


