### PR TITLE
Use memory mapping in digitalmicrograph reader

### DIFF
--- a/rsciio/blockfile/_api.py
+++ b/rsciio/blockfile/_api.py
@@ -226,6 +226,7 @@ def file_reader(filename, lazy=False, chunks="auto", endianess="<"):
     %s
     %s
     %s
+
     %s
     """
 

--- a/rsciio/digitalmicrograph/_api.py
+++ b/rsciio/digitalmicrograph/_api.py
@@ -30,7 +30,8 @@ import numpy as np
 from box import Box
 
 import rsciio.utils.readfile as iou
-from rsciio._docstrings import FILENAME_DOC, LAZY_DOC, RETURNS_DOC
+from rsciio._docstrings import CHUNKS_READ_DOC, FILENAME_DOC, LAZY_DOC, RETURNS_DOC
+from rsciio.utils.distributed import memmap_distributed
 from rsciio.utils.exceptions import DM3DataTypeError, DM3TagIDError, DM3TagTypeError
 from rsciio.utils.tools import ensure_unicode
 
@@ -612,20 +613,6 @@ class ImageObject(object):
         else:
             return ""
 
-    def _get_data_array(self):
-        need_to_close = False
-        if self.file.closed:
-            self.file = open(self.filename, "rb")
-            need_to_close = True
-        self.file.seek(self.imdict.ImageData.Data.offset)
-        count = self.imdict.ImageData.Data.size
-        if self.imdict.ImageData.DataType in (27, 28):  # Packed complex
-            count = int(count / 2)
-        data = np.fromfile(self.file, dtype=self.dtype, count=count)
-        if need_to_close:
-            self.file.close()
-        return data
-
     @property
     def size(self):
         if self.imdict.ImageData.DataType in (27, 28):  # Packed complex
@@ -638,10 +625,39 @@ class ImageObject(object):
         else:
             return self.imdict.ImageData.Data.size
 
-    def get_data(self):
+    def get_data(self, lazy, chunks="auto"):
         if isinstance(self.imdict.ImageData.Data, np.ndarray):
             return self.imdict.ImageData.Data
-        data = self._get_data_array()
+
+        if lazy:
+            shape = list(self.shape)
+            if self.imdict.ImageData.DataType in (8, 23):
+                raise ValueError(
+                    "Lazy loading of ABGR images is not supported. "
+                    "Please load the image without lazy=True."
+                )
+            if self.imdict.ImageData.DataType in (27, 28):  # Packed complex
+                shape[-1] = int(shape[-1] / 2 + 1)
+            data = memmap_distributed(
+                self.filename,
+                offset=self.imdict.ImageData.Data.offset,
+                shape=tuple(shape),
+                dtype=np.dtype(self.dtype),
+                chunks=chunks,
+            )
+        else:
+            need_to_close = False
+            if self.file.closed:
+                self.file = open(self.filename, "rb")
+                need_to_close = True
+            self.file.seek(self.imdict.ImageData.Data.offset)
+            count = self.imdict.ImageData.Data.size
+            if self.imdict.ImageData.DataType in (27, 28):  # Packed complex
+                count = int(count / 2)
+            data = np.fromfile(self.file, dtype=self.dtype, count=count)
+            if need_to_close:
+                self.file.close()
+
         if self.imdict.ImageData.DataType in (27, 28):  # New packed complex
             return self.unpack_new_packed_complex(data)
         elif self.imdict.ImageData.DataType == 5:  # Old packed compled
@@ -651,11 +667,14 @@ class ImageObject(object):
             data = data[["R", "G", "B", "A"]].astype(
                 [("R", "u1"), ("G", "u1"), ("B", "u1"), ("A", "u1")]
             )
-        return data.reshape(self.shape, order=self.order)
+        if not lazy:
+            data = data.reshape(self.shape, order=self.order)
+
+        return data
 
     def unpack_new_packed_complex(self, data):
         packed_shape = (self.shape[0], int(self.shape[1] / 2 + 1))
-        data = data.reshape(packed_shape, order=self.order)
+        data = data.reshape(packed_shape)
         return np.hstack((data[:, ::-1], np.conjugate(data[:, 1:-1])))
 
     def unpack_packed_complex(self, tmpdata):
@@ -706,7 +725,7 @@ class ImageObject(object):
         realpart = tmpdata[start:stop:step]
         imagpart = tmpdata[start + 1 : stop + 1 : step]
         complexdata = realpart + imagpart * 1j
-        data[N + 1 : 2 * N, N : 2 * N] = complexdata.reshape(N - 1, N, order=self.order)
+        data[N + 1 : 2 * N, N : 2 * N] = complexdata.reshape(N - 1, N)
 
         # fill in the empty pixels: A(i)(j) = A(2N-i)(2N-j)*
         # 1st row, top left quarter, except 1st element
@@ -1249,7 +1268,7 @@ class ImageObject(object):
         return mapping
 
 
-def file_reader(filename, lazy=False, order=None, optimize=True):
+def file_reader(filename, lazy=False, order=None, optimize=True, chunks="auto"):
     """
     Read a DM3/4 file and loads the data into the appropriate class.
 
@@ -1270,6 +1289,7 @@ def file_reader(filename, lazy=False, order=None, optimize=True):
         during data loading, which for large data sets can lead to a slow down on
         machines with limited memory. When operating on lazy signals, if ``True``,
         the chunks are optimised for the new axes configuration.
+    %s
 
     %s
     """
@@ -1286,6 +1306,7 @@ def file_reader(filename, lazy=False, order=None, optimize=True):
         dm.tags_dict["ImageList"] = {}
 
         for image in images:
+            image.filename = filename
             dm.tags_dict["ImageList"]["TagGroup0"] = image.imdict.to_dict()
             axes = image.get_axes_dict()
             mp = image.get_metadata()
@@ -1294,15 +1315,7 @@ def file_reader(filename, lazy=False, order=None, optimize=True):
             if image.to_spectrum is True:
                 post_process.append(lambda s: s.to_signal1D(optimize=optimize))
             post_process.append(lambda s: s.squeeze())
-            if lazy:
-                image.filename = filename
-                import dask.delayed as dd
-                from dask.array import from_delayed
-
-                val = dd(image.get_data, pure=True)()
-                data = from_delayed(val, shape=image.shape, dtype=image.dtype)
-            else:
-                data = image.get_data()
+            data = image.get_data(lazy, chunks)
             # in the event there are multiple signals contained within this
             # DM file, it is important to make a "deepcopy" of the metadata
             # and original_metadata, since they are changed in each iteration
@@ -1323,4 +1336,4 @@ def file_reader(filename, lazy=False, order=None, optimize=True):
     return imd
 
 
-file_reader.__doc__ %= (FILENAME_DOC, LAZY_DOC, RETURNS_DOC)
+file_reader.__doc__ %= (FILENAME_DOC, LAZY_DOC, CHUNKS_READ_DOC, RETURNS_DOC)

--- a/rsciio/tests/test_digitalmicrograph.py
+++ b/rsciio/tests/test_digitalmicrograph.py
@@ -627,6 +627,7 @@ def generate_parameters():
                     "filename": filename,
                     "subfolder": subfolder,
                     "key": key,
+                    "dim": dim,
                 }
             )
         for key in dm4_data_types.keys():
@@ -637,6 +638,7 @@ def generate_parameters():
                     "filename": filename,
                     "subfolder": subfolder,
                     "key": key,
+                    "dim": dim,
                 }
             )
     return parameters
@@ -646,6 +648,16 @@ def generate_parameters():
 @pytest.mark.parametrize("pdict", generate_parameters())
 @pytest.mark.parametrize("lazy", (True, False))
 def test_data_and_axes(pdict, lazy):
+    if lazy:
+        if pdict["dim"] == 1:
+            # 1D data cannot be lazy loaded
+            # memmap_distributed currently does not support 1D data
+            pytest.skip("1D data cannot be lazy loaded")
+        if pdict["key"] in (8, 23):  # RGBA
+            with pytest.raises(ValueError):
+                # RGBA data cannot be lazy loaded
+                hs.load(pdict["filename"], lazy=lazy)
+            pytest.skip("RGBA data cannot be lazy loaded")
     s = hs.load(pdict["filename"], lazy=lazy)
     if lazy:
         s.compute(close_file=True)
@@ -676,6 +688,18 @@ def test_data_and_axes(pdict, lazy):
         err_msg=f"content {subfolder} type {key}: "
         f"\n{str(s.data)} not equal to \n{str(dat)}",
     )
+
+
+def test_compare_complex_data_lazily():
+    # Check that complex data is read correctly when lazy loaded
+    # unpacking is the same as for non-lazy data
+    s = hs.load(DM_2D_PATH / "test_fft_packed_complex8.dm4", lazy=False)
+    s_lazy = hs.load(DM_2D_PATH / "test_fft_packed_complex8.dm4", lazy=True)
+    s_lazy.compute(close_file=True)
+
+    assert s.data.dtype == np.complex64
+    assert s_lazy.data.dtype == np.complex64
+    np.testing.assert_allclose(s.data, s_lazy.data)
 
 
 def test_axes_bug_for_image():


### PR DESCRIPTION
The lazy implementation may have worked fine in the past with older version of dask but it doesn't anymore!

### Progress of the PR
- [x] Use memory mapping in digitalmicrograph reader,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [ ] ready for review.


