### PR TITLE
Improve DE MRC File Loading

### DIFF
--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -380,10 +380,12 @@ def file_reader(
                     suffix = ""
                 if len(dir_name) == 0:
                     dir_name = "."
-                metadata = glob.glob(dir_name + "/" + unique_id + suffix + "_info.txt")
-                virtual_images = glob.glob(
-                    dir_name + "/" + unique_id + suffix + "*_[0-4]_*.mrc"
-                )
+                metadata = glob.glob(dir_name + "/" + unique_id + suffix + "*_info.txt")
+                virtual_images = [
+                    p
+                    for p in glob.glob(dir_name + "/" + unique_id + suffix + "*_[0-4]_*.mrc")
+                    if "movie" not in os.path.basename(p).lower()
+                ]
                 virtual_images_old = glob.glob(
                     dir_name + "/" + unique_id + suffix + "_virt[0-4]_*.mrc"
                 )
@@ -434,24 +436,27 @@ def file_reader(
         positions = None
     metadata["General"]["original_filename"] = os.path.split(filename)[1]
     metadata["Signal"]["signal_type"] = ""
-
+    metadata["General"]["virtual_images"] = {}
     if virtual_images is not None and len(virtual_images) > 0:
         imgs = []
-        for v in virtual_images:
-            img = file_reader(v)[0]["data"]
+        for i, v in enumerate(virtual_images):
+            signal = file_reader(v)[0]
+            img = signal["data"]
             if navigation_shape is not None and navigation_shape[::-1] != img.shape:
                 if np.prod(img.shape) == np.prod(navigation_shape[::-1]):
-                    img = img.reshape(navigation_shape[::-1])
+                    signal["data"] = img.reshape(navigation_shape[::-1])
                 else:  # pragma: no cover
                     _logger.warning(
                         f"Virtual image {v} does not match the navigation shape {navigation_shape[::-1]}"
                     )
-            imgs.append(img)
-        metadata["General"]["virtual_images"] = imgs
+            imgs.append(signal)
+            print(f"Adding virtual image _sig_image_{i}")
+            metadata["General"]["virtual_images"][f"_sig_image_{i}"] = signal
+            print(metadata["General"]["virtual_images"])
         # checking to make sure the navigator is valid
-        if navigation_shape is not None and navigation_shape[::-1] == imgs[0].shape:
+        if navigation_shape is not None and navigation_shape[::-1] == imgs[0]["data"].shape:
             metadata["_HyperSpy"] = {}
-            metadata["_HyperSpy"]["navigator"] = imgs[0]
+            metadata["_HyperSpy"]["_sig_navigator"] = imgs[0]
 
     if external_images is not None and len(external_images) > 0:
         imgs = []

--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -606,17 +606,17 @@ def file_reader(
 
     original_metadata["std_header"] = sarray2dict(std_header)
 
-    # Convert bytes to unicode
-    for key in ["CMAP", "STAMP", "LABELS"]:
-        try:
-            original_metadata["std_header"][key] = original_metadata["std_header"][
-                key
-            ].decode()
-        except UnicodeDecodeError:
-            _logger.warning(
-                f"Could not decode {key} in the standard header. "
-                f"Using the raw bytes instead."
-            )
+    # Convert void/bytes fields to hex strings so they are JSON-serializable
+    # (e.g. when saving to zspy/zarr). CMAP, STAMP, LABELS are bytes/void;
+    # EXTRA and EXTRA2 are numpy.void padding fields.
+    for key in ["EXTRA", "EXTRA2", "CMAP", "STAMP", "LABELS"]:
+        val = original_metadata["std_header"].get(key)
+        if val is None:
+            continue
+        if isinstance(val, (bytes, np.void)):
+            original_metadata["std_header"][key] = bytes(val).hex()
+        elif isinstance(val, np.ndarray) and val.dtype.kind == "V":
+            original_metadata["std_header"][key] = val.tobytes().hex()
     if fei_header is not None:
         fei_dict = sarray2dict(
             fei_header,

--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -530,8 +530,8 @@ def file_reader(
         positions = None
     metadata["General"]["original_filename"] = os.path.split(filename)[1]
     metadata["Signal"]["signal_type"] = ""
-    metadata["_HyperSpy"] = {}
-    metadata["_HyperSpy"]["navigators"] = {}
+    metadata.setdefault("_HyperSpy", {})
+    metadata["_HyperSpy"].setdefault("navigators", {})
     if virtual_images is not None and len(virtual_images) > 0:
         imgs = []
         for i, v in enumerate(virtual_images):
@@ -550,14 +550,15 @@ def file_reader(
             if virtual_image_names and i < len(virtual_image_names):
                 name = f"_sig_{virtual_image_names[i]}"
             else:
-                name = f"_sig_virtual_image_{i}" # _sig_ is dropped in hyperspy. List  --> BaseSignal
+                name = f"_sig_virtual_image_{i}"  # _sig_ is dropped in hyperspy. List  --> BaseSignal
             metadata["_HyperSpy"]["navigators"][name] = signal
         # checking to make sure the navigator is valid
         if (
             navigation_shape is not None
             and navigation_shape[::-1] == imgs[0]["data"].shape
         ):
-            metadata["_HyperSpy"] = {}
+            # Preserve existing navigator entries (virtual/external) and only
+            # set the default navigator signal.
             metadata["_HyperSpy"]["_sig_navigator"] = imgs[0]
 
     if external_images is not None and len(external_images) > 0:
@@ -566,10 +567,10 @@ def file_reader(
             imgs.append(file_reader(e)[0])
         for i, signal in enumerate(imgs):
             _logger.debug(f"Adding external image _sig_external_image_{i}")
-            if virtual_image_names and i < len(virtual_image_names):
-                name = f"_sig_{virtual_image_names[i]}"
+            if external_images_names and i < len(external_images_names):
+                name = f"_sig_{external_images_names[i]}"
             else:
-                name = f"_sig_external_image_{i}" # _sig_ is dropped in hyperspy. List  --> BaseSignal
+                name = f"_sig_external_image_{i}"  # _sig_ is dropped in hyperspy. List  --> BaseSignal
 
             metadata["_HyperSpy"]["navigators"][name] = signal
 

--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -530,7 +530,8 @@ def file_reader(
         positions = None
     metadata["General"]["original_filename"] = os.path.split(filename)[1]
     metadata["Signal"]["signal_type"] = ""
-    metadata["General"]["virtual_images"] = {}
+    metadata["_HyperSpy"] = {}
+    metadata["_HyperSpy"]["navigators"] = {}
     if virtual_images is not None and len(virtual_images) > 0:
         imgs = []
         for i, v in enumerate(virtual_images):
@@ -544,13 +545,13 @@ def file_reader(
                         f"Virtual image {v} does not match the navigation shape {navigation_shape[::-1]}"
                     )
             imgs.append(signal)
-            _logger.debug(f"Adding virtual image _sig_image_{i}")
+            _logger.debug(f"Adding virtual image _sig_virtual_image_{i}")
 
             if virtual_image_names and i < len(virtual_image_names):
                 name = f"_sig_{virtual_image_names[i]}"
             else:
-                name = f"_sig_Virt_{i}"
-            metadata["General"]["virtual_images"][name] = signal
+                name = f"_sig_virtual_image_{i}" # _sig_ is dropped in hyperspy. List  --> BaseSignal
+            metadata["_HyperSpy"]["navigators"][name] = signal
         # checking to make sure the navigator is valid
         if (
             navigation_shape is not None
@@ -561,17 +562,16 @@ def file_reader(
 
     if external_images is not None and len(external_images) > 0:
         imgs = []
-        metadata["General"]["external_images"] = {}
         for e in external_images:
             imgs.append(file_reader(e)[0])
         for i, signal in enumerate(imgs):
-            _logger.debug(f"Adding external image _sig_ext_{i}")
+            _logger.debug(f"Adding external image _sig_external_image_{i}")
             if virtual_image_names and i < len(virtual_image_names):
                 name = f"_sig_{virtual_image_names[i]}"
             else:
-                name = f"_sig_Virt_{i}"
+                name = f"_sig_external_image_{i}" # _sig_ is dropped in hyperspy. List  --> BaseSignal
 
-            metadata["General"]["external_images"][name] = signal
+            metadata["_HyperSpy"]["navigators"][name] = signal
 
     f = open(filename, "rb")
     std_header = np.fromfile(f, dtype=get_std_dtype_list(endianness), count=1)

--- a/rsciio/mrc/_api.py
+++ b/rsciio/mrc/_api.py
@@ -23,6 +23,7 @@
 import glob
 import logging
 import os
+import re
 
 import numpy as np
 
@@ -43,6 +44,129 @@ from rsciio.utils._deprecated import (
 )
 
 _logger = logging.getLogger(__name__)
+
+# Regex to parse movie files: YYYYMMDD_acq[_optionalSuffix][_optionalMovieNum]_movie.mrc
+MOVIE_RE = re.compile(
+    r"^(?P<timestamp>\d{8})_"
+    r"(?P<acquisitionNumber>\d+)"
+    r"(?:_(?P<optionalSuffix>.+?))?"
+    r"(?:_(?P<movieNum>\d+))?_movie\.mrc$"
+)
+
+# Regex to parse virtual images:
+# YYYYMMDD_acq[_optionalSuffix]_virtualImageNum_name_calculationType.mrc
+# Example: 20251103_23389_3_CentroidAmp_centroid_amplitude.mrc
+VIRTUAL_RE = re.compile(
+    r"^(?P<timestamp>\d{8})_"
+    r"(?P<acquisitionNumber>\d+)"
+    r"(?:_(?P<optionalSuffix>.+?))?"
+    r"_(?P<virtualImageNum>(?:\d+|virt\d+))_"
+    r"(?P<name>[^_]+)_"
+    r"(?P<calculationType>[^.]+)\.mrc$"
+)
+
+
+def find_related_de_files(movie_filename: str):
+    """
+    Given a DE movie filename, find related files:
+    - info_file: `YYYYMMDD_acq[_optionalSuffix]_info.txt`
+    - virtual_images: `YYYYMMDD_acq[_optionalSuffix]_virtualImageNum_name_calculationType.mrc`
+                      (virtualImageNum supports '<digits>' or 'virt<digits>')
+    - external_images: `YYYYMMDD_acq[_optionalSuffix]_ext<#>[_Name].mrc`
+    - scan_csv: `YYYYMMDD_acq[_optionalSuffix]_scan_coordinates.csv`
+    Returns a dict including a deduplicated list of virtual image names.
+    """
+    dir_name = os.path.dirname(movie_filename) or "."
+    base_name = os.path.basename(movie_filename)
+
+    # Parse timestamp and acquisitionNumber from the movie name
+    m = MOVIE_RE.fullmatch(base_name)
+    if m:
+        ts = m.group("timestamp")
+        acq = m.group("acquisitionNumber")
+    else:
+        return {
+            "info_file": None,
+            "virtual_images": [],
+            "virtual_image_names": [],
+            "external_images": [],
+            "scan_csv": None,
+        }
+    prefix = f"{ts}_{acq}_"
+
+    # Utilities
+    def _first_or_none(paths):
+        return sorted(paths)[0] if paths else None
+
+    def _dedupe(seq):
+        seen = {}
+        out = []
+        for x in seq:
+            if x not in seen:
+                seen[x] = 1
+                out.append(x)
+            else:
+                count = seen[x]
+                new_name = f"{x}_{count}"
+                while new_name in seen:
+                    count += 1
+                    new_name = f"{x}_{count}"
+                seen[x] = count + 1
+                seen[new_name] = 1
+                out.append(new_name)
+        return out
+
+    # Collect all candidate .mrc files sharing the same timestamp and acquisitionNumber
+    all_mrc = glob.glob(os.path.join(dir_name, f"{prefix}*.mrc"))
+
+    # Virtual images via regex (supports '<digits>' and 'virt<digits>')
+    virtual_images = []
+    virtual_image_names = []
+    for p in all_mrc:
+        name = os.path.basename(p)
+        if name.endswith("_movie.mrc"):
+            continue
+        mv = VIRTUAL_RE.fullmatch(name)
+        if mv:
+            virtual_images.append(p)
+            virtual_image_names.append(mv.group("name"))
+
+    virtual_image_names = _dedupe(virtual_image_names)
+
+    # External detector images (e.g., _ext3.mrc or _ext3_Name.mrc)
+    ext_re = re.compile(
+        rf"^{re.escape(ts)}_{re.escape(acq)}_(?:.+?_)?ext(?P<num>\d+)(?:_(?P<name>[^.]+))?\.mrc$"
+    )
+    external_images = []
+    external_image_names = []
+    for p in all_mrc:
+        fname = os.path.basename(p)
+        mext = ext_re.fullmatch(fname)
+        if mext:
+            external_images.append(p)
+            ext_name = mext.group("name") or f"ext{mext.group('num')}"
+            external_image_names.append(ext_name)
+    external_image_names = _dedupe(external_image_names)
+    # Info file
+    info_file = _first_or_none(
+        glob.glob(os.path.join(dir_name, f"{prefix}info.txt"))
+        + glob.glob(os.path.join(dir_name, f"{prefix}*_info.txt"))
+    )
+
+    # Scan coordinates CSV
+    scan_csv = _first_or_none(
+        glob.glob(os.path.join(dir_name, f"{prefix}scan_coordinates.csv"))
+        + glob.glob(os.path.join(dir_name, f"{prefix}*_scan_coordinates.csv"))
+    )
+
+    return {
+        "info_file": info_file,
+        "virtual_images": sorted(virtual_images),
+        "virtual_image_names": virtual_image_names,
+        "external_images": sorted(external_images),
+        "external_image_names": external_image_names,
+        "scan_csv": scan_csv,
+    }
 
 
 def get_std_dtype_list(endianness="<"):
@@ -127,7 +251,7 @@ def get_fei_dtype_list(endianness="<"):
 
 def get_data_type(mode):
     mode_to_dtype = {
-        0: np.int8,
+        0: np.uint8,
         1: np.int16,
         2: np.float32,
         4: np.complex64,
@@ -294,6 +418,8 @@ def read_de_metadata_file(filename, nav_shape=None, scan_pos_file=None):
     ind = 0
     for i, s in enumerate(axes_shapes):
         if s != 1:
+            if axes_scales[i] == -1:
+                axes_scales[i] = 1
             axes.append(
                 {
                     "name": axes_names[i],
@@ -367,51 +493,19 @@ def file_reader(
 
     %s
     """
+    virtual_image_names = None
+    external_images_names = None
+
     if metadata_file == "auto":
         if "movie" in filename:
-            try:  # DE movie
-                dir_name = os.path.dirname(filename)
-                base_name = os.path.basename(filename)
-                split = base_name.split("_")
-                unique_id = "_".join(split[:2])
-                if len(split) > 3:  # File Suffix
-                    suffix = "_".join(split[2:-1])
-                else:
-                    suffix = ""
-                if len(dir_name) == 0:
-                    dir_name = "."
-                metadata = glob.glob(dir_name + "/" + unique_id + suffix + "*_info.txt")
-                virtual_images = [
-                    p
-                    for p in glob.glob(dir_name + "/" + unique_id + suffix + "*_[0-4]_*.mrc")
-                    if "movie" not in os.path.basename(p).lower()
-                ]
-                virtual_images_old = glob.glob(
-                    dir_name + "/" + unique_id + suffix + "_virt[0-4]_*.mrc"
-                )
-                virtual_images += virtual_images_old
-
-                external_images = glob.glob(
-                    dir_name + "/" + unique_id + suffix + "_ext[1-4]_*.mrc"
-                )
-            except IndexError:  # pragma: no cover
-                # Not a DE movie or File Naming Convention is not followed
-                _logger.warning("Could not find metadata file for DE movie.")
-                metadata = []
-            try:
-                scan_file = glob.glob(
-                    f"{dir_name}/{unique_id}_{suffix}*coordinates.csv"
-                )[0]
-            except IndexError:
-                _logger.warning(
-                    f"Could not find scan file [{dir_name}/{unique_id}_{suffix}*_coordinates.csv]"
-                    f" for DE movie {filename}."
-                )
-                scan_file = None
-        else:
-            metadata = []
-        if len(metadata) == 1:
-            metadata_file = metadata[0]
+            info = find_related_de_files(filename)
+            # Populate from related DE files helper
+            metadata_file = info.get("info_file")
+            virtual_images = info.get("virtual_images") or []
+            virtual_image_names = info.get("virtual_image_names") or []
+            external_images = info.get("external_images") or []
+            scan_file = info.get("scan_csv")
+            external_images_names = info.get("external_image_names") or []
         else:
             metadata_file = None
 
@@ -450,19 +544,34 @@ def file_reader(
                         f"Virtual image {v} does not match the navigation shape {navigation_shape[::-1]}"
                     )
             imgs.append(signal)
-            print(f"Adding virtual image _sig_image_{i}")
-            metadata["General"]["virtual_images"][f"_sig_image_{i}"] = signal
-            print(metadata["General"]["virtual_images"])
+            _logger.debug(f"Adding virtual image _sig_image_{i}")
+
+            if virtual_image_names and i < len(virtual_image_names):
+                name = f"_sig_{virtual_image_names[i]}"
+            else:
+                name = f"_sig_Virt_{i}"
+            metadata["General"]["virtual_images"][name] = signal
         # checking to make sure the navigator is valid
-        if navigation_shape is not None and navigation_shape[::-1] == imgs[0]["data"].shape:
+        if (
+            navigation_shape is not None
+            and navigation_shape[::-1] == imgs[0]["data"].shape
+        ):
             metadata["_HyperSpy"] = {}
             metadata["_HyperSpy"]["_sig_navigator"] = imgs[0]
 
     if external_images is not None and len(external_images) > 0:
         imgs = []
+        metadata["General"]["external_images"] = {}
         for e in external_images:
-            imgs.append(file_reader(e)[0]["data"])
-        metadata["General"]["external_detectors"] = imgs
+            imgs.append(file_reader(e)[0])
+        for i, signal in enumerate(imgs):
+            _logger.debug(f"Adding external image _sig_ext_{i}")
+            if virtual_image_names and i < len(virtual_image_names):
+                name = f"_sig_{virtual_image_names[i]}"
+            else:
+                name = f"_sig_Virt_{i}"
+
+            metadata["General"]["external_images"][name] = signal
 
     f = open(filename, "rb")
     std_header = np.fromfile(f, dtype=get_std_dtype_list(endianness), count=1)

--- a/rsciio/tests/test_mrc.py
+++ b/rsciio/tests/test_mrc.py
@@ -139,8 +139,9 @@ def test_mrc_metadata_auto():
     assert s.metadata.Acquisition_instrument.TEM.detector == "DESim"
     assert s.metadata.Acquisition_instrument.TEM.magnification == "1000"
     assert s.metadata.Acquisition_instrument.TEM.frames_per_second == "700"
-    assert len(s.metadata.General.virtual_images) == 2
+    assert len(s.metadata.General.virtual_images.keys()) == 2
     assert len(s.metadata.General.external_detectors) == 1
+    assert isinstance(s.metadata.General.virtual_images.image_0, hs.signals.Signal2D)
 
     assert s.metadata._HyperSpy.navigator is not None
 

--- a/rsciio/tests/test_mrc.py
+++ b/rsciio/tests/test_mrc.py
@@ -22,6 +22,12 @@ import pytest
 
 from rsciio.exceptions import VisibleDeprecationWarning
 from rsciio.mrc import file_reader
+from rsciio.mrc._api import (
+    MOVIE_RE,
+    VIRTUAL_RE,
+    find_related_de_files,
+    get_data_type,
+)
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
 
@@ -140,8 +146,8 @@ def test_mrc_metadata_auto():
     assert s.metadata.Acquisition_instrument.TEM.magnification == "1000"
     assert s.metadata.Acquisition_instrument.TEM.frames_per_second == "700"
     assert len(s.metadata.General.virtual_images.keys()) == 2
-    assert len(s.metadata.General.external_detectors) == 1
-    assert isinstance(s.metadata.General.virtual_images.image_0, hs.signals.Signal2D)
+    assert len(s.metadata.General.external_images.keys()) == 1
+    assert isinstance(s.metadata.General.virtual_images["Virt 0"], hs.signals.Signal2D)
 
     assert s.metadata._HyperSpy.navigator is not None
 
@@ -165,10 +171,12 @@ def test_mrc_metadata_auto_custom_shape():
     assert s.metadata.Acquisition_instrument.TEM.magnification == "1000"
     assert s.metadata.Acquisition_instrument.TEM.frames_per_second == "700"
     assert len(s.metadata.General.virtual_images) == 2
-    assert len(s.metadata.General.external_detectors) == 1
+    assert len(s.metadata.General.external_images) == 1
 
     assert s.metadata._HyperSpy.navigator is not None
-    assert s.metadata._HyperSpy.navigator.shape == navigation_shape[::-1]
+    assert s.metadata._HyperSpy.navigator.data.shape == navigation_shape[::-1]
+
+    assert isinstance(s.metadata._HyperSpy.navigator, hs.signals.BaseSignal)
 
     shape = (
         s.axes_manager._navigation_shape_in_array
@@ -238,3 +246,205 @@ def test_repeated_mrc_custom_no_scan_file():
             TEST_DATA_DIR / "Custom_movie.mrc",
             metadata_file=TEST_DATA_DIR / "Custom_info.txt",
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for new PR code: regex patterns, find_related_de_files, uint8 mode 0
+# ---------------------------------------------------------------------------
+
+
+class TestMovieRegex:
+    """Tests for the MOVIE_RE regex pattern."""
+
+    @pytest.mark.parametrize(
+        "filename, expected",
+        [
+            (
+                "20241021_00405_movie.mrc",
+                {
+                    "timestamp": "20241021",
+                    "acquisitionNumber": "00405",
+                    "optionalSuffix": None,
+                    "movieNum": None,
+                },
+            ),
+            (
+                "20241021_00405_suffix_movie.mrc",
+                {
+                    "timestamp": "20241021",
+                    "acquisitionNumber": "00405",
+                    "optionalSuffix": "suffix",
+                    "movieNum": None,
+                },
+            ),
+            (
+                "20241021_00405_suffix_extra_movie.mrc",
+                {
+                    "timestamp": "20241021",
+                    "acquisitionNumber": "00405",
+                    "optionalSuffix": "suffix_extra",
+                    "movieNum": None,
+                },
+            ),
+        ],
+    )
+    def test_movie_re_matches(self, filename, expected):
+        m = MOVIE_RE.fullmatch(filename)
+        assert m is not None
+        for key, val in expected.items():
+            assert m.group(key) == val
+
+    def test_movie_re_no_match(self):
+        assert MOVIE_RE.fullmatch("20241021_00405_info.txt") is None
+        assert MOVIE_RE.fullmatch("not_a_movie.mrc") is None
+        assert MOVIE_RE.fullmatch("20241021_00405_0_Virt 0_sum.mrc") is None
+
+
+class TestVirtualRegex:
+    """Tests for the VIRTUAL_RE regex pattern."""
+
+    @pytest.mark.parametrize(
+        "filename, expected_name, expected_calc",
+        [
+            ("20241021_00405_0_Virt 0_sum.mrc", "Virt 0", "sum"),
+            ("20241021_00405_1_Virt 1_sum.mrc", "Virt 1", "sum"),
+            (
+                "20251103_23389_3_CentroidAmp_centroid_amplitude.mrc",
+                "CentroidAmp",
+                "centroid_amplitude",
+            ),
+        ],
+    )
+    def test_virtual_re_matches(self, filename, expected_name, expected_calc):
+        m = VIRTUAL_RE.fullmatch(filename)
+        assert m is not None, f"VIRTUAL_RE should match {filename!r}"
+        assert m.group("name") == expected_name
+        assert m.group("calculationType") == expected_calc
+
+    def test_virtual_re_no_match_movie(self):
+        assert VIRTUAL_RE.fullmatch("20241021_00405_movie.mrc") is None
+
+    def test_virtual_re_virt_prefix(self):
+        # virtualImageNum with 'virt<digits>' prefix should also match
+        m = VIRTUAL_RE.fullmatch("20241021_00405_virt0_BF_sum.mrc")
+        assert m is not None
+        assert m.group("virtualImageNum") == "virt0"
+        assert m.group("name") == "BF"
+
+
+class TestGetDataType:
+    """Tests for the get_data_type function."""
+
+    def test_mode_0_is_uint8(self):
+        dtype = get_data_type(np.array([0]))
+        assert dtype == np.dtype(np.uint8)
+
+    def test_mode_1_is_int16(self):
+        assert get_data_type(np.array([1])) == np.dtype(np.int16)
+
+    def test_mode_2_is_float32(self):
+        assert get_data_type(np.array([2])) == np.dtype(np.float32)
+
+    def test_mode_6_is_uint16(self):
+        assert get_data_type(np.array([6])) == np.dtype(np.uint16)
+
+    def test_mode_12_is_float16(self):
+        assert get_data_type(np.array([12])) == np.dtype(np.float16)
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Unrecognised mode"):
+            get_data_type(np.array([99]))
+
+
+class TestFindRelatedDeFiles:
+    """Tests for find_related_de_files."""
+
+    def test_find_related_de_files_basic(self):
+        movie = str(TEST_DATA_DIR / "20241021_00405_movie.mrc")
+        result = find_related_de_files(movie)
+
+        assert result["info_file"] is not None
+        assert "20241021_00405_info.txt" in result["info_file"]
+
+        assert len(result["virtual_images"]) == 2
+        assert len(result["virtual_image_names"]) == 2
+        assert "Virt 0" in result["virtual_image_names"]
+        assert "Virt 1" in result["virtual_image_names"]
+
+        assert len(result["external_images"]) == 1
+        assert len(result["external_image_names"]) == 1
+        assert "Ext 1" in result["external_image_names"]
+
+        # scan CSV is not present for this dataset
+        assert result["scan_csv"] is None
+
+    def test_find_related_de_files_non_movie_name(self):
+        """Non-matching filenames should return empty result."""
+        result = find_related_de_files("not_a_real_movie_file.mrc")
+        assert result["info_file"] is None
+        assert result["virtual_images"] == []
+        assert result["virtual_image_names"] == []
+        assert result["external_images"] == []
+        assert result["scan_csv"] is None
+
+    def test_find_related_de_files_virtual_images_sorted(self):
+        """Virtual image list should be sorted."""
+        movie = str(TEST_DATA_DIR / "20241021_00405_movie.mrc")
+        result = find_related_de_files(movie)
+        assert result["virtual_images"] == sorted(result["virtual_images"])
+
+    def test_find_related_de_files_dedupe(self, tmp_path):
+        """_dedupe should rename duplicate virtual image names."""
+        import shutil
+
+        # Create a minimal movie file and two virtual images with the same name
+        src_movie = TEST_DATA_DIR / "20241021_00405_movie.mrc"
+        ts = "20260101"
+        acq = "99999"
+        movie = tmp_path / f"{ts}_{acq}_movie.mrc"
+        shutil.copy(src_movie, movie)
+        v0 = tmp_path / f"{ts}_{acq}_0_BF_sum.mrc"
+        v1 = tmp_path / f"{ts}_{acq}_1_BF_sum.mrc"
+        shutil.copy(src_movie, v0)
+        shutil.copy(src_movie, v1)
+        # Create a dummy info file
+        (tmp_path / f"{ts}_{acq}_info.txt").write_text("Camera Model = TestCamera\n")
+
+        result = find_related_de_files(str(movie))
+        names = result["virtual_image_names"]
+        assert len(names) == 2
+        # First occurrence keeps the name, second gets a suffix
+        assert names[0] == "BF"
+        assert names[1] != "BF"
+        assert names[1].startswith("BF")
+
+
+class TestMetadataVirtualImageNames:
+    """Test that virtual and external image names appear correctly in loaded signal metadata."""
+
+    def test_virtual_image_names_in_metadata(self):
+        s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
+        # HyperSpy stores _sig_* keys and exposes them without the prefix as signals
+        keys = list(s.metadata.General.virtual_images.as_dictionary().keys())
+        assert "_sig_Virt 0" in keys
+        assert "_sig_Virt 1" in keys
+        # Accessible via HyperSpy attribute (prefix stripped)
+        assert "Virt 0" in s.metadata.General.virtual_images
+
+    def test_external_image_names_in_metadata(self):
+        s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
+        ext_keys = list(s.metadata.General.external_images.as_dictionary().keys())
+        assert len(ext_keys) == 1
+        # Key stored with _sig_ prefix
+        assert ext_keys[0] == "_sig_Ext 1"
+        # Accessible via HyperSpy attribute (prefix stripped)
+        assert "Ext 1" in s.metadata.General.external_images
+
+    def test_navigator_is_signal(self):
+        s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
+        assert isinstance(s.metadata._HyperSpy.navigator, hs.signals.BaseSignal)
+
+    def test_virtual_image_is_signal2d(self):
+        s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
+        virt = s.metadata.General.virtual_images["Virt 0"]
+        assert isinstance(virt, hs.signals.Signal2D)

--- a/rsciio/tests/test_mrc.py
+++ b/rsciio/tests/test_mrc.py
@@ -145,9 +145,8 @@ def test_mrc_metadata_auto():
     assert s.metadata.Acquisition_instrument.TEM.detector == "DESim"
     assert s.metadata.Acquisition_instrument.TEM.magnification == "1000"
     assert s.metadata.Acquisition_instrument.TEM.frames_per_second == "700"
-    assert len(s.metadata.General.virtual_images.keys()) == 2
-    assert len(s.metadata.General.external_images.keys()) == 1
-    assert isinstance(s.metadata.General.virtual_images["Virt 0"], hs.signals.Signal2D)
+    assert len(s.metadata._HyperSpy.navigators.keys()) == 3
+    assert isinstance(s.metadata._HyperSpy.navigators["Virt 0"], hs.signals.Signal2D)
 
     assert s.metadata._HyperSpy.navigator is not None
 
@@ -170,8 +169,7 @@ def test_mrc_metadata_auto_custom_shape():
     assert s.metadata.Acquisition_instrument.TEM.detector == "DESim"
     assert s.metadata.Acquisition_instrument.TEM.magnification == "1000"
     assert s.metadata.Acquisition_instrument.TEM.frames_per_second == "700"
-    assert len(s.metadata.General.virtual_images) == 2
-    assert len(s.metadata.General.external_images) == 1
+    assert len(s.metadata._HyperSpy.navigators) == 3
 
     assert s.metadata._HyperSpy.navigator is not None
     assert s.metadata._HyperSpy.navigator.data.shape == navigation_shape[::-1]
@@ -425,20 +423,21 @@ class TestMetadataVirtualImageNames:
     def test_virtual_image_names_in_metadata(self):
         s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
         # HyperSpy stores _sig_* keys and exposes them without the prefix as signals
-        keys = list(s.metadata.General.virtual_images.as_dictionary().keys())
+        keys = list(s.metadata._HyperSpy.navigators.as_dictionary().keys())
         assert "_sig_Virt 0" in keys
         assert "_sig_Virt 1" in keys
         # Accessible via HyperSpy attribute (prefix stripped)
-        assert "Virt 0" in s.metadata.General.virtual_images
+        assert "Virt 0" in s.metadata._HyperSpy.navigators
 
     def test_external_image_names_in_metadata(self):
         s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
-        ext_keys = list(s.metadata.General.external_images.as_dictionary().keys())
-        assert len(ext_keys) == 1
-        # Key stored with _sig_ prefix
-        assert ext_keys[0] == "_sig_Ext 1"
+        nav_keys = list(s.metadata._HyperSpy.navigators.as_dictionary().keys())
+        # 2 virtual + 1 external = 3 navigators total
+        assert len(nav_keys) == 3
+        # External key stored with _sig_ prefix
+        assert "_sig_Ext 1" in nav_keys
         # Accessible via HyperSpy attribute (prefix stripped)
-        assert "Ext 1" in s.metadata.General.external_images
+        assert "Ext 1" in s.metadata._HyperSpy.navigators
 
     def test_navigator_is_signal(self):
         s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
@@ -446,5 +445,5 @@ class TestMetadataVirtualImageNames:
 
     def test_virtual_image_is_signal2d(self):
         s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
-        virt = s.metadata.General.virtual_images["Virt 0"]
+        virt = s.metadata._HyperSpy.navigators["Virt 0"]
         assert isinstance(virt, hs.signals.Signal2D)

--- a/rsciio/tests/test_mrc.py
+++ b/rsciio/tests/test_mrc.py
@@ -17,6 +17,7 @@
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 from pathlib import Path
 
+import importlib.util
 import numpy as np
 import pytest
 
@@ -30,6 +31,7 @@ from rsciio.mrc._api import (
 )
 
 hs = pytest.importorskip("hyperspy.api", reason="hyperspy not installed")
+zarr_missing = importlib.util.find_spec("zarr") is None
 
 
 TEST_DATA_DIR = Path(__file__).parent / "data" / "mrc"
@@ -447,3 +449,59 @@ class TestMetadataVirtualImageNames:
         s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
         virt = s.metadata._HyperSpy.navigators["Virt 0"]
         assert isinstance(virt, hs.signals.Signal2D)
+
+
+@pytest.mark.skipif(zarr_missing, reason="zarr not installed")
+class TestLoadSave:
+    @pytest.mark.parametrize(
+        "metadata_file",
+        [
+            TEST_DATA_DIR / "3DSTEM_scan_info.txt",
+            TEST_DATA_DIR / "3DTEM_scan_info.txt",
+            TEST_DATA_DIR / "3DTEMDiffracting_scan_info.txt",
+        ],
+    )
+    def test_mrc_metadata_save(self, metadata_file, tmp_path):
+        """Saving an MRC-loaded signal to zspy should not raise a
+        JSON-serialization error for numpy.void / bytes header fields."""
+        s = hs.load(
+            TEST_DATA_DIR / "20241021_00405_movie.mrc", metadata_file=metadata_file
+        )
+        diffracting = (
+            "STEM" in metadata_file.name or "Diffracting" in metadata_file.name
+        )
+        s.axes_manager.navigation_axes[0].units = "sec"
+        if diffracting:
+            s.axes_manager.signal_axes[0].units = "nm^-1"
+            s.axes_manager.signal_axes[1].units = "nm^-1"
+        else:
+            s.axes_manager.signal_axes[0].units = "nm"
+            s.axes_manager.signal_axes[1].units = "nm"
+
+        out = tmp_path / "out.zspy"
+        # Must not raise TypeError: Object of type void is not JSON serializable
+        s.save(str(out))
+
+    def test_mrc_void_header_fields_are_hex_strings(self):
+        """numpy.void and bytes fields in the MRC header (EXTRA, EXTRA2,
+        CMAP, STAMP, LABELS) must be stored as plain hex strings, not raw
+        numpy/bytes objects, so they can be JSON-serialized (e.g. for zspy)."""
+        s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc")
+        std_header = s.original_metadata.std_header
+        for field in ("EXTRA", "EXTRA2", "CMAP", "STAMP", "LABELS"):
+            value = std_header[field]
+            assert isinstance(
+                value, str
+            ), f"Header field '{field}' should be a hex string, got {type(value)}"
+            # Must be a valid hex string
+            bytes.fromhex(value)
+
+    def test_mrc_save_reload_zspy(self, tmp_path):
+        """Round-trip: load MRC, save to zspy, reload – data and key metadata
+        should be preserved, and no serialization errors should occur."""
+        zarr = pytest.importorskip("zarr", reason="zarr not installed")  # noqa: F841
+        s = hs.load(TEST_DATA_DIR / "20241021_00405_movie.mrc", lazy=True)
+        out = tmp_path / "round_trip.zspy"
+        s.save(str(out))
+        s2 = hs.load(str(out))
+        np.testing.assert_array_equal(s.data.compute(), s2.data)

--- a/rsciio/tests/test_mrc.py
+++ b/rsciio/tests/test_mrc.py
@@ -15,9 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
+import importlib.util
 from pathlib import Path
 
-import importlib.util
 import numpy as np
 import pytest
 
@@ -490,9 +490,9 @@ class TestLoadSave:
         std_header = s.original_metadata.std_header
         for field in ("EXTRA", "EXTRA2", "CMAP", "STAMP", "LABELS"):
             value = std_header[field]
-            assert isinstance(
-                value, str
-            ), f"Header field '{field}' should be a hex string, got {type(value)}"
+            assert isinstance(value, str), (
+                f"Header field '{field}' should be a hex string, got {type(value)}"
+            )
             # Must be a valid hex string
             bytes.fromhex(value)
 

--- a/rsciio/utils/_array.py
+++ b/rsciio/utils/_array.py
@@ -39,7 +39,8 @@ def sarray2dict(sarray, dictionary=None):
     if dictionary is None:
         dictionary = OrderedDict()
     for name in sarray.dtype.names:
-        dictionary[name] = sarray[name][0] if len(sarray[name]) == 1 else sarray[name]
+        value = sarray[name][0] if len(sarray[name]) == 1 else sarray[name]
+        dictionary[name] = value
     return dictionary
 
 

--- a/upcoming_changes/515.enhancements.rst
+++ b/upcoming_changes/515.enhancements.rst
@@ -1,0 +1,4 @@
+Improve MRC file reader: add support for loading virtual and external images
+as HyperSpy navigators, with regex-based discovery of related files and
+streamlined metadata structure.
+


### PR DESCRIPTION
This pull request significantly refactors and improves the handling and parsing of DE movie and related files in the `rsciio.mrc` module. The main changes include the introduction of robust regex-based filename parsing, a new utility function to gather related files, and a reorganization of how virtual and external images are loaded and stored in metadata. These updates make the code more maintainable, extensible, and accurate in handling various file naming conventions.

**Improvements to DE file handling and metadata extraction:**

* Added regular expressions (`MOVIE_RE`, `VIRTUAL_RE`) to robustly parse DE movie and virtual image filenames, supporting multiple naming conventions.
* Introduced the `find_related_de_files` function to reliably discover and deduplicate related info files, virtual images, external images, and scan CSVs associated with a DE movie file.
* Refactored the `file_reader` function to use `find_related_de_files`, improving reliability and simplifying logic for finding metadata, virtual, and external images.
