### PR TITLE
Increase tolerance in digitalsurf tests

### DIFF
--- a/rsciio/tests/test_digitalsurf.py
+++ b/rsciio/tests/test_digitalsurf.py
@@ -769,7 +769,9 @@ def test_writegeneric_nans(tmp_path, compressed):
     gen.save(fgen, compressed=compressed, is_special=True, overwrite=True)
 
     gen2 = hs.load(fgen)
-    np.testing.assert_allclose(gen2.data, gen.data, equal_nan=True)
+    np.testing.assert_allclose(
+        gen2.data, gen.data, equal_nan=True, rtol=1e-6, atol=1e-8
+    )
 
 
 def test_writegeneric_transposedprofile(tmp_path):
@@ -804,7 +806,7 @@ def test_writegeneric_transposedsurface(
 
     gen2 = hs.load(fgen)
 
-    np.testing.assert_allclose(gen.data, gen2.data, rtol=1e-6)
+    np.testing.assert_allclose(gen.data, gen2.data, rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Some more tweaks of the tolerance in the digitalsurf tests to reduce the occurrence of occasional failure. This happens because of save/read cycle using compression and it is not fully reproducible and it will also on the environment and the binaries used.
Based on:
https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/23523113755/job/68470456510
https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/23523113755/job/68470456520
https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/23523113755/job/68470456463


### Progress of the PR
- [x] Increase tolerance,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.


