### PR TITLE
write rsciio __version__ in msa export

### DIFF
--- a/rsciio/msa/_api.py
+++ b/rsciio/msa/_api.py
@@ -31,6 +31,7 @@ from rsciio._docstrings import (
     SIGNAL_DOC,
 )
 from rsciio.utils._dictionary import DTBox
+from rsciio import __version__
 
 _logger = logging.getLogger(__name__)
 
@@ -477,7 +478,7 @@ def file_writer(filename, signal, format="Y", separator=", ", encoding="latin-1"
         #        'YUNITS' : '',
     }
     if "COMMENT" not in loc_kwds:
-        loc_kwds["COMMENT"] = "File created by RosettaSciIO version {__version__}"
+        loc_kwds["COMMENT"] = f"File created by RosettaSciIO version {__version__}"
         # Microscope
         #        'BEAMKV' : ,
         #        'EMISSION' : ,

--- a/rsciio/msa/_api.py
+++ b/rsciio/msa/_api.py
@@ -23,6 +23,7 @@ from datetime import datetime as dt
 
 import numpy as np
 
+from rsciio import __version__
 from rsciio._docstrings import (
     ENCODING_DOC,
     FILENAME_DOC,
@@ -31,7 +32,6 @@ from rsciio._docstrings import (
     SIGNAL_DOC,
 )
 from rsciio.utils._dictionary import DTBox
-from rsciio import __version__
 
 _logger = logging.getLogger(__name__)
 

--- a/rsciio/tests/test_msa.py
+++ b/rsciio/tests/test_msa.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from rsciio.utils._tests import assert_deep_almost_equal
+from rsciio import msa, __version__
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
@@ -504,3 +505,18 @@ def test_time_with_seconds():
     # but it is found in some files.
     s = hs.load(TEST_DATA_PATH / "example1_with_seconds.msa")
     assert s.metadata.General.time == "12:00:00"
+
+
+def test_parsed_version(tmp_path):
+    s = msa.file_reader(TEST_DATA_PATH / "minimum_metadata.msa")[0]
+    fname = tmp_path / 'example_with_version.msa'
+    _ = s['original_metadata'].pop('COMMENT')
+    msa.file_writer(fname, s)
+
+    # drop the revision hash from the setuptools_scm version if its there
+    # as it's long enough to split across lines.
+    version_parts = __version__.split('.')
+    nv = 3 if len(version_parts) == 3 else 4
+    v = '.'.join(version_parts[:nv])
+    with open(fname, 'r') as fi: 
+        assert v in fi.read()

--- a/rsciio/tests/test_msa.py
+++ b/rsciio/tests/test_msa.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from rsciio import __version__, msa
 from rsciio.utils._tests import assert_deep_almost_equal
-from rsciio import msa, __version__
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
@@ -509,14 +509,14 @@ def test_time_with_seconds():
 
 def test_parsed_version(tmp_path):
     s = msa.file_reader(TEST_DATA_PATH / "minimum_metadata.msa")[0]
-    fname = tmp_path / 'example_with_version.msa'
-    _ = s['original_metadata'].pop('COMMENT')
+    fname = tmp_path / "example_with_version.msa"
+    _ = s["original_metadata"].pop("COMMENT")
     msa.file_writer(fname, s)
 
     # drop the revision hash from the setuptools_scm version if its there
     # as it's long enough to split across lines.
-    version_parts = __version__.split('.')
+    version_parts = __version__.split(".")
     nv = 3 if len(version_parts) == 3 else 4
-    v = '.'.join(version_parts[:nv])
-    with open(fname, 'r') as fi: 
+    v = ".".join(version_parts[:nv])
+    with open(fname, "r") as fi:
         assert v in fi.read()

--- a/upcoming_changes/504.bugfix.rst
+++ b/upcoming_changes/504.bugfix.rst
@@ -1,0 +1,1 @@
+Parse and write the rsciio version when using the :ref:`msa-format` writer.


### PR DESCRIPTION
### Description of the change

Updates the msa file_writer to parse the rsciio `__version__` in the comment line rather than writing `'__version__'`

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature

```python
from rsciio.msa import file_writer
import numpy as np

# make a fake signal to write
nE = 100
signal = {
    'data': np.random.random((nE,)),
    'axes': [{'size': nE,
             'index_in_array': 0,
             'name': 'Energy',
             'scale': np.float64(0.005),
             'offset': np.float32(0.0),
             'units': 'keV',
             'navigate': False}],
    'metadata': {'General': {'original_filename': 'C-12.spd', 'title': 'EDS Spectrum Image'},
                 'Signal': {'signal_type': 'EDS_SEM'},
                 'Acquisition_instrument': {'SEM': {'Detector': {'EDS': {'azimuth_angle': np.float32(0.0),
                                             'elevation_angle': np.float32(33.5),
                                             'energy_resolution_MnKa': np.float32(125.19505),
                                             'live_time': np.float32(3276.8)}},
                                                'beam_energy': np.float32(15.0),
                                                'Stage': {'tilt_alpha': np.float32(0.0)}}},
                  'Sample': {'elements': ['Al', 'Ca', 'Fe', 'K', 'Mg', 'Na', 'O', 'Si']}}, 
    'original_metadata':{},    
}

file_writer("file.msa", signal)
```
and then on this branch, line 4 will read:

```
#COMMENT     : File created by RosettaSciIO version 0.13.1.dev1+g42789d677
``` 

On main, `__version__` is not parsed and it reads:

```
#COMMENT     : File created by RosettaSciIO version __version__
```


