### PR TITLE
Document ``DISABLE_C_EXTENSIONS`` to install development version of rosettasciio without compiler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build pure python wheel
-        run: DISABLE_C_EXTENTIONS=1 pipx run build --wheel
+        run: DISABLE_C_EXTENSIONS=1 pipx run build --wheel
 
       - name: List SDist
         run: |

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -145,3 +145,25 @@ To install a development version on CI, it is advised to use
 in order to get the correct development version, e.g. ``0.3.dev14+g706deac``::
 
     pip install git+https://github.com/hyperspy/rosettasciio.git
+
+.. note::
+
+    To install a development version on a system without a compiler available, the compilation
+    of the C-extension of the Bruker reader can be disabled using the ``DISABLE_C_EXTENSIONS``
+    environment variable:
+
+    .. tab-set::
+
+        .. tab-item:: Windows
+
+            .. code-block:: bash
+
+              set DISABLE_C_EXTENSIONS=1
+              pip install git+https://github.com/hyperspy/rosettasciio.git
+
+        .. tab-item:: Linux/macOS
+
+            .. code-block:: bash
+
+              DISABLE_C_EXTENSIONS=1
+              pip install git+https://github.com/hyperspy/rosettasciio.git

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -145,3 +145,25 @@ To install a development version on CI, it is advised to use
 in order to get the correct development version, e.g. ``0.3.dev14+g706deac``::
 
     pip install git+https://github.com/hyperspy/rosettasciio.git
+
+.. note::
+
+    To install a development version on a system without a compiler available, the compilation
+    of the C-extension of the Bruker reader can be disabled using the ``DISABLE_C_EXTENSIONS``
+    environment variable:
+
+    .. tab-set::
+
+        .. tab-item:: Windows
+
+            .. code-block:: bat
+
+              set DISABLE_C_EXTENSIONS=1
+              pip install git+https://github.com/hyperspy/rosettasciio.git
+
+        .. tab-item:: Linux/macOS
+
+            .. code-block:: bash
+
+              export DISABLE_C_EXTENSIONS=1
+              pip install git+https://github.com/hyperspy/rosettasciio.git

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ def no_cythonize(extensions):
 
 
 # to cythonize, or not to cythonize... :
-if os.environ.get("DISABLE_C_EXTENTIONS"):
+if os.environ.get("DISABLE_C_EXTENSIONS"):
     # Explicitly disable
     extensions = []
 elif len(raw_extensions) > count_c_extensions(raw_extensions):

--- a/upcoming_changes/507.doc.rst
+++ b/upcoming_changes/507.doc.rst
@@ -1,0 +1,1 @@
+Document ``DISABLE_C_EXTENSIONS`` to install development version of rosettasciio without compiler.

--- a/upcoming_changes/507.doc.rst
+++ b/upcoming_changes/507.doc.rst
@@ -1,0 +1,1 @@
+Document ``DISABLE_C_EXTENSIONS`` to install development version of rosettasciio without a compiler.


### PR DESCRIPTION
### Progress of the PR
- [n/a] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

