### PR TITLE
Increase tolerance in digitalsurf

### DIFF
--- a/rsciio/tests/test_digitalsurf.py
+++ b/rsciio/tests/test_digitalsurf.py
@@ -966,7 +966,7 @@ def test_writegeneric_surfaceseries(tmp_path, dtype, compressed):
     gen2 = hs.load(fgen)
 
     # increase tolerance for float64, which fails randomly, most likely due to compression losses
-    np.testing.assert_allclose(gen.data, gen2.data, rtol=1e-05)
+    np.testing.assert_allclose(gen.data, gen2.data, rtol=1e-04)
 
 
 def test_writegeneric_datetime(tmp_path):


### PR DESCRIPTION
Follow up of #492: increase tolerance further as noticed in https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/24273390216/job/70882652568. The error depends on compression losses and it seems to be environment dependent, which makes difficult to control the error and therefore to figure out what is a good tolerance in the test!

### Progress of the PR
- [x] Increase tolerance in digitalsurf test,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.


