### PR TITLE
Allow saving image with scalebar when the scales have opposite signs

### DIFF
--- a/rsciio/image/_api.py
+++ b/rsciio/image/_api.py
@@ -173,7 +173,9 @@ def file_writer(
             # relative difference normalized to the size of the second axis
             # the more pixels is in the second axis, the higher the tolerance need to be
             not math.isclose(
-                axes[0]["scale"], axes[1]["scale"], rel_tol=0.1 / axes[1]["size"]
+                abs(axes[0]["scale"]),
+                abs(axes[1]["scale"]),
+                rel_tol=0.1 / axes[1]["size"],
             )
         ):
             raise ValueError(

--- a/rsciio/tests/test_image.py
+++ b/rsciio/tests/test_image.py
@@ -214,6 +214,19 @@ def test_export_scalebar_scale_close_enough(tmp_path, pixels_below_above):
         s.save(filename, scalebar=True)
 
 
+def test_save_image_scalebar_scale_opposite_signs(tmp_path):
+    hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+    pixels = 16
+    s = hs.signals.Signal2D(
+        np.arange(pixels**2).reshape((pixels, pixels)).astype("int32")
+    )
+    s.axes_manager[0].scale = -1.0
+    s.axes_manager[1].scale = 1.0
+
+    fname = tmp_path / "test_save_image_scalebar_scale_opposite_signs.png"
+    s.save(fname, scalebar=True)
+
+
 @pytest.mark.parametrize("output_size", (512, [512, 512]))
 def test_export_output_size(output_size, tmp_path):
     hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")

--- a/rsciio/tests/test_image.py
+++ b/rsciio/tests/test_image.py
@@ -37,12 +37,13 @@ testfile_dir = (Path(__file__).parent / "data" / "image").resolve()
 @pytest.mark.parametrize(("dtype"), ["uint8", "int32", bool])
 @pytest.mark.parametrize(("ext"), ["png", "bmp", "gif", "jpg"])
 def test_save_load_cycle_grayscale(dtype, ext, tmp_path):
+    if dtype == "int32" and ext in ["png", "bmp", "jpg"]:
+        # PNG, BMP and JPG do not support int32.
+        return
+
     hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
     s = hs.signals.Signal2D(np.arange(128 * 128).reshape(128, 128).astype(dtype))
 
-    if dtype == "int32" and ext in ["bmp", "jpg"]:
-        # BMP and JPG does not support uint32.
-        return
     print(f"Saving-loading cycle for the extension `{ext}` with dtype `{dtype}`")  # noqa: T201
     filename = tmp_path / f"test_image.{ext}"
     s.save(filename)
@@ -58,6 +59,7 @@ def test_save_load_cycle_color(color, ext, tmp_path):
     if dim == 4 and ext == "jpeg":
         # JPEG does not support alpha channel.
         return
+
     print("color:", color, "; dim:", dim, "; dtype:", dtype)  # noqa: T201
     s = hs.signals.Signal1D(
         np.arange(128 * 128 * dim).reshape(128, 128, dim).astype(dtype)
@@ -77,12 +79,12 @@ def test_save_load_cycle_color(color, ext, tmp_path):
 @pytest.mark.parametrize(("dtype"), ["uint8", "int32"])
 @pytest.mark.parametrize(("ext"), ["png", "bmp", "gif", "jpg"])
 def test_save_load_cycle_kwds(dtype, ext, tmp_path):
+    if dtype == "int32" and ext in ["png", "bmp", "jpg"]:
+        # PNG, BMP and JPG do not support int32.
+        return
+
     hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
     s = hs.signals.Signal2D(np.arange(128 * 128).reshape(128, 128).astype(dtype))
-
-    if dtype == "int32" and ext in ["bmp", "jpg"]:
-        # BMP and JPG does not support uint32.
-        return
 
     print(f"Saving-loading cycle for the extension `{ext}` with dtype `{dtype}`")  # noqa: T201
     filename = tmp_path / f"test_image.{ext}"
@@ -269,7 +271,11 @@ def test_export_output_size_aspect(aspect, output_size, tmp_path):
 
     fname = tmp_path / "test_export_size_non_square_aspect.jpg"
     s.save(
-        fname, scalebar=True, output_size=output_size, imshow_kwds=dict(aspect=aspect)
+        fname,
+        scalebar=True,
+        output_size=output_size,
+        imshow_kwds={"aspect": aspect},
+        scalebar_kwds={"rotation": "horizontal-only"},
     )
     s_reload = hs.load(fname)
 

--- a/upcoming_changes/475.enhancements.rst
+++ b/upcoming_changes/475.enhancements.rst
@@ -1,0 +1,1 @@
+Allow saving image with scalebar when the scales have opposite signs.


### PR DESCRIPTION
### Progress of the PR
- [x] Allow saving image with scalebar when the scales have opposite signs,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
  pixels = 16
  s = hs.signals.Signal2D(
      np.arange(pixels**2).reshape((pixels, pixels)).astype("int32")
  )
  s.axes_manager[0].scale = -1.0
  s.axes_manager[1].scale = 1.0

  fname = tmp_path / "test_save_image_scalebar_scale_opposite_signs.png"
  s.save(fname, scalebar=True)
```

