### PR TITLE
Remove distributed argument rpl reader

### DIFF
--- a/doc/user_guide/lazy.rst
+++ b/doc/user_guide/lazy.rst
@@ -18,25 +18,6 @@ The data will be loaded as a dask array instead of a numpy array.
     dask.array<array, shape=(10, 20, 30), dtype=int64, chunksize=(10, 20, 30), chunktype=numpy.ndarray>
 
 
-Memory mapping
-==============
-
-Binary file formats are loaded lazily using `memory mapping`_.
-The common implementation consists in passing the :class:`numpy.memmap` to the :func:`dask.array.from_array`.
-However, it has some shortcomings, to name a few: it is not compatible with the `dask distributed`_
-scheduler and it has limited control on the memory usage.
-
-For supported file formats, a different implementation can be used to load data lazily in a manner that is
-compatible with the `dask distributed`_  scheduler and allow for better control of the memory usage. 
-This implementation uses an approach similar to that described in the dask documentation on
-`memory mapping`_ and is enabled using the ``distributed`` parameter (not all formats are
-:ref:`supported <supported-formats>`):
-
-.. code:: python
-
-    >>> s = hs.load("file.mrc", lazy=True, distributed=True)
-
-
 Chunks
 ======
 
@@ -46,25 +27,23 @@ The chunking can also be specified as follow using the ``chunks`` parameter:
 
 .. code:: python
 
-    >>> s = hs.load("file.mrc", lazy=True, distributed=True, chunks=(5, 10, 10))
+    >>> s = hs.load("file.mrc", lazy=True, chunks=(5, 10, 10))
 
-.. note::
+Memory mapping
+==============
 
-    Some file reader support specifying the ``chunks`` parameter with the ``distributed`` parameter
-    being set to ``True`` or ``False``. In both cases the reader will return a dask array with
-    specifyed chunks, However, the way the dask array is created differs significantly and if
-    there are issues with memory usage or slow loading, it is recommend to try the ``distributed`` implementation.
+Binary file formats are loaded lazily using `memory mapping`_ and are compatible with the `dask distributed`_
+scheduler. This implementation uses an approach similar to that described in the dask documentation on
+`memory mapping`_ - see the :func:`~.utils.distributed.memmap_distributed` function for more information.
 
 
 Distributed Loading
 ===================
 
-The distributed loading is enabled when using the ``distributed`` parameter.  In many cases it
-is recommended to use the ``distributed`` parameter when loading data even when not using the
-`dask distributed`_ scheduler.  This implementation is often faster than the default implementation
-in dask and allows for better control of the memory usage.
+Not all formats are compatible with the `dask distributed`_ scheduler. See the last columns of the 
+:ref:`supported formats <supported-formats>` table to know which reader are supported.
 
-In almost all cases the :func:`rsciio.utils.distributed.memmap_distributed` function can be dropped in-place of the
+In almost all cases the :func:`~.utils.distributed.memmap_distributed` function can be dropped in-place of the
 :class:`numpy.memmap` function. It also now supports the ``positions`` parameter which is different from the equivalent
 numpy function.  The ``positions`` parameter is a numpy array of positions which maps some arbitrary scan positions
 to a grid.  This is useful for loading arbitrary scan positions from a file.  The ``positions`` parameter does require

--- a/rsciio/_docstrings.py
+++ b/rsciio/_docstrings.py
@@ -114,14 +114,6 @@ COMPRESSION_HDF5_NOTES_DOC = """It is possible to enable other compression filte
     """
 
 
-DISTRIBUTED_DOC = """distributed : bool, default=False
-        Whether to load the data using memory-mapping in a way that is
-        compatible with dask-distributed.  This can sometimes improve
-        performance when reading large files. And splitting the data
-        loading/processing over multiple workers.
-        """
-
-
 RETURNS_DOC = """Returns
     -------
 

--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -31,11 +31,13 @@ from rsciio._docstrings import (
     ENDIANESS_DOC,
     FILENAME_DOC,
     LAZY_DOC,
-    MMAP_DOC,
     NAVIGATION_SHAPE,
     RETURNS_DOC,
 )
-from rsciio.utils._deprecated import distributed_keyword_deprecation
+from rsciio.utils._deprecated import (
+    distributed_keyword_deprecation,
+    mmap_mode_keyword_deprecation,
+)
 from rsciio.utils.distributed import memmap_distributed
 from rsciio.utils.tools import sarray2dict
 
@@ -326,10 +328,10 @@ def read_de_metadata_file(filename, nav_shape=None, scan_pos_file=None):
 
 
 @distributed_keyword_deprecation
+@mmap_mode_keyword_deprecation
 def file_reader(
     filename,
     lazy=False,
-    mmap_mode=None,
     endianess="<",
     navigation_shape=None,
     chunks="auto",
@@ -343,7 +345,6 @@ def file_reader(
 
     Parameters
     ----------
-    %s
     %s
     %s
     %s
@@ -468,8 +469,6 @@ def file_reader(
         f.seek(1024 + std_header["NEXT"][0])
         fei_header = None
     NX, NY, NZ = std_header["NX"], std_header["NY"], std_header["NZ"]
-    if mmap_mode is None:
-        mmap_mode = "r" if lazy else "c"
     shape = (NX[0], NY[0], NZ[0])
     if navigation_shape is not None:
         shape = shape[:2] + navigation_shape
@@ -609,7 +608,6 @@ mapping = {
 file_reader.__doc__ %= (
     FILENAME_DOC,
     LAZY_DOC,
-    MMAP_DOC,
     ENDIANESS_DOC,
     NAVIGATION_SHAPE,
     CHUNKS_READ_DOC,

--- a/rsciio/tests/test_mrc.py
+++ b/rsciio/tests/test_mrc.py
@@ -81,6 +81,15 @@ def test_distributed_deprecation_warning(distributed):
         )
 
 
+def test_deprecated_mmap_mode():
+    with pytest.warns(VisibleDeprecationWarning):
+        file_reader(
+            str(TEST_DATA_DIR / "4DSTEMscan.mrc"),
+            navigation_shape=(8, 32),
+            mmap_mode="r",
+        )
+
+
 def test_mrc_chunks_equal():
     s = hs.load(
         TEST_DATA_DIR / "4DSTEMscan.mrc",

--- a/rsciio/tests/test_ripple.py
+++ b/rsciio/tests/test_ripple.py
@@ -6,6 +6,7 @@ import numpy.testing as npt
 import pytest
 
 from rsciio.ripple import _api as ripple
+from rsciio.utils.exceptions import VisibleDeprecationWarning
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 exspy = pytest.importorskip("exspy", reason="exspy not installed")
@@ -141,9 +142,8 @@ def _create_signal(shape, dim, dtype, metadata=None):
     return s
 
 
-@pytest.mark.parametrize("distributed", (True, False))
 @pytest.mark.parametrize("pdict", generate_parameters())
-def test_data(pdict, distributed, tmp_path):
+def test_data(pdict, tmp_path):
     dtype, shape, dim, metadata = (
         pdict["dtype"],
         pdict["shape"],
@@ -154,7 +154,7 @@ def test_data(pdict, distributed, tmp_path):
     filename = _get_filename(s, metadata)
     s.save(tmp_path / filename)
     s_just_saved = hs.load(tmp_path / filename)
-    s_ref = hs.load(TEST_DATA_PATH / filename, distributed=distributed)
+    s_ref = hs.load(TEST_DATA_PATH / filename)
     try:
         for stest in (s_just_saved, s_ref):
             npt.assert_array_equal(s.data, stest.data)
@@ -207,26 +207,44 @@ def test_data(pdict, distributed, tmp_path):
         gc.collect()
 
 
-@pytest.mark.parametrize("distributed", (True, False))
-def test_load_distributed_chunks(tmp_path, distributed):
+def test_load_chunks(tmp_path):
     s = _create_signal(shape=(20, 30, 40), dim=1, dtype="uint16")
     fname = tmp_path / "test_chunks.rpl"
     s.save(fname)
 
     chunks = (10, 15, 40)
-    s2 = hs.load(fname, lazy=True, distributed=distributed, chunks=chunks)
+    s2 = hs.load(fname, lazy=True, chunks=chunks)
     assert tuple([c[0] for c in s2.data.chunks]) == chunks
 
 
-def test_load_distributed_not_lazy(tmp_path):
+def test_load_not_lazy(tmp_path):
     s = _create_signal(shape=(20, 30, 40), dim=1, dtype="uint16")
     fname = tmp_path / "test_chunks.rpl"
     s.save(fname)
 
     chunks = (10, 15, 40)
-    s2 = hs.load(fname, lazy=False, distributed=True, chunks=chunks)
+    s2 = hs.load(fname, lazy=False, chunks=chunks)
     assert isinstance(s2.data, np.ndarray)
     np.testing.assert_allclose(s2.data, s.data)
+
+
+@pytest.mark.parametrize("distributed", [True, False])
+def test_deprecated_distributed(tmp_path, distributed):
+    s = _create_signal(shape=(20, 30, 40), dim=1, dtype="uint16")
+    fname = tmp_path / "test_deprecated_distributed.rpl"
+    s.save(fname)
+
+    with pytest.warns(VisibleDeprecationWarning):
+        _ = hs.load(fname, distributed=distributed)
+
+
+def test_deprecated_mmap_mode(tmp_path):
+    s = _create_signal(shape=(20, 30, 40), dim=1, dtype="uint16")
+    fname = tmp_path / "test_deprecated_mmap_mode.rpl"
+    s.save(fname)
+
+    with pytest.warns(VisibleDeprecationWarning):
+        _ = hs.load(fname, mmap_mode="r")
 
 
 def generate_files():

--- a/rsciio/utils/_deprecated.py
+++ b/rsciio/utils/_deprecated.py
@@ -162,3 +162,11 @@ def distributed_keyword_deprecation(func):
         "0.8.0",
         additional_msg=" Distributed memory mapping is now supported in the default implementation.",
     )(func)
+
+
+def mmap_mode_keyword_deprecation(func):
+    return deprecated_argument(
+        "mmap_mode",
+        "0.8.0",
+        additional_msg=" `mmap_mode` is deprecated because it is not used anymore.",
+    )(func)

--- a/upcoming_changes/404.enhancements.rst
+++ b/upcoming_changes/404.enhancements.rst
@@ -1,0 +1,1 @@
+Remove non-distributed memory mapping implementation in :ref:`rpl <ripple-format>` reader. Deprecate ``mmap_mode`` in :ref:`mrc <mrc-format>` reader since it is not used anymore with the distributed memory mapping implementation.


### PR DESCRIPTION
### Progress of the PR
- [x] Remove non-distributed memory mapping implementation in `rpl` reader,
- [x] deprecate `mmap_mode` in `mrc` reader since it is not used anymore with the distributed memory mapping implementation,
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


