### PR TITLE
Fix memory usage in lazy loading of mib file

### DIFF
--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -35,7 +35,7 @@ from rsciio._docstrings import (
     NAVIGATION_SHAPE,
     RETURNS_DOC,
 )
-from rsciio.utils._deprecated import deprecated_argument
+from rsciio.utils._deprecated import distributed_keyword_deprecation
 from rsciio.utils.distributed import memmap_distributed
 from rsciio.utils.tools import sarray2dict
 
@@ -325,9 +325,7 @@ def read_de_metadata_file(filename, nav_shape=None, scan_pos_file=None):
     return original_metadata, metadata, axes, nav_shape, positions
 
 
-@deprecated_argument(
-    "distributed", "0.8.0", additional_msg=" This should have no effect on basic usage."
-)
+@distributed_keyword_deprecation
 def file_reader(
     filename,
     lazy=False,

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -326,13 +326,14 @@ def load_mib_data(
                 data = data.compute()
             data = data.squeeze()
     elif isinstance(path, bytes):
-        data = np.frombuffer(
+        buffer = np.frombuffer(
             path,
             dtype=merlin_frame_dtype,
             count=mib_prop.xy,
             offset=mib_prop.offset,
-        )["data"]
-        data = data.reshape(navigation_shape + mib_prop.merlin_size).squeeze()
+        ).reshape(navigation_shape)
+        headers = buffer["header"]
+        data = buffer["data"]
 
     else:  # pragma: no cover
         raise TypeError("`path` must be a str or a buffer.")

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -34,6 +34,7 @@ from rsciio._docstrings import (
     NAVIGATION_SHAPE,
     RETURNS_DOC,
 )
+from rsciio.utils._deprecated import distributed_keyword_deprecation
 from rsciio.utils.distributed import memmap_distributed
 
 _logger = logging.getLogger(__name__)
@@ -186,6 +187,7 @@ class MIBProperties:
     parse_file.__doc__ %= _PATH_DOCSTRING
 
 
+@distributed_keyword_deprecation
 def load_mib_data(
     path,
     lazy=False,
@@ -482,6 +484,7 @@ def file_reader(
     first_frame=None,
     last_frame=None,
     print_info=False,
+    **kwargs,
 ):
     """
     Read a Quantum Detectors ``mib`` file.
@@ -499,6 +502,8 @@ def file_reader(
     %s
     print_info : bool
         Display information about the mib file.
+    **kwargs : dict
+        Keyword arguments are passed to :func:`~.quantumdetector.load_mib_data`.
 
     %s
 
@@ -584,6 +589,7 @@ def file_reader(
         mib_prop=mib_prop,
         print_info=print_info,
         return_mmap=False,
+        **kwargs,
     )
     data = np.flip(data, axis=-2)
 

--- a/rsciio/quantumdetector/_api.py
+++ b/rsciio/quantumdetector/_api.py
@@ -24,12 +24,10 @@ import os
 import warnings
 from pathlib import Path
 
-import dask.array as da
 import numpy as np
 
 from rsciio._docstrings import (
     CHUNKS_READ_DOC,
-    DISTRIBUTED_DOC,
     FILENAME_DOC,
     LAZY_DOC,
     MMAP_DOC,
@@ -196,7 +194,6 @@ def load_mib_data(
     navigation_shape=None,
     first_frame=None,
     last_frame=None,
-    distributed=False,
     mib_prop=None,
     return_headers=False,
     print_info=False,
@@ -213,12 +210,11 @@ def load_mib_data(
     %s
     %s
     %s
-    %s
     mib_prop : ``MIBProperties``, default=None
         The ``MIBProperties`` instance of the file. If None, it will be
         parsed from the file.
     return_headers : bool, default=False
-        If True, also return headers.
+        If True, also return headers. Only when ``return_mmap`` is True.
     print_info : bool, default=False
         If True, display information when loading the file.
     return_mmap : bool
@@ -240,6 +236,11 @@ def load_mib_data(
 
     if lazy and isinstance(path, bytes):
         raise ValueError("Loading memory buffer lazily is not supported.")
+
+    if return_headers and not return_mmap:
+        raise ValueError(
+            "To use `return_headers=True`, `return_mmap=True` is required."
+        )
 
     # As we save the dtype name, we don't have the endianess and we
     # need to specify it here
@@ -308,57 +309,33 @@ def load_mib_data(
     if isinstance(mib_prop.path, str):
         memmap_kwargs = dict(
             filename=mib_prop.path,
+            shape=navigation_shape,
             # take into account first_frame
             offset=mib_prop.offset + merlin_frame_dtype.itemsize * first_frame,
-            # need to use np.prod(navigation_shape) to crop number line
-            shape=np.prod(navigation_shape),
             dtype=merlin_frame_dtype,
         )
-        if distributed:
+        if return_mmap:
+            memmap_ = np.memmap(mode=mmap_mode, **memmap_kwargs)
+            headers = memmap_["header"]
+            data = memmap_["data"]
+        else:
             data = memmap_distributed(chunks=chunks, key="data", **memmap_kwargs)
             if not lazy:
                 data = data.compute()
-                # get_file_handle(data).close()
-        else:
-            data = np.memmap(mode=mmap_mode, **memmap_kwargs)
+            data = data.squeeze()
     elif isinstance(path, bytes):
         data = np.frombuffer(
             path,
             dtype=merlin_frame_dtype,
             count=mib_prop.xy,
             offset=mib_prop.offset,
-        )
+        )["data"]
+        data = data.reshape(navigation_shape + mib_prop.merlin_size).squeeze()
 
     else:  # pragma: no cover
         raise TypeError("`path` must be a str or a buffer.")
 
-    if not distributed:
-        headers = data["header"]
-        data = data["data"]
-    if not return_mmap:
-        if not distributed and lazy:
-            if isinstance(chunks, tuple) and len(chunks) > 2:
-                # Since the data is reshaped later on, we set only the
-                # signal dimension chunks here
-                _chunks = ("auto",) + chunks[-2:]
-            else:
-                _chunks = chunks
-            data = da.from_array(data, chunks=_chunks)
-        else:
-            data = np.array(data)
-
-    # remove navigation_dimension with value 1 before reshaping
-    navigation_shape = tuple(i for i in navigation_shape if i > 1)
-    data = data.reshape(navigation_shape + mib_prop.merlin_size)
-    if lazy and isinstance(chunks, tuple) and len(chunks) > 2:
-        # rechunk navigation space when chunking is specified as a tuple
-        data = data.rechunk(chunks)
-
     if return_headers:
-        if distributed:
-            raise ValueError(
-                "Retuning headers is not supported with `distributed=True`."
-            )
         return data, headers
     else:
         return data
@@ -371,7 +348,6 @@ load_mib_data.__doc__ %= (
     MMAP_DOC,
     NAVIGATION_SHAPE,
     _FIRST_LAST_FRAME,
-    DISTRIBUTED_DOC,
 )
 
 
@@ -505,7 +481,6 @@ def file_reader(
     navigation_shape=None,
     first_frame=None,
     last_frame=None,
-    distributed=False,
     print_info=False,
 ):
     """
@@ -516,7 +491,6 @@ def file_reader(
 
     Parameters
     ----------
-    %s
     %s
     %s
     %s
@@ -607,7 +581,6 @@ def file_reader(
         navigation_shape=navigation_shape,
         first_frame=first_frame,
         last_frame=last_frame,
-        distributed=distributed,
         mib_prop=mib_prop,
         print_info=print_info,
         return_mmap=False,
@@ -672,6 +645,5 @@ file_reader.__doc__ %= (
     MMAP_DOC,
     NAVIGATION_SHAPE,
     _FIRST_LAST_FRAME,
-    DISTRIBUTED_DOC,
     RETURNS_DOC,
 )

--- a/rsciio/tests/test_mrc.py
+++ b/rsciio/tests/test_mrc.py
@@ -20,6 +20,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from rsciio.mrc import file_reader
+from rsciio.utils.exceptions import VisibleDeprecationWarning
+
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
 
@@ -58,38 +61,30 @@ def test_4DSTEM_image_navigation_shape_16_16():
     assert s.axes_manager.navigation_shape == (16, 16)
 
 
-@pytest.mark.parametrize("distributed", [True, False])
-def test_4DSTEM_image_navigation_shape_8_32(distributed):
+def test_4DSTEM_image_navigation_shape_8_32():
     s = hs.load(
         TEST_DATA_DIR / "4DSTEMscan.mrc",
         navigation_shape=(8, 32),
-        distributed=distributed,
     )
     assert s.data.shape == (32, 8, 256, 256)
     assert s.axes_manager.signal_shape == (256, 256)
     assert s.axes_manager.navigation_shape == (8, 32)
 
 
-def test_mrc_distributed_equal():
-    s = hs.load(
-        TEST_DATA_DIR / "4DSTEMscan.mrc",
-        navigation_shape=(8, 32),
-        distributed=False,
-    )
-    s2 = hs.load(
-        TEST_DATA_DIR / "4DSTEMscan.mrc",
-        navigation_shape=(8, 32),
-        distributed=True,
-    )
-    np.testing.assert_array_equal(s.data, s2.data)
-
-
 @pytest.mark.parametrize("distributed", [True, False])
-def test_mrc_chunks_equal(distributed):
+def test_distributed_deprecation_warning(distributed):
+    with pytest.warns(VisibleDeprecationWarning):
+        file_reader(
+            str(TEST_DATA_DIR / "4DSTEMscan.mrc"),
+            navigation_shape=(8, 32),
+            distributed=distributed,
+        )
+
+
+def test_mrc_chunks_equal():
     s = hs.load(
         TEST_DATA_DIR / "4DSTEMscan.mrc",
         navigation_shape=(8, 32),
-        distributed=distributed,
         chunks=(16, 4, 256, 256),
         lazy=True,
     )

--- a/rsciio/tests/test_quantumdetector.py
+++ b/rsciio/tests/test_quantumdetector.py
@@ -320,27 +320,24 @@ def test_test_load_mib_data_from_buffer():
             _ = load_mib_data(f.read(), lazy=True)
 
 
-@pytest.mark.parametrize("return_mmap", (True, False))
-def test_parse_exposures(return_mmap):
+def test_parse_exposures():
     fname = TEST_DATA_DIR_UNZIPPED / "001_4x2_6bit.mib"
 
-    data, headers = load_mib_data(
-        str(fname), return_headers=True, return_mmap=return_mmap
-    )
+    data, headers = load_mib_data(str(fname), return_headers=True, return_mmap=True)
     exposures = parse_exposures(headers[0])
     assert exposures == [100.0]
 
     exposures = parse_exposures(headers)
     assert exposures == [100.0] * headers.shape[0]
 
+    with pytest.raises(ValueError):
+        load_mib_data(str(fname), return_headers=True, return_mmap=False)
 
-@pytest.mark.parametrize("return_mmap", (True, False))
-def test_parse_timestamps(return_mmap):
+
+def test_parse_timestamps():
     fname = TEST_DATA_DIR_UNZIPPED / "001_4x2_6bit.mib"
 
-    data, headers = load_mib_data(
-        str(fname), return_headers=True, return_mmap=return_mmap
-    )
+    data, headers = load_mib_data(str(fname), return_headers=True, return_mmap=True)
     timestamps = parse_timestamps(headers[0])
     assert timestamps == ["2021-05-07T16:51:10.905800928Z"]
 
@@ -403,24 +400,6 @@ def test_frames_in_acquisition_zero():
 
     s = hs.load(f"{fname}.mib")
     assert s.axes_manager.navigation_shape == ()
-
-
-@pytest.mark.parametrize("lazy", (True, False))
-def test_distributed(lazy):
-    s = hs.load(
-        TEST_DATA_DIR_UNZIPPED / "001_4x2_6bit.mib",
-        distributed=False,
-        lazy=lazy,
-    )
-    s2 = hs.load(
-        TEST_DATA_DIR_UNZIPPED / "001_4x2_6bit.mib",
-        distributed=True,
-        lazy=lazy,
-    )
-    if lazy:
-        s.compute()
-        s2.compute()
-    np.testing.assert_array_equal(s.data, s2.data)
 
 
 @pytest.mark.parametrize("fname", SIGNAL_ROI_FNAME_LIST)

--- a/rsciio/tests/test_quantumdetector.py
+++ b/rsciio/tests/test_quantumdetector.py
@@ -33,6 +33,7 @@ from rsciio.quantumdetector._api import (
     parse_hdr_file,
     parse_timestamps,
 )
+from rsciio.utils.exceptions import VisibleDeprecationWarning
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 zarr = pytest.importorskip("zarr", reason="zarr not installed")
@@ -422,3 +423,13 @@ def test_signal_shape_ROI(fname):
         assert s.axes_manager.signal_shape == (256, 64)
     if "sig256x128" in fname:
         assert s.axes_manager.signal_shape == (256, 128)
+
+
+@pytest.mark.parametrize("distributed", [True, False])
+def test_deprecated_distributed(distributed):
+    fname = TEST_DATA_DIR_UNZIPPED / "Single_9_Frame_CounterDepth_1_Rows_256.mib"
+    with pytest.warns(VisibleDeprecationWarning):
+        _ = hs.load(fname, distributed=distributed)
+
+    with pytest.warns(VisibleDeprecationWarning):
+        load_mib_data(str(fname), distributed=distributed)

--- a/rsciio/tests/test_quantumdetector.py
+++ b/rsciio/tests/test_quantumdetector.py
@@ -316,6 +316,14 @@ def test_test_load_mib_data_from_buffer():
     assert data.shape == (2, 4, 256, 256)
 
     with open(fname, mode="rb") as f:
+        data, headers = load_mib_data(
+            f.read(), navigation_shape=(4, 2), return_headers=True
+        )
+
+    assert data.shape == (2, 4, 256, 256)
+    assert headers.shape == (2, 4)
+
+    with open(fname, mode="rb") as f:
         with pytest.raises(ValueError):
             # loading lazy memory buffer is not supported
             _ = load_mib_data(f.read(), lazy=True)

--- a/rsciio/utils/_deprecated.py
+++ b/rsciio/utils/_deprecated.py
@@ -154,3 +154,11 @@ class deprecated_argument:
             return func(*args, **kwargs)
 
         return wrapped
+
+
+def distributed_keyword_deprecation(func):
+    return deprecated_argument(
+        "distributed",
+        "0.8.0",
+        additional_msg=" Distributed memory mapping is now supported in the default implementation.",
+    )(func)

--- a/upcoming_changes/400.bugfix.rst
+++ b/upcoming_changes/400.bugfix.rst
@@ -1,0 +1,1 @@
+Remove non-distributed memory mapping implementation in quantum detector reader because it doesn't work anymore with recent versions of dask and it is not supposed to. The :ref:`distributed memory mapping <lazy>` implementation is now always used. Fix setting ``chunks``.


### PR DESCRIPTION
With recent version of dask the non distributed lazy loading loads the whole dataset in memory. This implementation is not supposed to work anymore, (see for example: https://github.com/dask/dask/issues/11850) therefore, it is removed in this PR and only the distributed memory mapping is kept.

### Progress of the PR
- [x] Remove non-distributed memory mapping implementation in quantum detector reader,
- [x] fix passing `chunks` - same as #395.
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.

