### PR TITLE
BugFix: Fix load block file with arbitrary chunking.

### DIFF
--- a/rsciio/blockfile/_api.py
+++ b/rsciio/blockfile/_api.py
@@ -275,13 +275,13 @@ def file_reader(filename, lazy=False, chunks="auto", endianess="<"):
     offset2 = header["Data_offset_2"]
     # Every frame is preceeded by a 6 byte sequence
     # (AA 55, and then a 4 byte integer specifying frame number)
-    frame_dtype = np.dtype(
-        [
-            ("header", np.dtype(endianess + "u1"), 6),
-            ("data", np.dtype(endianess + "u1"), np.prod(signal_shape)),
-        ]
-    )
     if not lazy:
+        frame_dtype = np.dtype(
+            [
+                ("header", np.dtype(endianess + "u1"), 6),
+                ("data", np.dtype(endianess + "u1"), np.prod(signal_shape)),
+            ]
+        )
         f.seek(offset2)
         data = np.fromfile(f, dtype=frame_dtype)["data"]
         try:
@@ -296,15 +296,20 @@ def file_reader(filename, lazy=False, chunks="auto", endianess="<"):
             data = np.pad(data, pw, mode="constant")
             data = data.reshape(navigation_shape + signal_shape).squeeze()
     else:
+        frame_dtype = np.dtype(
+            [
+                ("header", np.dtype(endianess + "u1"), 6),
+                ("data", np.dtype(endianess + "u1"), signal_shape),
+            ]
+        )
         data = memmap_distributed(
             filename,
             chunks=chunks,
             offset=offset2,
-            shape=np.prod(navigation_shape),
+            shape=navigation_shape,
             dtype=frame_dtype,
             key="data",
         )
-        data = data.reshape(navigation_shape + signal_shape).squeeze()
 
     units = ["nm", "nm", "cm", "cm"]
     names = ["y", "x", "dy", "dx"]

--- a/rsciio/tests/test_blockfile.py
+++ b/rsciio/tests/test_blockfile.py
@@ -534,3 +534,16 @@ def test_crop_notes(save_path):
         signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
     assert sig_reload.original_metadata.blockfile_header.Note == note[:note_len]
+
+
+def test_blo_chunking_lazy(save_path):
+    data = np.zeros((90, 121, 144, 144), dtype=np.uint8)
+    sig = hs.signals.Signal2D(data)
+    sig.save(save_path, overwrite=True)
+    new_s = hs.load(save_path, lazy=True, chunks=(1, 1, 144//2, 144//2))
+    assert isinstance(new_s.data, da.Array)
+    assert new_s.data.shape == (90, 121, 144, 144)
+    assert new_s.data.chunks[0] == (1,)*90
+    assert new_s.data.chunks[1] == (1,)*121
+    assert new_s.data.chunks[2] == (72, 72)
+    assert new_s.data.chunks[3] == (72, 72)

--- a/rsciio/utils/distributed.py
+++ b/rsciio/utils/distributed.py
@@ -186,7 +186,7 @@ def memmap_distributed(
         block_size_limit=block_size_limit,
         dtype=array_dtype,
     )
-    num_dim = len(shape)
+    num_dim = len(shape + sub_array_shape)
     data = da.map_blocks(
         slice_memmap,
         chunked_slices,

--- a/upcoming_changes/395.bugfix.rst
+++ b/upcoming_changes/395.bugfix.rst
@@ -1,0 +1,2 @@
+Fix Distributed loading of ``.blo`` files (and other binary files with the ``key`` parameter)
+with chunks that don't span the signal axis.


### PR DESCRIPTION
### Description of the change

Alternative to #393 and Fixes #390.

@ericpre This should now allow you to have any arbitary chunking for a binary file even it it used the `key` keyword. 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

This now works when it used to fail.

```python
def test_blo_chunking_lazy(save_path):
    data = np.zeros((90, 121, 144, 144), dtype=np.uint8)
    sig = hs.signals.Signal2D(data)
    sig.save(save_path, overwrite=True)
    new_s = hs.load(save_path, lazy=True, chunks=(1, 1, 144//2, 144//2))
    assert isinstance(new_s.data, da.Array)
    assert new_s.data.shape == (90, 121, 144, 144)
    assert new_s.data.chunks[0] == (1,)*90
    assert new_s.data.chunks[1] == (1,)*121
    assert new_s.data.chunks[2] == (72, 72)
    assert new_s.data.chunks[3] == (72, 72)
```

