### PR TITLE
Use `file_format` and use new FileIO hyperspy metadata

### DIFF
--- a/doc/file_specification/index.rst
+++ b/doc/file_specification/index.rst
@@ -34,7 +34,7 @@ MRC (CCP-EM)
 
 The :ref:`MRC <mrc-format>` file format is a standard open file format for electron microscopy data and is
 defined by  `Cheng et al <https://doi.org/10.1016/j.jsb.2015.04.002>`_. The file format is described in
-detail following the link as well:  `MRC2014 <https://www.ccpem.ac.uk/mrc_format/mrc2014.php>`_.
+detail following the link as well:  `MRC2014 <https://www.ccpem.ac.uk/mrc-format>`_.
 
 Additionally Direct Electron saves a couple of files along with the ``.mrc`` file. In general, the file naming
 scheme is CurrentDate_MovieNumber_suffix_movie.mrc with the metadata file named CurrentDate_MovieNumber_suffix_info.txt.

--- a/doc/supported_formats/mrcz.rst
+++ b/doc/supported_formats/mrcz.rst
@@ -8,7 +8,7 @@ MRCZ format
    required.
 
 The ``mrcz`` format is an extension of the CCP-EM MRC2014 file format.
-`CCP-EM MRC2014 <https://www.ccpem.ac.uk/mrc_format/mrc2014.php>`_ file format.
+`CCP-EM MRC2014 <https://www.ccpem.ac.uk/mrc-format>`_ file format.
 It uses the `blosc` meta-compression library to bitshuffle and compress files in
 a blocked, multi-threaded environment. The supported data types are ``float32``,
 ``int8``, ``uint16``, ``int16`` and ``complex64``.

--- a/rsciio/emd/_api.py
+++ b/rsciio/emd/_api.py
@@ -25,6 +25,7 @@
 
 import json
 import logging
+from pathlib import Path
 
 import h5py
 
@@ -94,6 +95,9 @@ def is_EMD_Velox(file):
             if v_dict["format"] in ["Velox", "DevelopersKit"]:
                 return True
         return False
+
+    if isinstance(file, Path):
+        file = str(file)
 
     if isinstance(file, str):
         with h5py.File(file, "r") as f:
@@ -173,6 +177,9 @@ def file_reader(
     ModuleNotFoundError
         When reading spectrum image from Velox EMD file and the ``sparse`` library is missing.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
+
     file = h5py.File(filename, "r")
     dictionaries = []
     try:
@@ -230,6 +237,8 @@ def file_writer(filename, signal, chunks=None, **kwds):
         Dictionary containing metadata, which will be written as attribute
         of the root group.
     """
+    if isinstance(filename, Path):
+        filename = str(filename)
     from ._emd_ncem import EMD_NCEM
 
     EMD_NCEM().write_file(filename, signal, chunks=chunks, **kwds)

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -212,7 +212,10 @@ def file_writer(
     folder = signal["tmp_parameters"].get("original_folder", "")
     fname = signal["tmp_parameters"].get("original_filename", "")
     ext = signal["tmp_parameters"].get("original_extension", "")
-    original_path = Path(folder, f"{fname}.{ext}")
+    if ext and not ext.startswith("."):
+        # add a dot if not present
+        ext = f".{ext}"
+    original_path = Path(folder, f"{fname}{ext}")
 
     f = None
     if signal["attributes"]["_lazy"] and Path(filename).absolute() == original_path:

--- a/rsciio/tests/test_delmic.py
+++ b/rsciio/tests/test_delmic.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 pytest.importorskip("h5py", reason="h5py not installed")
@@ -9,6 +10,10 @@ pytest.importorskip("h5py", reason="h5py not installed")
 testfile_dir = (Path(__file__).parent / "data" / "delmic").resolve()
 testfile_hyperspectral_path = (testfile_dir / "test_hyperspectral.h5").resolve()
 
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "Delmic"}
 
 ref = np.array(
     [
@@ -529,7 +534,7 @@ ref = np.array(
 
 
 def test_read():
-    s = hs.load(testfile_hyperspectral_path, reader="Delmic")
+    s = hs.load(testfile_hyperspectral_path, **hs_load_kwargs)
 
     np.testing.assert_allclose(s.axes_manager[0].scale, 0.00010759749808557962)
     np.testing.assert_allclose(s.axes_manager[0].offset, 0)

--- a/rsciio/tests/test_digitalmicrograph.py
+++ b/rsciio/tests/test_digitalmicrograph.py
@@ -22,7 +22,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
+import rsciio
 from rsciio.digitalmicrograph._api import (
     DigitalMicrographReader,
     ImageObject,
@@ -533,8 +535,12 @@ def test_multi_signal():
             "FileIO": {
                 "0": {
                     "operation": "load",
+                    "folder": str(DM_2D_PATH),
+                    "filename": fname.stem,
+                    "extension": ".dm3",
                     "hyperspy_version": hs.__version__,
                     "io_plugin": "rsciio.digitalmicrograph",
+                    "rosettasciio_version": rsciio.__version__,
                 }
             },
         },
@@ -580,8 +586,12 @@ def test_multi_signal():
             "FileIO": {
                 "0": {
                     "operation": "load",
+                    "folder": str(DM_2D_PATH),
+                    "filename": fname.stem,
+                    "extension": ".dm3",
                     "hyperspy_version": hs.__version__,
                     "io_plugin": "rsciio.digitalmicrograph",
+                    "rosettasciio_version": rsciio.__version__,
                 }
             },
         },
@@ -594,8 +604,14 @@ def test_multi_signal():
         },
     }
     # remove timestamps from metadata since these are runtime dependent
-    del s1.metadata.General.FileIO.Number_0.timestamp
-    del s2.metadata.General.FileIO.Number_0.timestamp
+    del s1.metadata.General.FileIO[0].timestamp
+    del s2.metadata.General.FileIO[0].timestamp
+    for md in [s1_md_truth, s2_md_truth]:
+        if Version(hs.__version__) < Version("2.4.0.dev64"):
+            del md["General"]["FileIO"]["0"]["folder"]
+            del md["General"]["FileIO"]["0"]["filename"]
+            del md["General"]["FileIO"]["0"]["extension"]
+            del md["General"]["FileIO"]["0"]["rosettasciio_version"]
 
     # make sure the metadata dictionaries are as we expect
     assert s1.metadata.as_dictionary() == s1_md_truth

--- a/rsciio/tests/test_emd_velox.py
+++ b/rsciio/tests/test_emd_velox.py
@@ -31,7 +31,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 from dateutil import tz
+from packaging.version import Version
 
+import rsciio
 from rsciio.utils.tests import assert_deep_almost_equal
 from rsciio.utils.tools import dummy_context_manager
 
@@ -94,8 +96,12 @@ class TestFeiEMD:
                 "FileIO": {
                     "0": {
                         "operation": "load",
+                        "folder": str(self.fei_files_path),
+                        "filename": "fei_emd_image",
+                        "extension": ".emd",
                         "hyperspy_version": hs.__version__,
                         "io_plugin": "rsciio.emd",
+                        "rosettasciio_version": rsciio.__version__,
                     }
                 },
             },
@@ -119,7 +125,13 @@ class TestFeiEMD:
 
         signal = hs.load(self.fei_files_path / "fei_emd_image.emd", lazy=lazy)
         # delete timestamp from metadata since it's runtime dependent
-        del signal.metadata.General.FileIO.Number_0.timestamp
+        del signal.metadata.General.FileIO[0].timestamp
+        if Version(hs.__version__) < Version("2.4.0.dev64"):
+            del md["General"]["FileIO"]["0"]["folder"]
+            del md["General"]["FileIO"]["0"]["filename"]
+            del md["General"]["FileIO"]["0"]["extension"]
+            del md["General"]["FileIO"]["0"]["rosettasciio_version"]
+
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)

--- a/rsciio/tests/test_empad.py
+++ b/rsciio/tests/test_empad.py
@@ -35,6 +35,11 @@ DATA_DIR = Path(__file__).parent / "data" / "empad"
 FILENAME_STACK_RAW = DATA_DIR / "series_x10.raw"
 FILENAME_MAP_RAW = DATA_DIR / "scan_x4_y4.raw"
 
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "EMPAD"}
+
 
 def _create_raw_data(filename, shape):
     size = np.prod(shape)
@@ -61,7 +66,7 @@ def teardown_module(module):
 @pytest.mark.parametrize("lazy", (False, True))
 def test_read_stack(lazy):
     # xml file version 0.51 211118
-    s = hs.load(DATA_DIR / "stack_images.xml", lazy=lazy, reader="EMPAD")
+    s = hs.load(DATA_DIR / "stack_images.xml", lazy=lazy, **hs_load_kwargs)
     assert s.data.dtype == "float32"
     ref_data = np.arange(166400).reshape((10, 130, 128))[..., :128, :]
     np.testing.assert_allclose(s.data, ref_data.astype("float32"))
@@ -92,7 +97,7 @@ def test_read_stack(lazy):
 @pytest.mark.parametrize("lazy", (False, True))
 def test_read_map(lazy):
     # xml file version 0.51 211118
-    s = hs.load(DATA_DIR / "map4x4.xml", lazy=lazy, reader="EMPAD")
+    s = hs.load(DATA_DIR / "map4x4.xml", lazy=lazy, **hs_load_kwargs)
     assert s.data.dtype == "float32"
     ref_data = np.arange(266240).reshape((4, 4, 130, 128))[..., :128, :]
     np.testing.assert_allclose(s.data, ref_data.astype("float32"))

--- a/rsciio/tests/test_hamamatsu.py
+++ b/rsciio/tests/test_hamamatsu.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
@@ -33,11 +34,16 @@ testfile_photon_count_path = (testfile_dir / "photon_counting.img").resolve()
 testfile_shading_path = (testfile_dir / "shading_file.img").resolve()
 testfile_xaxisother_path = (testfile_dir / "xaxis_other.img").resolve()
 
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "Hamamatsu"}
+
 
 class TestOperate:
     @classmethod
     def setup_class(cls):
-        cls.s = hs.load(testfile_operate_mode_path, reader="Hamamatsu")
+        cls.s = hs.load(testfile_operate_mode_path, **hs_load_kwargs)
 
     @classmethod
     def teardown_class(cls):
@@ -329,7 +335,7 @@ class TestOperate:
 class TestFocus:
     @classmethod
     def setup_class(cls):
-        cls.s_focus = hs.load(testfile_focus_mode_path, reader="Hamamatsu")
+        cls.s_focus = hs.load(testfile_focus_mode_path, **hs_load_kwargs)
 
     @classmethod
     def teardown_class(cls):
@@ -363,7 +369,7 @@ class TestFocus:
 class TestPhotonCount:
     @classmethod
     def setup_class(cls):
-        cls.s = hs.load(testfile_photon_count_path, reader="Hamamatsu")
+        cls.s = hs.load(testfile_photon_count_path, **hs_load_kwargs)
 
     @classmethod
     def teardown_class(cls):
@@ -390,7 +396,7 @@ class TestPhotonCount:
 class TestShading:
     @classmethod
     def setup_class(cls):
-        cls.s = hs.load(testfile_shading_path, reader="Hamamatsu")
+        cls.s = hs.load(testfile_shading_path, **hs_load_kwargs)
 
     @classmethod
     def teardown_class(cls):
@@ -410,7 +416,7 @@ class TestShading:
 class TestOther:
     @classmethod
     def setup_class(cls):
-        cls.s = hs.load(testfile_xaxisother_path, reader="Hamamatsu")
+        cls.s = hs.load(testfile_xaxisother_path, **hs_load_kwargs)
 
     @classmethod
     def teardown_class(cls):

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -54,6 +54,11 @@ if importlib.util.find_spec("zarr") is None:
 else:
     zspy_marker = pytest.mark.parametrize("file", ["test.hspy", "test.zspy"])
 
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "HSPY"}
+
 
 data = np.array(
     [
@@ -146,7 +151,7 @@ class Example1:
 
 class TestExample1_12(Example1):
     def setup_method(self, method):
-        self.s = hs.load(TEST_DATA_PATH / "example1_v1.2.hdf5", reader="HSPY")
+        self.s = hs.load(TEST_DATA_PATH / "example1_v1.2.hdf5", **hs_load_kwargs)
 
     def test_date(self):
         assert self.s.metadata.General.date == "1991-10-01"
@@ -157,17 +162,17 @@ class TestExample1_12(Example1):
 
 class TestExample1_10(Example1):
     def setup_method(self, method):
-        self.s = hs.load(TEST_DATA_PATH / "example1_v1.0.hdf5", reader="HSPY")
+        self.s = hs.load(TEST_DATA_PATH / "example1_v1.0.hdf5", **hs_load_kwargs)
 
 
 class TestExample1_11(Example1):
     def setup_method(self, method):
-        self.s = hs.load(TEST_DATA_PATH / "example1_v1.1.hdf5", reader="HSPY")
+        self.s = hs.load(TEST_DATA_PATH / "example1_v1.1.hdf5", **hs_load_kwargs)
 
 
 class TestLoadingNewSavedMetadata:
     def setup_method(self, method):
-        self.s = hs.load(TEST_DATA_PATH / "with_lists_etc.hdf5", reader="HSPY")
+        self.s = hs.load(TEST_DATA_PATH / "with_lists_etc.hdf5", **hs_load_kwargs)
 
     def test_signal_inside(self):
         np.testing.assert_array_almost_equal(
@@ -424,7 +429,7 @@ class TestSavingMetadataContainers:
 
 
 def test_none_metadata():
-    s = hs.load(TEST_DATA_PATH / "none_metadata.hdf5", reader="HSPY")
+    s = hs.load(TEST_DATA_PATH / "none_metadata.hdf5", **hs_load_kwargs)
     assert s.metadata.should_be_None is None
 
 
@@ -432,7 +437,7 @@ def test_rgba16():
     print(TEST_DATA_PATH)  # noqa: T201
     with pytest.warns(VisibleDeprecationWarning):
         #  The binned attribute has been moved from metadata.Signal
-        s = hs.load(TEST_DATA_PATH / "test_rgba16.hdf5", reader="HSPY")
+        s = hs.load(TEST_DATA_PATH / "test_rgba16.hdf5", **hs_load_kwargs)
     data = np.load(TEST_NPZ_DATA_PATH / "test_rgba16.npz")["a"]
     assert (s.data == data).all()
 
@@ -501,7 +506,7 @@ def test_lazy_loading(tmp_path):
     s.create_dataset("data", shape=shape, dtype="float64", chunks=True)
     f.close()
 
-    s = hs.load(fname, lazy=True, reader="HSPY")
+    s = hs.load(fname, lazy=True, **hs_load_kwargs)
     assert shape == s.data.shape
     assert isinstance(s.data, da.Array)
     assert s._lazy
@@ -789,7 +794,7 @@ class TestPermanentMarkersIO:
         # where one of them has an unknown marker type and raise an error
         fname = TEST_DATA_PATH / "test_marker_bad_marker_type.hdf5"
         with pytest.raises(AttributeError):
-            _ = hs.load(fname, reader="HSPY")
+            _ = hs.load(fname, **hs_load_kwargs)
 
     def test_load_missing_y2_value(self):
         # test_marker_point_y2_data_deleted.hdf5 has 5 markers,
@@ -799,7 +804,7 @@ class TestPermanentMarkersIO:
         fname = TEST_DATA_PATH / "test_marker_point_y2_data_deleted.hdf5"
         with pytest.warns(VisibleDeprecationWarning):
             # The binned attribute has been moved from metadata.Signal
-            s = hs.load(fname, reader="HSPY")
+            s = hs.load(fname, **hs_load_kwargs)
         assert len(s.metadata.Markers) == 5
 
     def test_save_variable_length_markers(self, tmp_path):

--- a/rsciio/tests/test_jeol.py
+++ b/rsciio/tests/test_jeol.py
@@ -80,12 +80,17 @@ TEST_FILES2 = [
     "Dummy-Data_0000024.APB",
 ]
 
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "jeol"}
+
 
 def test_load_project():
     pytest.importorskip("numba")
     # test load all elements of the project rawdata.ASW
     filename = TESTS_FILE_PATH / TEST_FILES[0]
-    s = hs.load(filename, reader="JEOL")
+    s = hs.load(filename, **hs_load_kwargs)
     # first file is always a 16bit image of the work area
     assert s[0].data.dtype == np.uint8
     assert s[0].data.shape == (512, 512)
@@ -121,12 +126,12 @@ def test_load_project():
 
     # check scale (image)
     filename = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[1]
-    s1 = hs.load(filename, reader="JEOL")
+    s1 = hs.load(filename, **hs_load_kwargs)
     np.testing.assert_allclose(s[0].axes_manager[0].scale, s1.axes_manager[0].scale)
     assert s[0].axes_manager[0].units == s1.axes_manager[0].units
     # check scale (pts)
     filename = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[7]
-    s2 = hs.load(filename, reader="JEOL")
+    s2 = hs.load(filename, **hs_load_kwargs)
     np.testing.assert_allclose(s[6].axes_manager[0].scale, s2.axes_manager[0].scale)
     assert s[6].axes_manager[0].units == s2.axes_manager[0].units
 
@@ -134,7 +139,7 @@ def test_load_project():
 def test_load_image():
     # test load work area haadf image
     filename = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[1]
-    s = hs.load(filename, reader="JEOL")
+    s = hs.load(filename, **hs_load_kwargs)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (512, 512)
     assert s.axes_manager.signal_dimension == 2
@@ -151,7 +156,7 @@ def test_load_datacube(SI_dtype):
     pytest.importorskip("numba")
     # test load eds datacube
     filename = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[7]
-    s = hs.load(filename, SI_dtype=SI_dtype, cutoff_at_kV=5, reader="JEOL")
+    s = hs.load(filename, SI_dtype=SI_dtype, cutoff_at_kV=5, **hs_load_kwargs)
     assert s.data.dtype == SI_dtype
     assert s.data.shape == (512, 512, 596)
     assert s.axes_manager.signal_dimension == 1
@@ -171,20 +176,20 @@ def test_load_datacube(SI_dtype):
 def test_load_datacube_rebin_energy():
     pytest.importorskip("numba")
     filename = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[7]
-    s = hs.load(filename, cutoff_at_kV=0.1, reader="JEOL")
+    s = hs.load(filename, cutoff_at_kV=0.1, **hs_load_kwargs)
     s_sum = s.sum()
 
     ref_data = hs.signals.Signal1D(np.array([3, 23, 77, 200, 487, 984, 1599, 2391]))
     np.testing.assert_allclose(s_sum.data[88:96], ref_data.data)
 
     rebin_energy = 8
-    s2 = hs.load(filename, rebin_energy=rebin_energy, reader="JEOL")
+    s2 = hs.load(filename, rebin_energy=rebin_energy, **hs_load_kwargs)
     s2_sum = s2.sum()
 
     np.testing.assert_allclose(s2_sum.data[11:12], ref_data.data.sum())
 
     with pytest.raises(ValueError, match="must be a divisor"):
-        _ = hs.load(filename, rebin_energy=10, reader="JEOL")
+        _ = hs.load(filename, rebin_energy=10, **hs_load_kwargs)
 
 
 def test_load_datacube_cutoff_at_kV():
@@ -192,8 +197,8 @@ def test_load_datacube_cutoff_at_kV():
     gc.collect()
     cutoff_at_kV = 10.0
     filename = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[7]
-    s = hs.load(filename, cutoff_at_kV=None, reader="JEOL")
-    s2 = hs.load(filename, cutoff_at_kV=cutoff_at_kV, reader="JEOL")
+    s = hs.load(filename, cutoff_at_kV=None, **hs_load_kwargs)
+    s2 = hs.load(filename, cutoff_at_kV=cutoff_at_kV, **hs_load_kwargs)
 
     assert s2.axes_manager[-1].size == 1096
     np.testing.assert_allclose(s2.axes_manager[2].scale, 0.00999866)
@@ -206,8 +211,8 @@ def test_load_datacube_downsample():
     pytest.importorskip("numba")
     downsample = 8
     filename = TESTS_FILE_PATH / TEST_FILES[0]
-    s = hs.load(filename, downsample=1, reader="JEOL")[-1]
-    s2 = hs.load(filename, downsample=downsample, reader="JEOL")[-1]
+    s = hs.load(filename, downsample=1, **hs_load_kwargs)[-1]
+    s2 = hs.load(filename, downsample=downsample, **hs_load_kwargs)[-1]
 
     s_sum = s.sum(-1).rebin(scale=(downsample, downsample))
     s2_sum = s2.sum(-1)
@@ -224,34 +229,34 @@ def test_load_datacube_downsample():
     np.testing.assert_allclose(s_sum.data, s2_sum.data)
 
     with pytest.raises(ValueError, match="must be a divisor"):
-        _ = hs.load(filename, downsample=10, reader="JEOL")[-1]
+        _ = hs.load(filename, downsample=10, **hs_load_kwargs)[-1]
 
     with pytest.raises(
         ValueError,
         match="`downsample` can't be an iterable of length different from 2.",
     ):
-        _ = hs.load(filename, downsample=[2, 2, 2], reader="JEOL")[-1]
+        _ = hs.load(filename, downsample=[2, 2, 2], **hs_load_kwargs)[-1]
 
     downsample = [8, 16]
-    s = hs.load(filename, downsample=downsample, reader="JEOL")[-1]
+    s = hs.load(filename, downsample=downsample, **hs_load_kwargs)[-1]
     assert s.axes_manager["x"].size * downsample[0] == 512
     assert s.axes_manager["y"].size * downsample[1] == 512
 
     with pytest.raises(ValueError, match="must be a divisor"):
-        _ = hs.load(filename, downsample=[256, 100], reader="JEOL")[-1]
+        _ = hs.load(filename, downsample=[256, 100], **hs_load_kwargs)[-1]
 
     with pytest.raises(ValueError, match="must be a divisor"):
-        _ = hs.load(filename, downsample=[100, 256], reader="JEOL")[-1]
+        _ = hs.load(filename, downsample=[100, 256], **hs_load_kwargs)[-1]
 
 
 def test_load_datacube_frames():
     pytest.importorskip("numba")
     rebin_energy = 2048
     filename = TESTS_FILE_PATH / "Sample" / "00_View000" / TEST_FILES[7]
-    s = hs.load(filename, sum_frames=True, rebin_energy=rebin_energy, reader="JEOL")
+    s = hs.load(filename, sum_frames=True, rebin_energy=rebin_energy, **hs_load_kwargs)
     assert s.data.shape == (512, 512, 2)
     s_frame = hs.load(
-        filename, sum_frames=False, rebin_energy=rebin_energy, reader="JEOL"
+        filename, sum_frames=False, rebin_energy=rebin_energy, **hs_load_kwargs
     )
     assert s_frame.data.shape == (14, 512, 512, 2)
     np.testing.assert_allclose(s_frame.sum(axis="Frame").data, s.data)
@@ -285,7 +290,7 @@ def test_load_eds_file(filename_as_string):
     filename = TESTS_FILE_PATH / "met03.EDS"
     if filename_as_string:
         filename = str(filename)
-    s = hs.load(filename, reader="JEOL")
+    s = hs.load(filename, **hs_load_kwargs)
     assert s.metadata.Signal.signal_type == "EDS_TEM"
     assert isinstance(s, hs.signals.Signal1D)
     assert s.data.shape == (2048,)
@@ -345,7 +350,7 @@ def test_shift_jis_encoding():
     with open(filename, "br"):
         pass
     try:
-        _ = hs.load(filename, reader="JEOL")
+        _ = hs.load(filename, **hs_load_kwargs)
     except FileNotFoundError:
         # we don't have the other files required to open the data
         pass
@@ -375,7 +380,7 @@ def test_number_of_frames():
             downsample=[32, 32],
             rebin_energy=512,
             SI_dtype=np.int32,
-            reader="JEOL",
+            **hs_load_kwargs,
         )
         assert data.axes_manager["Frame"].size == frames
 
@@ -387,7 +392,7 @@ def test_number_of_frames():
             downsample=[32, 32],
             rebin_energy=512,
             SI_dtype=np.int32,
-            reader="JEOL",
+            **hs_load_kwargs,
         )
         assert data.axes_manager["Frame"].size == valid
 
@@ -404,7 +409,7 @@ def test_em_image_in_pts():
         read_em_image=False,
         only_valid_data=False,
         cutoff_at_kV=1,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     assert len(s) == 7
 
@@ -413,7 +418,7 @@ def test_em_image_in_pts():
         read_em_image=True,
         only_valid_data=False,
         cutoff_at_kV=1,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     assert len(s) == 7
 
@@ -423,7 +428,7 @@ def test_em_image_in_pts():
         read_em_image=False,
         only_valid_data=False,
         cutoff_at_kV=1,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     assert len(s) == 22
     s = hs.load(
@@ -431,7 +436,7 @@ def test_em_image_in_pts():
         read_em_image=True,
         only_valid_data=False,
         cutoff_at_kV=1,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     assert len(s) == 25
     assert (
@@ -449,7 +454,7 @@ def test_em_image_in_pts():
         sum_frames=True,
         cutoff_at_kV=1,
         frame_list=[0, 0, 0, 1],
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     assert s[1].data[0, 0] == 87 * 4
     assert s[1].data[63, 63] == 87 * 3
@@ -460,7 +465,7 @@ def test_em_image_in_pts():
         only_valid_data=False,
         sum_frames=False,
         cutoff_at_kV=1,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     s2 = hs.load(
         dir2p / TEST_FILES2[16],
@@ -468,7 +473,7 @@ def test_em_image_in_pts():
         only_valid_data=False,
         sum_frames=True,
         cutoff_at_kV=1,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     s1 = [s[0].data.sum(axis=0), s[1].data.sum(axis=0)]
     assert np.array_equal(s1[0], s2[0].data)
@@ -485,7 +490,7 @@ def test_pts_lazy():
         only_valid_data=False,
         sum_frames=False,
         lazy=True,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     s1 = [s[0].data.sum(axis=0).compute(), s[1].data.sum(axis=0).compute()]
     s2 = hs.load(
@@ -494,7 +499,7 @@ def test_pts_lazy():
         only_valid_data=False,
         sum_frames=True,
         lazy=False,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     assert np.array_equal(s1[0], s2[0].data)
     assert np.array_equal(s1[1], s2[1].data)
@@ -511,7 +516,7 @@ def test_pts_frame_shift():
         only_valid_data=False,
         sum_frames=False,
         lazy=False,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     #         x, y, en
     points = [[24, 23, 106], [21, 16, 106]]
@@ -541,7 +546,7 @@ def test_pts_frame_shift():
             sum_frames=False,
             frame_shifts=shifts,
             lazy=False,
-            reader="JEOL",
+            **hs_load_kwargs,
         )
 
         for frame in range(s0[0].axes_manager["Frame"].size):
@@ -559,7 +564,7 @@ def test_pts_frame_shift():
             sum_frames=False,
             frame_shifts=shifts,
             lazy=True,
-            reader="JEOL",
+            **hs_load_kwargs,
         )
         dt = s1[0].data.compute()
         for frame in range(s0[0].axes_manager["Frame"].size):
@@ -575,7 +580,11 @@ def test_pts_frame_shift():
     min_sfts = sfts.min(axis=0)
     fs = sfts - max_sfts
     s = hs.load(
-        file, frame_shifts=sfts, sum_frames=False, only_valid_data=False, reader="JEOL"
+        file,
+        frame_shifts=sfts,
+        sum_frames=False,
+        only_valid_data=False,
+        **hs_load_kwargs,
     )
     sz = min_sfts - max_sfts + ref[0].data.shape[1:3]
     assert s.data.shape == (2, sz[0], sz[1], 4096)
@@ -596,10 +605,10 @@ def test_broken_files(tmp_path):
         if file.suffix == ".asw":
             # in case of asw, valid data can not be obtained
             with pytest.raises(ValueError, match="Not a valid JEOL asw format"):
-                _ = hs.load(file, reader="JEOL")
+                _ = hs.load(file, **hs_load_kwargs)
         else:
             # just skipping broken files
-            s = hs.load(file, reader="JEOL")
+            s = hs.load(file, **hs_load_kwargs)
             assert s == []
 
 
@@ -617,7 +626,7 @@ def test_seq_eds_files(tmp_path):
         zipped.extractall(tmp_path)
 
     # test reading sequential acuired EDS spectrum
-    s = hs.load(tmp_path / "1" / "1.ASW", reader="JEOL")
+    s = hs.load(tmp_path / "1" / "1.ASW", **hs_load_kwargs)
     # check if three subfiles are in file (img, eds, eds)
     assert len(s) == 3
     # check positional information in subfiles
@@ -647,7 +656,7 @@ def test_seq_eds_files(tmp_path):
     data2[0x42D] = 0x30
     with open(fname2, "wb") as f:
         f.write(data2)
-    dat = hs.load(fname2, reader="JEOL")
+    dat = hs.load(fname2, **hs_load_kwargs)
     assert len(dat) == 0
 
     # No ViewInfo
@@ -655,7 +664,7 @@ def test_seq_eds_files(tmp_path):
     data2[0x1AD] = 0x30
     with open(fname2, "wb") as f:
         f.write(data2)
-    dat = hs.load(fname2, reader="JEOL")
+    dat = hs.load(fname2, **hs_load_kwargs)
     assert len(dat) == 0
 
     # No SampleInfo
@@ -663,7 +672,7 @@ def test_seq_eds_files(tmp_path):
     data2[0x6E] = 0x30
     with open(fname2, "wb") as f:
         f.write(data2)
-    dat = hs.load(fname2, reader="JEOL")
+    dat = hs.load(fname2, **hs_load_kwargs)
     assert len(dat) == 0
 
     # test read for pseudo SEM eds/img data
@@ -678,7 +687,7 @@ def test_seq_eds_files(tmp_path):
         data[0x75BD] = 0x41
     with open(sub_dir / ("x" + test_files[0]), "wb") as f:
         f.write(data)
-    s = hs.load(sub_dir / ("x" + test_files[0]), reader="JEOL")
+    s = hs.load(sub_dir / ("x" + test_files[0]), **hs_load_kwargs)
     assert "SEM" in s.metadata["Acquisition_instrument"]
 
     # .eds
@@ -687,7 +696,7 @@ def test_seq_eds_files(tmp_path):
         data[0x4B13] = 0x34
     with open(sub_dir / ("x" + test_files[1]), "wb") as f:
         f.write(data)
-    s = hs.load(sub_dir / ("x" + test_files[1]), reader="JEOL")
+    s = hs.load(sub_dir / ("x" + test_files[1]), **hs_load_kwargs)
     assert s.metadata.Signal.signal_type == "EDS_SEM"
     assert isinstance(s, hs.signals.Signal1D)
     assert "SEM" in s.metadata["Acquisition_instrument"]
@@ -720,7 +729,7 @@ def test_frame_start_index(tmp_path):
         downsample=[32, 32],
         rebin_energy=512,
         SI_dtype=np.int32,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     frame_start_index = ref.original_metadata.jeol_pts_frame_start_index
     assert np.array_equal(frame_start_index, frame_start_index_ref)
@@ -731,7 +740,7 @@ def test_frame_start_index(tmp_path):
         downsample=[32, 32],
         rebin_energy=512,
         SI_dtype=np.int32,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     frame_start_index = s.original_metadata.jeol_pts_frame_start_index
     assert np.array_equal(frame_start_index[0:6], frame_start_index_ref[0:6])
@@ -744,7 +753,7 @@ def test_frame_start_index(tmp_path):
         downsample=[32, 32],
         rebin_energy=512,
         SI_dtype=np.int32,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     frame_start_index = s.original_metadata.jeol_pts_frame_start_index
     assert np.array_equal(frame_start_index[0:10], frame_start_index_ref[0:10])
@@ -758,7 +767,7 @@ def test_frame_start_index(tmp_path):
         downsample=[32, 32],
         rebin_energy=512,
         SI_dtype=np.int32,
-        reader="JEOL",
+        **hs_load_kwargs,
     )
     assert s.data.shape == (2, 16, 16, 8)
 
@@ -776,6 +785,6 @@ def test_frame_start_index(tmp_path):
             downsample=[32, 32],
             rebin_energy=512,
             SI_dtype=np.int32,
-            reader="JEOL",
+            **hs_load_kwargs,
         )
     assert s.metadata["Signal"]["signal_type"] == "EDS_SEM"

--- a/rsciio/tests/test_jobinyvon.py
+++ b/rsciio/tests/test_jobinyvon.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
@@ -49,37 +50,43 @@ else:
     lumispy_installed = True
 
 
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "JobinYvon"}
+
+
 class TestSpec:
     @classmethod
     def setup_class(cls):
         cls.s = hs.load(
             testfile_spec_wavelength_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=True,
         )
         cls.s_non_uniform = hs.load(
             testfile_spec_wavelength_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=False,
         )
         cls.s_wn = hs.load(
             testfile_spec_wavenumber_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=True,
         )
         cls.s_abs_wn = hs.load(
             testfile_spec_abs_wavenumber_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=True,
         )
         cls.s_ev = hs.load(
             testfile_spec_energy_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=True,
         )
         cls.s_count = hs.load(
             testfile_spec_count_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=True,
         )
 
@@ -101,7 +108,7 @@ class TestSpec:
         lum = pytest.importorskip("lumispy", reason="lumispy not installed")
         s_lum = hs.load(
             testfile_spec_wavelength_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=True,
         )
         assert isinstance(s_lum, lum.signals.luminescence_spectrum.LumiSpectrum)
@@ -447,12 +454,12 @@ class TestLinescan:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_linescan_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=True,
         )
         cls.s_non_uniform = hs.load(
             testfile_linescan_path,
-            reader="JobinYvon",
+            **hs_load_kwargs,
             use_uniform_signal_axis=False,
         )
 
@@ -680,12 +687,12 @@ class TestMap:
     @classmethod
     def setup_class(cls):
         cls.s = hs.load(
-            testfile_map_path, reader="JobinYvon", use_uniform_signal_axis=True
+            testfile_map_path, **hs_load_kwargs, use_uniform_signal_axis=True
         )
         cls.s_non_uniform = hs.load(
-            testfile_map_path, reader="JobinYvon", use_uniform_signal_axis=False
+            testfile_map_path, **hs_load_kwargs, use_uniform_signal_axis=False
         )
-        cls.s_rotated = hs.load(testfile_map_rotated_path, reader="JobinYvon")
+        cls.s_rotated = hs.load(testfile_map_rotated_path, **hs_load_kwargs)
 
     @classmethod
     def teardown_class(cls):
@@ -987,10 +994,10 @@ class TestGlue:
     @classmethod
     def setup_class(cls):
         cls.s = hs.load(
-            testfile_glue_path, reader="JobinYvon", use_uniform_signal_axis=True
+            testfile_glue_path, **hs_load_kwargs, use_uniform_signal_axis=True
         )
         cls.s_non_uniform = hs.load(
-            testfile_glue_path, reader="JobinYvon", use_uniform_signal_axis=False
+            testfile_glue_path, **hs_load_kwargs, use_uniform_signal_axis=False
         )
 
     @classmethod

--- a/rsciio/tests/test_mrcz.py
+++ b/rsciio/tests/test_mrcz.py
@@ -19,7 +19,6 @@
 import importlib
 import os
 import tempfile
-from datetime import datetime
 from time import perf_counter, sleep
 
 import numpy as np
@@ -84,20 +83,6 @@ class TestPythonMrcz:
         if lazy:
             testSignal = testSignal.as_lazy()
 
-        # Add "File" metadata to testSignal
-        testSignal.metadata.General.add_dictionary(
-            {
-                "FileIO": {
-                    "0": {
-                        "operation": "load",
-                        "hyperspy_version": hs.__version__,
-                        "io_plugin": "rsciio.mrcz",
-                        "timestamp": datetime.now().astimezone().isoformat(),
-                    }
-                }
-            }
-        )
-
         # Unfortunately one cannot iterate over axes_manager in a Pythonic way
         # for axis in testSignal.axes_manager:
         testSignal.axes_manager[0].name = "z"
@@ -147,9 +132,7 @@ class TestPythonMrcz:
             print("Warning: file {} left on disk".format(mrcName))  # noqa: T201
 
         # change file timestamp to make the metadata of both signals equal
-        testSignal.metadata.General.FileIO.Number_0.timestamp = (
-            reSignal.metadata.General.FileIO.Number_0.timestamp
-        )
+        del testSignal.metadata.General.FileIO
 
         npt.assert_array_almost_equal(testSignal.data.shape, reSignal.data.shape)
         npt.assert_array_almost_equal(testSignal.data, reSignal.data)
@@ -176,7 +159,7 @@ class TestPythonMrcz:
             assert isinstance(reSignal, hs.signals.Signal2D)
 
         # delete last load operation from reSignal metadata so we can compare
-        del reSignal.metadata.General.FileIO.Number_2
+        del reSignal.metadata.General.FileIO
         assert_deep_almost_equal(
             testSignal.axes_manager.as_dictionary(),
             reSignal.axes_manager.as_dictionary(),

--- a/rsciio/tests/test_protochips.py
+++ b/rsciio/tests/test_protochips.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 from rsciio.protochips._api import ProtochipsCSV, invalid_file_error
 
@@ -37,6 +38,12 @@ def create_numpy_file(filename, obj):
     np.save(filename, data.T)
 
 
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "protochips"}
+
+
 #######################
 # Protochips gas cell #
 #######################
@@ -44,7 +51,7 @@ def create_numpy_file(filename, obj):
 
 def test_read_protochips_gas_cell():
     filename = TEST_DATA_PATH / "protochips_gas_cell.csv"
-    s = hs.load(filename, reader="protochips")
+    s = hs.load(filename, **hs_load_kwargs)
     assert len(s) == 5
     assert s[0].metadata.General.title == "Holder Temperature (Degrees C)"
     assert s[0].metadata.Signal.signal_type == ""
@@ -84,14 +91,14 @@ def test_loading_random_csv_file():
 def test_loading_invalid_protochips_file():
     filename = TEST_DATA_PATH / "invalid_protochips_file.csv"
     with pytest.raises(IOError) as cm:
-        hs.load(filename, reader="protochips")
+        hs.load(filename, **hs_load_kwargs)
         cm.match(invalid_file_error)
 
 
 class TestProtochipsGasCellCSV:
     def setup_method(self, method):
         filename = TEST_DATA_PATH / "protochips_gas_cell.csv"
-        self.s_list = hs.load(filename, reader="protochips")
+        self.s_list = hs.load(filename, **hs_load_kwargs)
 
     def test_read_metadata(self):
         date, time, dt_np = datetime_gas_cell
@@ -123,7 +130,7 @@ class TestProtochipsGasCellCSV:
 class TestProtochipsGasCellCSVNoUser:
     def setup_method(self, method):
         filename = TEST_DATA_PATH / "protochips_gas_cell_no_user.csv"
-        self.s_list = hs.load(filename, reader="protochips")
+        self.s_list = hs.load(filename, **hs_load_kwargs)
 
     def test_read_metadata(self):
         date, time, dt_np = datetime_gas_cell_no_user
@@ -198,7 +205,7 @@ class TestProtochipsGasCellCSVReader:
 
 def test_read_protochips_electrical():
     filename = TEST_DATA_PATH / "protochips_electrical.csv"
-    s = hs.load(filename, reader="protochips")
+    s = hs.load(filename, **hs_load_kwargs)
     assert len(s) == 6
     assert s[0].metadata.General.title == "Channel A Current (Amps)"
     assert s[0].metadata.Signal.signal_type == ""
@@ -259,7 +266,7 @@ class TestProtochipsElectricalCSVReader:
 
 def test_read_protochips_thermal():
     filename = TEST_DATA_PATH / "protochips_thermal.csv"
-    s = hs.load(filename, reader="protochips")
+    s = hs.load(filename, **hs_load_kwargs)
     assert s.metadata.General.title == "Channel A Temperature (Degrees C)"
     assert s.metadata.Signal.signal_type == ""
     assert s.metadata.Signal.quantity == "Temperature (Degrees C)"
@@ -296,7 +303,7 @@ class TestProtochipsThermallCSVReader:
 
 def test_read_protochips_electrothermal():
     filename = TEST_DATA_PATH / "protochips_electrothermal.csv"
-    s = hs.load(filename, reader="protochips")
+    s = hs.load(filename, **hs_load_kwargs)
     assert len(s) == 4
     assert s[0].metadata.General.title == "Channel A Temperature (Degrees C)"
     assert s[0].metadata.Signal.signal_type == ""

--- a/rsciio/tests/test_renishaw.py
+++ b/rsciio/tests/test_renishaw.py
@@ -54,13 +54,11 @@ class TestSpec:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_spec,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )
 
         cls.s_non_uniform = hs.load(
             testfile_spec,
-            reader="Renishaw",
             use_uniform_signal_axis=False,
         )
 
@@ -893,11 +891,7 @@ class TestSpec:
 class TestLinescan:
     @classmethod
     def setup_class(cls):
-        cls.s = hs.load(
-            testfile_linescan,
-            reader="Renishaw",
-            use_uniform_signal_axis=True,
-        )[0]
+        cls.s = hs.load(testfile_linescan, use_uniform_signal_axis=True)[0]
 
     @classmethod
     def teardown_class(cls):
@@ -975,7 +969,6 @@ class TestMap:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_map,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )[0]
 
@@ -1110,7 +1103,6 @@ class TestZscan:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_zscan,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )
 
@@ -1158,7 +1150,6 @@ class TestUndefined:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_undefined,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )
 
@@ -1184,7 +1175,6 @@ class TestStreamline:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_streamline,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )[0]
 
@@ -1205,7 +1195,6 @@ class TestStreamline:
     def test_WHTL(self):
         s = hs.load(
             testfile_streamline,
-            reader="Renishaw",
         )[1]
         expected_WTHL = {
             "FocalPlaneResolutionUnit": 5,
@@ -1288,7 +1277,6 @@ class TestMapBlock:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_map_block,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )[0]
 
@@ -1328,7 +1316,6 @@ class TestTimeseries:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_timeseries,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )
 
@@ -1360,7 +1347,6 @@ class TestFocusTrack:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_focustrack,
-            reader="Renishaw",
             use_uniform_signal_axis=True,
         )
 
@@ -1480,17 +1466,14 @@ class TestIntegrationtime:
     def setup_class(cls):
         cls.s_11 = hs.load(
             testfile_acc1_exptime1,
-            reader="Renishaw",
             use_uniform_signal_axis=False,
         )
         cls.s_21 = hs.load(
             testfile_acc2_exptime1,
-            reader="Renishaw",
             use_uniform_signal_axis=False,
         )
         cls.s_110 = hs.load(
             testfile_acc1_exptime10,
-            reader="Renishaw",
             use_uniform_signal_axis=False,
         )
 

--- a/rsciio/tests/test_tiff.py
+++ b/rsciio/tests/test_tiff.py
@@ -475,13 +475,6 @@ class TestReadFEIHelios:
             "authors": "supervisor",
             "date": "2016-06-13",
             "time": "17:06:40",
-            "FileIO": {
-                "0": {
-                    "operation": "load",
-                    "hyperspy_version": hs.__version__,
-                    "io_plugin": "rsciio.tiff",
-                }
-            },
         },
         "Signal": {"signal_type": ""},
         "_HyperSpy": {
@@ -509,7 +502,6 @@ class TestReadFEIHelios:
             "date": "2022-05-17",
             "time": "09:07:08",
             "authors": "user",
-            "FileIO": {"0": {"operation": "load", "io_plugin": "rsciio.tiff"}},
         },
         "Signal": {"signal_type": ""},
         "Acquisition_instrument": {
@@ -544,7 +536,7 @@ class TestReadFEIHelios:
         np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1e-5)
         assert s.data.dtype == "uint8"
         # delete timestamp from metadata since it's runtime dependent
-        del s.metadata.General.FileIO.Number_0.timestamp
+        del s.metadata.General.FileIO
         self.FEI_Helios_metadata["General"]["original_filename"] = (
             "FEI-Helios-Ebeam-8bits.tif"
         )
@@ -561,7 +553,7 @@ class TestReadFEIHelios:
         np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1e-5)
         assert s.data.dtype == "uint16"
         # delete timestamp from metadata since it's runtime dependent
-        del s.metadata.General.FileIO.Number_0.timestamp
+        del s.metadata.General.FileIO
         self.FEI_Helios_metadata["General"]["original_filename"] = (
             "FEI-Helios-Ebeam-16bits.tif"
         )
@@ -578,8 +570,7 @@ class TestReadFEIHelios:
         np.testing.assert_allclose(s.axes_manager[1].scale, 0.2640, rtol=0.0001)
         assert s.data.dtype == "uint8"
         # delete timestamp and version from metadata since it's runtime dependent
-        del s.metadata.General.FileIO.Number_0.timestamp
-        del s.metadata.General.FileIO.Number_0.hyperspy_version
+        del s.metadata.General.FileIO
         self.FEI_navcam_metadata["General"]["original_filename"] = (
             "FEI-Helios-navcam.tif"
         )
@@ -596,8 +587,7 @@ class TestReadFEIHelios:
         np.testing.assert_allclose(s.axes_manager[1].scale, 1, rtol=0)
         assert s.data.dtype == "uint8"
         # delete timestamp and version from metadata since it's runtime dependent
-        del s.metadata.General.FileIO.Number_0.timestamp
-        del s.metadata.General.FileIO.Number_0.hyperspy_version
+        del s.metadata.General.FileIO
         self.FEI_navcam_metadata["General"]["original_filename"] = (
             "FEI-Helios-navcam-with-no-IRBeam.tif"
         )
@@ -609,8 +599,7 @@ class TestReadFEIHelios:
         assert s.axes_manager.signal_shape == (768, 551)
         assert s.axes_manager.navigation_shape == ()
         # delete timestamp and version from metadata since it's runtime dependent
-        del s.metadata.General.FileIO.Number_0.timestamp
-        del s.metadata.General.FileIO.Number_0.hyperspy_version
+        del s.metadata.General.FileIO
         self.FEI_navcam_metadata["General"]["original_filename"] = (
             "FEI-Helios-navcam-with-no-IRBeam-bad-floats.tif"
         )
@@ -658,13 +647,6 @@ class TestReadZeissSEM:
                 "original_filename": "test_tiff_Zeiss_SEM_1k.tif",
                 "time": "09:40:32",
                 "title": "",
-                "FileIO": {
-                    "0": {
-                        "operation": "load",
-                        "hyperspy_version": hs.__version__,
-                        "io_plugin": "rsciio.tiff",
-                    }
-                },
             },
             "Signal": {"signal_type": ""},
             "_HyperSpy": {
@@ -688,7 +670,7 @@ class TestReadZeissSEM:
         np.testing.assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1e-6)
         assert s.data.dtype == "uint8"
         # delete timestamp from metadata since it's runtime dependent
-        del s.metadata.General.FileIO.Number_0.timestamp
+        del s.metadata.General.FileIO
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
     def test_read_Zeiss_SEM_scale_metadata_512_image(self):
@@ -714,13 +696,6 @@ class TestReadZeissSEM:
                 "original_filename": "test_tiff_Zeiss_SEM_512pix.tif",
                 "time": "08:20:42",
                 "title": "",
-                "FileIO": {
-                    "0": {
-                        "operation": "load",
-                        "hyperspy_version": hs.__version__,
-                        "io_plugin": "rsciio.tiff",
-                    }
-                },
             },
             "Signal": {"signal_type": ""},
             "_HyperSpy": {
@@ -743,7 +718,7 @@ class TestReadZeissSEM:
         np.testing.assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1e-6)
         assert s.data.dtype == "uint8"
         # delete timestamp from metadata since it's runtime dependent
-        del s.metadata.General.FileIO.Number_0.timestamp
+        del s.metadata.General.FileIO
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
     def test_zeiss_multipage_as_separate_signals(self):
@@ -883,13 +858,6 @@ def test_read_TVIPS_metadata(tmp_path):
             "original_filename": "TVIPS_bin4.tif",
             "time": "9:01:17",
             "title": "",
-            "FileIO": {
-                "0": {
-                    "operation": "load",
-                    "hyperspy_version": hs.__version__,
-                    "io_plugin": "rsciio.tiff",
-                }
-            },
         },
         "Signal": {"signal_type": ""},
         "_HyperSpy": {
@@ -915,7 +883,7 @@ def test_read_TVIPS_metadata(tmp_path):
     np.testing.assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1e-5)
     np.testing.assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1e-5)
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.FileIO.Number_0.timestamp
+    del s.metadata.General.FileIO
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 

--- a/rsciio/tests/test_trivista.py
+++ b/rsciio/tests/test_trivista.py
@@ -52,13 +52,11 @@ class TestSpec:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_spec_path,
-            reader="TriVista",
             use_uniform_signal_axis=True,
             filter_original_metadata=True,
         )
         cls.s_non_uniform_unfiltered = hs.load(
             testfile_spec_path,
-            reader="TriVista",
             use_uniform_signal_axis=False,
             filter_original_metadata=False,
         )
@@ -1538,11 +1536,10 @@ class TestSpec:
 class TestLinescan:
     @classmethod
     def setup_class(cls):
-        cls.s = hs.load(
-            testfile_linescan_path, reader="TriVista", use_uniform_signal_axis=True
-        )
+        cls.s = hs.load(testfile_linescan_path, use_uniform_signal_axis=True)
         cls.s_non_uniform = hs.load(
-            testfile_linescan_path, reader="TriVista", use_uniform_signal_axis=False
+            testfile_linescan_path,
+            use_uniform_signal_axis=False,
         )
 
     @classmethod
@@ -1646,12 +1643,8 @@ class TestLinescan:
 class TestMap:
     @classmethod
     def setup_class(cls):
-        cls.s = hs.load(
-            testfile_map_path, reader="TriVista", use_uniform_signal_axis=True
-        )
-        cls.s_non_uniform = hs.load(
-            testfile_map_path, reader="TriVista", use_uniform_signal_axis=False
-        )
+        cls.s = hs.load(testfile_map_path, use_uniform_signal_axis=True)
+        cls.s_non_uniform = hs.load(testfile_map_path, use_uniform_signal_axis=False)
 
     @classmethod
     def teardown_class(cls):
@@ -1787,7 +1780,6 @@ class Test3Spectrometers:
     def setup_class(cls):
         cls.s = hs.load(
             testfile_triple_add_path,
-            reader="TriVista",
             use_uniform_signal_axis=True,
             filter_original_metadata=True,
         )
@@ -2335,14 +2327,12 @@ class TestStepAndGlue:
     def setup_class(cls):
         cls.glued = hs.load(
             testfile_step_and_glue_path,
-            reader="TriVista",
             use_uniform_signal_axis=True,
             filter_original_metadata=True,
             glued_data_as_stack=False,
         )
         cls.stack = hs.load(
             testfile_step_and_glue_path,
-            reader="TriVista",
             use_uniform_signal_axis=False,
             filter_original_metadata=True,
             glued_data_as_stack=True,
@@ -2418,13 +2408,11 @@ class TestTimeSeries:
     def setup_class(cls):
         cls.timeseries = hs.load(
             testfile_spec_timeseries_path,
-            reader="TriVista",
             use_uniform_signal_axis=True,
             filter_original_metadata=True,
         )
         cls.frames = hs.load(
             testfile_spec_2frames_path,
-            reader="TriVista",
             use_uniform_signal_axis=True,
             filter_original_metadata=True,
         )
@@ -2509,7 +2497,6 @@ class TestSpecIntegrationTime:
     def setup_class(cls):
         cls.s_2acc = hs.load(
             testfile_spec_2acc_path,
-            reader="TriVista",
             use_uniform_signal_axis=True,
             filter_original_metadata=True,
             glued_data_as_stack=True,
@@ -2519,7 +2506,6 @@ class TestSpecIntegrationTime:
         ## non-glued datasets
         cls.s_2acc_no_average = hs.load(
             testfile_spec_2acc_no_average_path,
-            reader="TriVista",
             use_uniform_signal_axis=True,
             filter_original_metadata=True,
             glued_data_as_stack=True,

--- a/rsciio/tests/test_usid.py
+++ b/rsciio/tests/test_usid.py
@@ -21,6 +21,7 @@ import tempfile
 import dask.array as da
 import numpy as np
 import pytest
+from packaging.version import Version
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 usid = pytest.importorskip("pyUSID", reason="pyUSID not installed")
@@ -28,6 +29,11 @@ sidpy = pytest.importorskip("sidpy", reason="sidpy not installed")
 h5py = pytest.importorskip("h5py", reason="h5py not installed")
 
 # ##################### HELPER FUNCTIONS ######################################
+
+argument_name = (
+    "reader" if Version(hs.__version__) < Version("2.4.0.dev33") else "file_format"
+)
+hs_load_kwargs = {argument_name: "USID"}
 
 
 def _array_translator_basic_checks(h5_f):
@@ -516,7 +522,7 @@ class TestUSID2HSbase:
             slow_to_fast=slow_to_fast,
         )
 
-        new_sig = hs.load(file_path, reader="USID")
+        new_sig = hs.load(file_path, **hs_load_kwargs)
         compare_signal_from_usid(
             file_path, ndata, new_sig, sig_type=hs.signals.BaseSignal, axes_to_spec=[]
         )
@@ -542,7 +548,7 @@ class TestUSID2HSbase:
             slow_to_fast=slow_to_fast,
         )
 
-        new_sig = hs.load(file_path, reader="USID")
+        new_sig = hs.load(file_path, **hs_load_kwargs)
         compare_signal_from_usid(
             file_path, ndata, new_sig, sig_type=hs.signals.BaseSignal, axes_to_spec=[]
         )
@@ -567,7 +573,7 @@ class TestUSID2HSbase:
             slow_to_fast=slow_to_fast,
         )
 
-        new_sig = hs.load(file_path, reader="USID", lazy=lazy)
+        new_sig = hs.load(file_path, lazy=lazy, **hs_load_kwargs)
         compare_signal_from_usid(
             file_path,
             ndata,
@@ -601,7 +607,7 @@ class TestUSID2HSdtype:
             slow_to_fast=slow_to_fast,
         )
 
-        new_sig = hs.load(file_path, reader="USID")
+        new_sig = hs.load(file_path, **hs_load_kwargs)
         compare_signal_from_usid(
             file_path,
             ndata,
@@ -630,7 +636,7 @@ class TestUSID2HSdtype:
             slow_to_fast=slow_to_fast,
         )
 
-        objects = hs.load(file_path, reader="USID")
+        objects = hs.load(file_path, **hs_load_kwargs)
         assert isinstance(objects, list)
         assert len(objects) == 2
 
@@ -673,10 +679,10 @@ class TestUSID2HSdtype:
         )
 
         with pytest.raises(ValueError):
-            _ = hs.load(file_path, reader="USID", ignore_non_uniform_dims=False)
+            _ = hs.load(file_path, ignore_non_uniform_dims=False, **hs_load_kwargs)
 
         with pytest.warns(UserWarning) as _:
-            new_sig = hs.load(file_path, reader="USID")
+            new_sig = hs.load(file_path, **hs_load_kwargs)
         compare_signal_from_usid(
             file_path,
             ndata,
@@ -730,7 +736,7 @@ class TestUSID2HSmultiDsets:
             )
 
         dataset_path = "/Measurement_001/Channel_000/Raw_Data"
-        new_sig = hs.load(file_path, dataset_path=dataset_path, reader="USID")
+        new_sig = hs.load(file_path, dataset_path=dataset_path, **hs_load_kwargs)
         compare_signal_from_usid(file_path, ndata_2, new_sig, dataset_path=dataset_path)
 
     def test_read_all_by_default(self):
@@ -772,7 +778,7 @@ class TestUSID2HSmultiDsets:
                 slow_to_fast=slow_to_fast,
             )
 
-        objects = hs.load(file_path, reader="USID")
+        objects = hs.load(file_path, **hs_load_kwargs)
         assert isinstance(objects, list)
         assert len(objects) == 2
 

--- a/upcoming_changes/425.maintenance.rst
+++ b/upcoming_changes/425.maintenance.rst
@@ -1,0 +1,1 @@
+Use ``file_format`` instead of deprecated ``reader`` in hyperspy load function. Update test suite for changes in ``FileIO`` hyperspy metadata.


### PR DESCRIPTION
The PR for https://github.com/hyperspy/hyperspy/pull/3528. These changes are compatible with the release and development version of hyperspy.

### Progress of the PR
- [x] Update reference metadata dictionary to support changes in #3528,
- [x] Handle deprecation of `reader` and `extension` parameters in the test suite, 
- [ ] update docstring: replace mentions of `reader` argument,
- [ ] update user guide: replace mentions of `reader` argument,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.

