### PR TITLE
Migrate marker api to hyperspy v2 in bruker reader

### DIFF
--- a/rsciio/bruker/_api.py
+++ b/rsciio/bruker/_api.py
@@ -644,17 +644,17 @@ class HyperHeader:
             if overlay_node is not None:
                 overlay_dict = x2d.dictionarize(overlay_node)
                 over_rect = overlay_dict["TRTOverlayElement"]["Rect"]
-                rect = {
-                    "y1": over_rect["Top"] * self.y_res,
-                    "x1": over_rect["Left"] * self.x_res,
-                    "y2": over_rect["Bottom"] * self.y_res,
-                    "x2": over_rect["Right"] * self.x_res,
-                }
+                x1, x2 = over_rect["Left"] * self.x_res, over_rect["Right"] * self.x_res
+                y1, y2 = over_rect["Top"] * self.y_res, over_rect["Bottom"] * self.y_res
+                width, height = x2 - x1, y2 - y1
                 md_over_dict = {
-                    "marker_type": "Rectangle",
-                    "plot_on_signal": True,
-                    "data": rect,
-                    "marker_properties": {"color": "yellow", "linewidth": 2},
+                    "class": "Rectangles",
+                    "offsets": ([x1 + width / 2, y1 + height / 2],),
+                    "widths": (width,),
+                    "heights": (height,),
+                    "color": "yellow",
+                    "linewidth": 2,
+                    "facecolor": "none",
                 }
         image = Container()
         image.width = int(xml_node.find("./Width").text)  # in pixels

--- a/rsciio/bruker/_api.py
+++ b/rsciio/bruker/_api.py
@@ -642,6 +642,9 @@ class HyperHeader:
                 "TRTBasicLineOverlayElement/TRTOverlayElement"
             )
             if overlay_node is not None:
+                # Currently not tested
+                # waiting on small test files to be provided by users
+                # See https://github.com/hyperspy/rosettasciio/pull/383
                 overlay_dict = x2d.dictionarize(overlay_node)
                 over_rect = overlay_dict["TRTOverlayElement"]["Rect"]
                 x1, x2 = over_rect["Left"] * self.x_res, over_rect["Right"] * self.x_res

--- a/upcoming_changes/383.bugfix.rst
+++ b/upcoming_changes/383.bugfix.rst
@@ -1,0 +1,1 @@
+Migrate HyperSpy markers API to HyperSpy v2 in bruker reader to fix loading files containing markers.


### PR DESCRIPTION
As mentioned in https://github.com/hyperspy/rosettasciio/issues/382#issuecomment-2746144367, migrate to the new marker API in the bruker reader.

### Progress of the PR
- [x] migrate to the new marker API in the bruker reader,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests: later when some files small enough are made available,
- [x] ready for review.


