### PR TITLE
Add `https://microscopy.org` to ignore link check list

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,6 +142,7 @@ linkcheck_ignore = [
     "https://zenodo.org",  # 403 Client Error: Forbidden for url
     "https://doi.org/10.5281/zenodo",  # resolves to zenodo.org, also blocked
     "https://www.tofwerk.com/software/tofdaq",  # 403 blocked
+    "https://microscopy.org",  # Time out, Max retries exceeded with url
 ]
 
 # https://github.com/sphinx-doc/sphinx/issues/12589#issuecomment-2229491106


### PR DESCRIPTION
The link to https://microscopy.org are failing consistently since a few weeks and the links are correct.
