### PR TITLE
Bug Fix: OverflowError: Python int too large to convert to C long on Windows

### DIFF
--- a/rsciio/blockfile/_api.py
+++ b/rsciio/blockfile/_api.py
@@ -242,6 +242,7 @@ def file_reader(filename, lazy=False, chunks="auto", endianness="<"):
             UserWarning,
         )
     header = sarray2dict(header)
+    # Convert the header value to python int to avoid potential overflow issues on 32-bit systems
     note = f.read(int(header["Data_offset_1"]) - f.tell())
     # It seems it uses "\x00" for padding, so we remove it
     try:
@@ -271,6 +272,7 @@ def file_reader(filename, lazy=False, chunks="auto", endianness="<"):
     # navigator = np.fromfile(f, dtype=endianness+"u1", shape=(NX, NY)).T
 
     # Then comes actual blockfile
+    # header["Data_offset_2"] is np.uint32. Converting to int to avoid potential overflow issues on 32-bit systems
     offset2 = int(header["Data_offset_2"])
     # Every frame is preceded by a 6 byte sequence
     # (AA 55, and then a 4 byte integer specifying frame number)

--- a/rsciio/blockfile/_api.py
+++ b/rsciio/blockfile/_api.py
@@ -271,7 +271,7 @@ def file_reader(filename, lazy=False, chunks="auto", endianness="<"):
     # navigator = np.fromfile(f, dtype=endianness+"u1", shape=(NX, NY)).T
 
     # Then comes actual blockfile
-    offset2 = header["Data_offset_2"]
+    offset2 = int(header["Data_offset_2"])
     # Every frame is preceded by a 6 byte sequence
     # (AA 55, and then a 4 byte integer specifying frame number)
     if not lazy:

--- a/rsciio/blockfile/_api.py
+++ b/rsciio/blockfile/_api.py
@@ -242,7 +242,7 @@ def file_reader(filename, lazy=False, chunks="auto", endianness="<"):
             UserWarning,
         )
     header = sarray2dict(header)
-    note = f.read(header["Data_offset_1"] - f.tell())
+    note = f.read(int(header["Data_offset_1"]) - f.tell())
     # It seems it uses "\x00" for padding, so we remove it
     try:
         header["Note"] = note.decode("latin1").strip("\x00")

--- a/upcoming_changes/506.bugfix.rst
+++ b/upcoming_changes/506.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed "OverflowError: Python int too large to convert to C int" on Windows and other 32-bit systems when Daks computes the lazily-loaded blockfiles 


### PR DESCRIPTION
### Description of the change
The original code line 274 assigned the data with 
```
offset2 = header["Data_offset_2"]
```
On Windows system this may trigger the error:
```
Python int too large to convert to C long
```
Fixes:
```
offset2 = int(header["Data_offset_2"])
```
Root cause:

On Windows, CPython's implementation tries to convert the argument to a C long, which is a signed 32-bit integer even in 64-bit builds. Any value above 2^32 - 1 overflows a signed 32-bit C long, causing the above error. By converting the large value of the numpy scalar to python integer, CPython uses the correct 64-bit seek path that supports up to 2^64 -1 bytes.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.

