### PR TITLE
Parsing scan sizes of EMPAD data

### DIFF
--- a/rsciio/empad/_api.py
+++ b/rsciio/empad/_api.py
@@ -80,16 +80,20 @@ def _parse_xml(filename):
     elif om.has_item("root.pix_x") and om.has_item("root.pix_y"):
         # 2D x 2D
         info.update({"scan_x": int(om.root.pix_x), "scan_y": int(om.root.pix_y)})
-    # in case root.pix_x and root.pix_y are not available
-    elif om.has_item("root.scan_parameters.scan_resolution_x") and om.has_item(
-        "root.scan_parameters.scan_resolution_y"
-    ):
-        info.update(
-            {
-                "scan_x": int(om.root.scan_parameters.scan_resolution_x),
-                "scan_y": int(om.root.scan_parameters.scan_resolution_y),
-            }
-        )
+    # in case root.pix_x and root.pix_y are not available, parse from the raw_file name
+    elif om.has_item("root.raw_file.filename"):
+        raw_filename = om.root.raw_file.filename
+        # The raw filename is in the format of "scan_xxx_yxx.raw", where xx is the scan size in x and y direction.
+        if raw_filename.startswith("scan_"):
+            try:
+                basename = raw_filename.split(".")[0]
+                scan_x = int(basename.split("_")[-2][1:])
+                scan_y = int(basename.split("_")[-1][1:])
+                info.update({"scan_x": scan_x, "scan_y": scan_y})
+            except Exception:
+                raise IOError(
+                    "Unsupported Empad file: the scan parameters cannot be imported."
+                )
     else:
         raise IOError("Unsupported Empad file: the scan parameters cannot be imported.")
 

--- a/rsciio/tests/test_empad.py
+++ b/rsciio/tests/test_empad.py
@@ -79,7 +79,9 @@ def test_read_stack(lazy):
     np.testing.assert_allclose(s.data, ref_data.astype("float32"))
     signal_axes = s.axes_manager.signal_axes
     assert signal_axes[0].name == "width"
+    assert signal_axes[0].size == 128
     assert signal_axes[1].name == "height"
+    assert signal_axes[1].size == 128
     for axis in signal_axes:
         units = EXPECTED_UNSPECIFIED_UNITS
         assert axis.units == units
@@ -135,8 +137,10 @@ def test_read_map_1_2_2(lazy, q_calibration):
     signal_axes = s.axes_manager.signal_axes
     assert signal_axes[0].name == "width"
     assert signal_axes[0].index_in_array == 3
+    assert signal_axes[0].size == 128
     assert signal_axes[1].name == "height"
     assert signal_axes[1].index_in_array == 2
+    assert signal_axes[1].size == 128
 
     for axis in signal_axes:
         if q_calibration is not None:
@@ -150,8 +154,10 @@ def test_read_map_1_2_2(lazy, q_calibration):
     navigation_axes = s.axes_manager.navigation_axes
     assert navigation_axes[0].name == "scan_x"
     assert navigation_axes[0].index_in_array == 1
+    assert navigation_axes[0].size == 32
     assert navigation_axes[1].name == "scan_y"
     assert navigation_axes[1].index_in_array == 0
+    assert navigation_axes[1].size == 64
     for axis in navigation_axes:
         assert axis.units == "nm"
         np.testing.assert_allclose(axis.scale, 27.6131150)

--- a/upcoming_changes/513.bugfix.rst
+++ b/upcoming_changes/513.bugfix.rst
@@ -1,0 +1,1 @@
+Modified empad reader to parse scan sizes from the raw file name following the pattern "scan_xaaa_ybbb.raw", where "aaa" and "bbb" represent the scan sizes in the x and y dimensions, respectively.


### PR DESCRIPTION
For issue #513 
### Description of the change
Modified the parsing logic for the scan sizes. Now the reader looks for the raw file name with a pattern of "scan_xaaa_ybbb.raw", in which the "aaa" and "bbb" are the scan sizes for x and y, respectively. All tests passed.

The reason for this change:

The EMPAD metadata (xml) saves two sets of scan parameters tagged "search" and "acquire" with the exactly same keys. When _parse_xml reads these keys it does not distinguish the different tags so the "search" keys are overwritten by the "acquire" keys. The original logic reads the scan sizes from these keys. Therefore, the parsed scan sizes are always from the "acquire" parameters. This may work most of the time because users usually use "acquire" to take the datasets. However, it will fail if the actual dataset has been taken with the "search" parameters (which the current EMPAD GUI does not forbid you to). On the other hand, at least up to the current version of EMPAD GUI v1.2.2 the raw file name is always in the pattern of "scan_xaaa_ybbb.raw". So this should be a safer way to parse the scan sizes.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.
