### PR TITLE
Exclude tifffile 2026.2.24

### DIFF
--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -15,5 +15,5 @@ dependencies:
 - hyperspy-base >=2.0
 - setuptools-scm
 - sparse
-- tifffile>=2022.7.28
+- tifffile>=2022.7.28,!=2026.2.24
 - zarr <3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ image = ["imageio>=2.16", "pillow>=9.0.1"]
 mrcz = ["mrcz>=0.3.6"]
 scalebar_export = ["matplotlib-scalebar", "matplotlib>=3.6"]
 speed = ["numba>=0.56"]
-tiff = ["tifffile>=2022.7.28", "imagecodecs"]
+tiff = ["tifffile>=2022.7.28,!=2026.2.24", "imagecodecs"]
 usid = ["pyUSID>=0.0.11"]
 zspy = ["zarr>=2,<3", "msgpack"]
 tests = [


### PR DESCRIPTION
Fix https://github.com/hyperspy/hyperspy-extensions-list/issues/84.

This has been fixed in tifffile 2026.3.3 (https://github.com/cgohlke/tifffile/issues/319) but it is still good to exclude this version from the dependency requirement.

