### PR TITLE
Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,13 @@
 ### Requirements
-* Until `RosettaSciIO` has a contributor guide, you can read the [HyperSpy developer guide](https://hyperspy.org/hyperspy-doc/current/dev_guide/intro.html) to familiarise yourself with how to contribute.
-* Base your pull request on the correct branch (so far ``main`` branch)
-* Fill out the template; it helps the review process and it is useful to summarise the PR.
+* Be aware of relevant documentation:
+  * [Pull request documentation](https://hyperspy.org/rosettasciio/contributing.html#pull-requests)
+  * [Adding new file format](https://hyperspy.org/rosettasciio/contributing.html#defining-new-rosettasciio-plugins)
+  * [Adding and making test files](https://hyperspy.org/rosettasciio/contributing.html#making-test-data-files)
+  * RosettaSciIO follows standard practises in open-source code development. If you need more information, you can refer to the [HyperSpy developer guide](https://hyperspy.org/hyperspy-doc/current/dev_guide/intro.html) to familiarise yourself with how to contribute.
+* Base your pull request on the ``main`` branch.
+* Fill out the template; it helps the review process and it is useful to summarise the PR and its progress.
+* Ask for help in the thread of the pull request when you need.
+* Ask for review when you are ready.
 * This template can be updated during the progression of the PR to summarise its status. 
 
 *You can delete this section after you read it.*

--- a/upcoming_changes/413.doc.rst
+++ b/upcoming_changes/413.doc.rst
@@ -1,0 +1,1 @@
+Improve pull request template, add relevant links to the contributor guide.


### PR DESCRIPTION
When looking #412, I noticed, that the pull request template is out of date.

### Progress of the PR
- [x] Add links to relevant part of the contributor guide,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

