### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,12 @@ jobs:
     name: Build wheels on ${{ matrix.os }} ${{ matrix.CIBW_ARCHS }}
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_ENVIRONMENT: POOCH_BASE_URL=https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/rsciio/tests/data/
+      # Copy the test data from the repository to the current folder of the 
+      # cibuildwheel test environment
+      CIBW_TEST_SOURCES: rsciio/tests/data
+      # When getting the test data, rsciio will use this environment variable
+      # to determine the source of the test data.
+      CIBW_TEST_ENVIRONMENT: RSCIIO_TEST_DATA_SOURCE=rsciio/tests/data
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,14 +102,12 @@ jobs:
       id-token: write
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v7
+        uses: hyperspy/.github/.github/actions/download-artifact@main
         with:
+          name: ""
           pattern: artifacts-*
           path: dist
           merge-multiple: true
-
-      - name: Display structure of downloaded files
-        run: ls -R
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'hyperspy' }}
@@ -123,8 +121,10 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+      - name: Create GitHub Release
+        uses: hyperspy/.github/.github/actions/create-github-release@main
+        with:
+          changelog: CHANGES.rst
+          heading-level: '='
+          artifact-name: ""
+          artifact-pattern: artifacts-*

--- a/rsciio/tests/registry_utils.py
+++ b/rsciio/tests/registry_utils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import os
 import sys
 import warnings
 from pathlib import Path
@@ -106,6 +107,10 @@ def download_all(pooch_object=None, ignore_hash=None, show_progressbar=True):
     Download all test data if they are not already locally available in
     ``rsciio.tests.data`` folder.
 
+    When the environment variable `RSCIIO_TEST_DATA_SOURCE` is set,
+    the test data will be copied from the specified directory instead of downloading.
+    This is useful for CI when the test data is cached as an artifact in a previous step.
+
     Parameters
     ----------
     pooch_object : pooch.Pooch or None, default=None
@@ -119,6 +124,17 @@ def download_all(pooch_object=None, ignore_hash=None, show_progressbar=True):
     show_progressbar : bool, default=True
         Whether to show the progressbar or not.
     """
+
+    src = os.environ.get("RSCIIO_TEST_DATA_SOURCE", "")
+    if src:
+        import shutil
+
+        src = Path(src)
+        dest = PATH / "data"
+        print(f"Copying test data from {src} to {dest}")  # noqa: T201
+        shutil.copytree(str(src), str(dest), dirs_exist_ok=True)
+        n = len(list(dest.rglob("*")))
+        print(f"Copied {n} entries to {dest}")  # noqa: T201
 
     from rsciio.tests.registry import TEST_DATA_REGISTRY
 

--- a/upcoming_changes/482.maintenance.rst
+++ b/upcoming_changes/482.maintenance.rst
@@ -1,0 +1,4 @@
+Improve release workflow:
+
+- Speed up release workflow by avoiding downloading tests data when testing wheels.
+- Add release notes and distribution files to GitHub release.


### PR DESCRIPTION
### Progress of the PR
- [x] Speed up release workflow by avoiding downloading tests data when testing wheels,
- [x] add release notes and distribution files to GitHub release, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

Release test at https://github.com/ericpre/rosettasciio/releases/tag/v0.13.0a0