### PR TITLE
Add tolerance when comparing scale in saving image with scalebar

### DIFF
--- a/rsciio/image/_api.py
+++ b/rsciio/image/_api.py
@@ -17,6 +17,7 @@
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import logging
+import math
 import os
 from collections.abc import Iterable
 
@@ -167,7 +168,15 @@ def file_writer(
         # Sanity check of the axes
         # This plugin doesn't support non-uniform axes, we don't need to check
         # if the axes have a scale attribute
-        if axes[0]["scale"] != axes[1]["scale"] or axes[0]["units"] != axes[1]["units"]:
+        if (
+            axes[0]["units"] != axes[1]["units"]
+            or
+            # relative difference normalized to the size of the second axis
+            # the more pixels is in the second axis, the higher the tolerance need to be
+            not math.isclose(
+                axes[0]["scale"], axes[1]["scale"], rel_tol=0.1 / axes[1]["size"]
+            )
+        ):
             raise ValueError(
                 "Scale and units must be the same for each axes "
                 "to export images with a scale bar."

--- a/rsciio/tests/test_image.py
+++ b/rsciio/tests/test_image.py
@@ -178,14 +178,38 @@ def test_export_scalebar_different_scale_units(tmp_path):
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     s.axes_manager[0].scale = 2
 
-    filename = tmp_path / "test_export_size.jpg"
+    filename = tmp_path / "test_export_scalebar_different_scale_units0.jpg"
     with pytest.raises(ValueError):
         s.save(filename, scalebar=True)
 
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     s.axes_manager[0].units = "nm"
 
-    filename = tmp_path / "test_export_size.jpg"
+    filename = tmp_path / "test_export_scalebar_different_scale_units1.jpg"
+    with pytest.raises(ValueError):
+        s.save(filename, scalebar=True)
+
+
+@pytest.mark.parametrize(
+    "pixels_below_above", [(10, 0.991, 0.989), (1000, 0.99991, 0.99989)]
+)
+def test_export_scalebar_scale_close_enough(tmp_path, pixels_below_above):
+    hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+    pytest.importorskip("matplotlib_scalebar")
+    pixels, below, above = pixels_below_above
+    s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
+    # scale is not exactly equal, but close enough
+    s.axes_manager[0].scale = below
+    s.axes_manager[1].scale = 1.0
+    s.axes_manager.signal_axes.set(units="nm")
+
+    filename = tmp_path / "test_export_scalebar_scale_close_enough0.jpg"
+    s.save(filename, scalebar=True)
+    _ = hs.load(filename)
+
+    # scale is not close enough above the limit of the relative error
+    s.axes_manager[0].scale = above
+    filename = tmp_path / "test_export_scalebar_scale_close_enough1.jpg"
     with pytest.raises(ValueError):
         s.save(filename, scalebar=True)
 

--- a/upcoming_changes/414.doc.rst
+++ b/upcoming_changes/414.doc.rst
@@ -1,0 +1,1 @@
+Allow 1% difference in scale of the signal axis when saving an image with the image plugin.


### PR DESCRIPTION
### Progress of the PR
- [x] allow 1% difference in scale when saving an image with the image plugin,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


