### PR TITLE
Fix getting filehandle from tiff file with dask >= 2025.4.0

### DIFF
--- a/rsciio/utils/tools.py
+++ b/rsciio/utils/tools.py
@@ -27,8 +27,10 @@ from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from pathlib import Path
 
+import dask
 import numpy as np
 from box import Box
+from packaging.version import Version
 from pint import UnitRegistry
 
 _UREG = UnitRegistry()
@@ -548,7 +550,11 @@ def get_file_handle(data, warn=True):
             # interfaces of tifffile
             # this may be brittle and may need maintenance as
             # dask or tifffile evolve
-            return data.dask[arrkey_tifffile][2][0].parent.filehandle._fh
+            if Version(dask.__version__) >= Version("2025.4.0"):
+                tiff_pages_series = data.dask[arrkey_tifffile].args[1]
+            else:
+                tiff_pages_series = data.dask[arrkey_tifffile][2][0]
+            return tiff_pages_series.parent.filehandle._fh
         except IndexError:  # pragma: no cover
             if warn:
                 _logger.warning(

--- a/upcoming_changes/397.maintenance.rst
+++ b/upcoming_changes/397.maintenance.rst
@@ -1,0 +1,1 @@
+Fix getting filehandle from tiff file with ``dask`` >= 2025.4.0.


### PR DESCRIPTION
We know the current approach is brittle but until https://github.com/hyperspy/rosettasciio/issues/331 is not closed, we need to stick to it.

### Progress of the PR
- [x] Fix getting filehandle from tiff file with dask >= 2025.4.0,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


