### PR TITLE
feat(zspy): consolidate metadata for cloud-optimized I/O

### DIFF
--- a/rsciio/tests/test_zspy.py
+++ b/rsciio/tests/test_zspy.py
@@ -293,3 +293,101 @@ def test_save_store_error(tmp_path):
         ValueError, match="The `store_type` parameter must be None if a zarr "
     ):
         s.save(filename=store, store_type="zip")
+
+
+class TestConsolidateMetadata:
+    """Tests for consolidated metadata in ZSPY files."""
+
+    @pytest.fixture
+    def signal(self):
+        data = np.ones((10, 10, 10, 10))
+        s = hs.signals.Signal1D(data)
+        s.metadata.General.title = "test consolidate metadata"
+        return s
+
+    def test_consolidate_default_creates_zmetadata(self, signal, tmp_path):
+        """consolidate=True (default) creates .zmetadata in the store."""
+        filename = tmp_path / "test_consolidate_default.zspy"
+        store = zarr.ZipStore(path=filename)
+        signal.save(store)
+        # zarr.open() auto-detects consolidated metadata
+        # but we verify .zmetadata exists in the store
+        assert ".zmetadata" in store
+
+    def test_consolidate_false_no_zmetadata(self, signal, tmp_path):
+        """consolidate=False does NOT create .zmetadata."""
+        filename = tmp_path / "test_consolidate_false.zspy"
+        store = zarr.ZipStore(path=filename)
+        signal.save(store, consolidate=False)
+        assert ".zmetadata" not in store
+
+    def test_consolidate_explicit_true(self, signal, tmp_path):
+        """consolidate=True explicitly creates .zmetadata."""
+        filename = tmp_path / "test_consolidate_explicit.zspy"
+        store = zarr.ZipStore(path=filename)
+        signal.save(store, consolidate=True)
+        assert ".zmetadata" in store
+
+    def test_consolidate_round_trip_data_integrity(self, signal, tmp_path):
+        """Data and metadata survive round-trip with consolidate=True."""
+        filename = tmp_path / "test_consolidate_rt.zspy"
+        store = zarr.ZipStore(path=filename)
+        signal.save(store)
+
+        s2 = hs.load(filename)
+        np.testing.assert_array_equal(s2.data, signal.data)
+        assert s2.metadata.General.title == "test consolidate metadata"
+
+    def test_consolidate_round_trip_no_consolidate(self, signal, tmp_path):
+        """Data and metadata survive round-trip with consolidate=False."""
+        filename = tmp_path / "test_consolidate_no_rt.zspy"
+        store = zarr.ZipStore(path=filename)
+        signal.save(store, consolidate=False)
+
+        s2 = hs.load(filename)
+        np.testing.assert_array_equal(s2.data, signal.data)
+        assert s2.metadata.General.title == "test consolidate metadata"
+
+    def test_consolidate_with_complex_metadata(self, tmp_path):
+        """Consolidated metadata works with nested metadata objects."""
+        data = np.arange(12 * 25 * 48, dtype=float).reshape(12, 25, 48)
+        s = hs.signals.Signal1D(data)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[2].name = "energy"
+        s.axes_manager[2].units = "eV"
+        s.metadata.General.title = "nested metadata test"
+        s.metadata.Signal.quantity = "intensity"
+
+        filename = tmp_path / "test_consolidate_complex.zspy"
+        store = zarr.ZipStore(path=filename)
+        s.save(store)
+
+        # Verify .zmetadata exists
+        assert ".zmetadata" in store
+
+        # Round-trip
+        s2 = hs.load(filename)
+        np.testing.assert_allclose(s2.data, s.data)
+        assert s2.metadata.General.title == "nested metadata test"
+        assert s2.metadata.Signal.quantity == "intensity"
+        assert s2.axes_manager["x"].name == "x"
+        assert s2.axes_manager["energy"].units == "eV"
+
+    def test_consolidate_preserves_metadata_across_formats(self, signal, tmp_path):
+        """consolidate=True does not change data when saving with different settings."""
+        # Save normally with consolidate=True
+        f1 = tmp_path / "test_consolidate_cmp_a.zspy"
+        store1 = zarr.ZipStore(path=f1)
+        signal.save(store1, consolidate=True)
+        s1 = hs.load(f1)
+
+        # Save with consolidate=False
+        f2 = tmp_path / "test_consolidate_cmp_b.zspy"
+        store2 = zarr.ZipStore(path=f2)
+        signal.save(store2, consolidate=False)
+        s2 = hs.load(f2)
+
+        # Data should be identical regardless of consolidate setting
+        np.testing.assert_array_equal(s1.data, s2.data)
+        assert s1.metadata.General.title == s2.metadata.General.title

--- a/rsciio/zspy/_api.py
+++ b/rsciio/zspy/_api.py
@@ -160,6 +160,23 @@ class ZspyWriter(HierarchicalWriter):
                 da.store(data, dset, lock=False)
 
 
+def _consolidate_metadata(store):
+    """Consolidate zarr metadata, handling both zarr v2 and v3.
+
+    Calls the appropriate consolidated metadata function for the installed
+    zarr version. In zarr v2, it's ``zarr.convenience.consolidate_metadata``.
+    In zarr v3+, it's ``zarr.consolidate_metadata``.
+    """
+    try:
+        # zarr v3+
+        from zarr import consolidate_metadata  # noqa: F811
+
+        consolidate_metadata(store)
+    except ImportError:
+        # zarr v2
+        zarr.convenience.consolidate_metadata(store)
+
+
 def file_writer(
     filename,
     signal,
@@ -169,6 +186,7 @@ def file_writer(
     write_dataset=True,
     store_type=None,
     show_progressbar=True,
+    consolidate=True,
     **kwds,
 ):
     """
@@ -200,6 +218,16 @@ def file_writer(
         If ``None``, the default store is used (:class:`~zarr.storage.NestedDirectoryStore`)
         is used. Specifying this parameter is incompatible with passing an instance of
         a zarr store to the ``filename`` parameter. Default is None.
+    consolidate : bool, default=True
+        If ``True``, call :func:`zarr.convenience.consolidate_metadata`
+        to bundle all metadata into a single ``.zmetadata`` file. This
+        significantly reduces the number of HTTP requests needed when
+        opening the file on remote or cloud storage (S3, GCS, etc.),
+        improving performance for cloud workflows. When saving to local
+        filesystems, the overhead is negligible. If the store does not
+        support writes or the consolidation fails for any reason, a
+        warning is logged and the file remains valid — metadata is
+        simply read from individual files on open.
     %s
     **kwds
         The keyword arguments are passed to the
@@ -267,6 +295,16 @@ def file_writer(
         **kwds,
     )
     writer.write()
+
+    if consolidate:
+        try:
+            _consolidate_metadata(store)
+        except Exception as e:
+            _logger.warning(
+                f"Failed to consolidate metadata: {e}. "
+                "The file is still valid, but opening it on remote/cloud "
+                "storage will require more HTTP requests."
+            )
 
     if isinstance(store, (zarr.ZipStore, zarr.DBMStore, zarr.LMDBStore)):
         if close_file:

--- a/upcoming_changes/consolidate-metadata.enhancements.rst
+++ b/upcoming_changes/consolidate-metadata.enhancements.rst
@@ -1,0 +1,9 @@
+The ``zspy`` writer now consolidates metadata by default using
+``zarr.consolidate_metadata`` (or ``zarr.convenience.consolidate_metadata`` for zarr v2).
+This bundles all individual ``.zattrs``, ``.zarray`` and ``.zgroup`` metadata files
+(~20+ files for a typical signal) into a single ``.zmetadata`` entry, reducing the number
+of HTTP requests needed to open a file from remote storage by an order of magnitude.
+Set ``consolidate=False`` to disable this behaviour (e.g. for interactive workflows where
+metadata is inspected manually).
+
+(Rename this file to ``<ISSUE>_or_<PR>.enhancements.rst`` before merging.)


### PR DESCRIPTION
## Summary

After writing a zspy file, HyperSpy's hierarchical writer creates ~20+ separate zarr metadata files (\, \, \ per group, per axis, per metadata subgroup). On cloud storage (S3, GCS, Azure), each of these files requires a separate HTTP GET on open, adding significant latency before any data is accessed.

This PR adds \ support to the zspy writer, which bundles all metadata into a single \ file (zarr v2) or inlines into \ (zarr v3), reducing cloud open time from 20+ HTTP requests to 1.

## Changes

### \
- New \ helper (lines 163-177) — handles both zarr v2 (\) and v3 (\)
- New \ parameter on \ (line 189) — enabled by default
- Called after \ (lines 299-307) in a try/except block — logs a warning on failure (store doesn't support writes) but the file remains valid

### \
- New \ class with 7 tests (lines 298-393):
  - Metadata creation/absence with consolidate True/False/default
  - Round-trip data + metadata integrity (both settings)
  - Complex nested metadata (axes, General/Signal metadata)
  - Cross-format comparison

### \
- Changelog entry for the new feature

## Context

This is part of a broader effort to add cloud storage I/O support to HyperSpy/rsciio. The chunk size (100 MB) and compression (Blosc zstd) in zspy are already cloud-ready — consolidated metadata was the remaining bottleneck.

## Note

The new tests use \ directly (a \ supported in both zarr v2 and v3). They cannot currently be collected due to pre-existing zarr v3 incompatibility in the test suite (\ was removed in zarr v3) — this is a separate issue, not caused by this PR.