### PR TITLE
Support for PRZ files with arbitrary dispersion direction

### DIFF
--- a/rsciio/pantarhei/_api.py
+++ b/rsciio/pantarhei/_api.py
@@ -144,8 +144,13 @@ def import_pr(data, meta_data, filename=None):
     content_type = meta_data.get("content.types")
     calibrations = []
     for axis in range(data_dimensions):
+        calib_key = "device.calib"
+        if "user.calib" in meta_data:
+            calib_key = "user.calib"
+        elif "inherited.calib" in meta_data:
+            calib_key = "inherited.calib"
         try:
-            calib = meta_data["device.calib"][axis]
+            calib = meta_data[calib_key][axis]
         except (IndexError, KeyError):
             calib = None
         calibrations.append(calib)

--- a/rsciio/pantarhei/_api.py
+++ b/rsciio/pantarhei/_api.py
@@ -227,8 +227,10 @@ def import_pr(data, meta_data, filename=None):
     calibration_ordered = [calibrations_np_order[i] for i in new_order]
     data = np.moveaxis(data, new_order, list(range(len(content_type_np_order))))
 
-    # TODO: Will have to be updated once CEOS adds selectable dispersion orientation
-    if meta_data.get("filter.mode") == "EELS":
+    # axis ordered by increasing energy means loss direction to the left
+    if meta_data.get("filter.mode") == "EELS" and not meta_data.get(
+        "source.flip_geometry"
+    ):
         flip_axis = tuple(i for i, label in enumerate(data_labels) if label == "Energy")
         if flip_axis:
             data = np.flip(data, flip_axis)


### PR DESCRIPTION
Historically Panta Rhei used to store EELS data with an "energy type" dispersion, similar to what is usually done in XPS. Since Panta Rhei 0.23 this behavior is toggleable, and the overwhelming majority of users have switched to "energy loss type" behaviour, coherently with what is normally done in the EELS community.

This is not just a cosmetic change, the energy channels are actually in a different order in the stored files, and this requires a change in the loader.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR
- [ ] add tests,
- [ ] ready for review.