### PR TITLE
Ci update and hspy fix on free-threaded python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
             HYPERSPY_VERSION: 'release'
           - os: ubuntu
             os_version: latest
-            PYTHON_VERSION: '3.13t'
+            PYTHON_VERSION: '3.14t'
             LABEL: '-hyperspy-minimum'
             HYPERSPY_VERSION: 'dev'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,31 +131,32 @@ jobs:
           echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
 
       - name: Display GIL information
-        if: ${{ contains(matrix.PYTHON_VERSION, '3.13') }}
+        if: ${{ endsWith(matrix.PYTHON_VERSION, 't') }}
         run: |
           # show if free-threaded build
           python -VV
           # show if GIL is enable
           python -c "import sys; print('GIL enabled:', sys._is_gil_enabled())"
 
-      - name: Install hyperspy (3.13t)
-        if: ${{ matrix.PYTHON_VERSION == '3.13t'}}
+      - name: Install hyperspy (free-threaded)
+        if: ${{ endsWith(matrix.PYTHON_VERSION, 't') }}
         run: |
           # no freethreaded build available for h5py
           # install other dependencies manually 
           pip install cloudpickle dask[array] importlib-metadata jinja2 matplotlib natsort numpy packaging pint prettytable pyyaml scikit-image scipy sympy tqdm pooch requests
           pip install traits
-          # with recent version of python3.13t, there are issue with installing from a git repository or source
+          # with recent versions of free-threaded python, there are issues with
+          # installing from a git repository or source
           # for now, install from pypi, as this is working...
           pip install hyperspy --no-deps
 
       - name: Install hyperspy and exspy (release)
-        if: ${{ matrix.HYPERSPY_VERSION == 'release' && matrix.PYTHON_VERSION != '3.13t'}}
+        if: ${{ matrix.HYPERSPY_VERSION == 'release' && ! endsWith(matrix.PYTHON_VERSION, 't') }}
         run: |
           pip install hyperspy exspy
 
       - name: Install hyperspy and exspy (dev)
-        if: ${{ matrix.HYPERSPY_VERSION == 'dev' && matrix.PYTHON_VERSION != '3.13t' }}
+        if: ${{ matrix.HYPERSPY_VERSION == 'dev' && ! endsWith(matrix.PYTHON_VERSION, 't') }}
         run: |
           pip install git+https://github.com/hyperspy/hyperspy.git
           pip install git+https://github.com/hyperspy/exspy.git

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ rsciio/bruker/*.pyd
 coverage.xml
 .vscode/*
 .zed
+.omo/*

--- a/doc/supported_formats/renishaw.rst
+++ b/doc/supported_formats/renishaw.rst
@@ -34,7 +34,7 @@ used as the ``signal_type``.
 
 This reader is based on the `py-wdf-reader <https://github.com/alchem0x2A/py-wdf-reader.git>`_,
 which is inspired by the `matlab reader <https://doi.org/10.5281/zenodo.495477>`_ from Alex Henderson.
-Moreover, inspiration is taken from `gwyddion's reader <http://gwyddion.net>`_.
+Moreover, inspiration is taken from `gwyddion's reader <https://gwyddion.net>`_.
 
 API functions
 ^^^^^^^^^^^^^

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -16,7 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with RosettaSciIO. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import contextlib
 import logging
+import os
+import threading
 from pathlib import Path
 
 import h5py
@@ -38,6 +41,34 @@ from rsciio.utils._array import is_dask_array
 from rsciio.utils._context_manager import get_progress_bar_context_manager
 
 _logger = logging.getLogger(__name__)
+
+# Track lazy file handles by absolute path so they can be closed before
+# the file is reopened in "w" (truncate) mode — which fails if any
+# handle to the same file is still open at the HDF5 C level.
+# A plain dict is used (not WeakValueDictionary) because h5py.Dataset
+# objects keep the C-level file handle alive even after the Python
+# h5py.File object is garbage-collected.
+
+_lazy_file_handles = {}
+_lazy_file_handles_lock = threading.Lock()
+
+
+def _track_lazy_handle(file_obj):
+    """Register *file_obj* keyed by its absolute path."""
+    path = os.fspath(Path(file_obj.filename).absolute())
+    with _lazy_file_handles_lock:
+        _lazy_file_handles.setdefault(path, []).append(file_obj)
+
+
+def _close_tracked_handles(filename):
+    """Close (and forget) all tracked handles for *filename*."""
+    path = os.fspath(Path(filename).absolute())
+    with _lazy_file_handles_lock:
+        handles = _lazy_file_handles.pop(path, [])
+    for handle in handles:
+        with contextlib.suppress(Exception):
+            handle.close()
+
 
 not_valid_format = "The file is not a valid HyperSpy hdf5 file"
 
@@ -157,7 +188,14 @@ def file_reader(filename, lazy=False, **kwds):
     try:
         exp_dict_list = reader.read(lazy=lazy)
     except BaseException as err:
+        if lazy:
+            # in the finally block, the file is closed only when lazy=False,
+            # so we need to close it here in case of exception
+            f.close()
         raise err
+    else:
+        if lazy:
+            _track_lazy_handle(f)
     finally:
         if not lazy:
             f.close()
@@ -235,6 +273,8 @@ def file_writer(
         mode = kwds.get("mode", "w" if write_dataset else "a")
         if mode != "a" and not write_dataset:
             raise ValueError("`mode='a'` is required to use `write_dataset=False`.")
+        if mode in ("w", "w-", "x"):
+            _close_tracked_handles(filename)
         f = h5py.File(filename, mode=mode)
 
     f.attrs["file_format"] = "HyperSpy"

--- a/rsciio/renishaw/_api.py
+++ b/rsciio/renishaw/_api.py
@@ -45,7 +45,7 @@
 # (https://github.com/alchem0x2A/py-wdf-reader),
 # which is inspired by Henderson, Alex
 # (https://doi.org/10.5281/zenodo.495477).
-# Moreover, this code is inspired by gwyddion (http://gwyddion.net).
+# Moreover, this code is inspired by gwyddion (https://gwyddion.net).
 
 # known limitations/problems:
 #   - cannot parse BKXL-Block

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -1088,17 +1088,34 @@ def test_saving_overwrite_data(tmp_path, file):
     # make sure we can open it after, file haven't been corrupted
     _ = hs.load(fname)
 
-    # now new data
-    @zspy_marker
-    def test_chunking_saving_lazy_specify(self, tmp_path, file):
-        filename = tmp_path / file
-        s = hs.signals.Signal2D(da.zeros((50, 100, 100))).as_lazy()
-        # specify chunks
-        chunks = (50, 10, 10)
-        s.data = s.data.rechunk([50, 25, 25])
-        s.save(filename, chunks=chunks)
-        s1 = hs.load(filename, lazy=True)
-        assert tuple([c[0] for c in s1.data.chunks]) == chunks
+
+@zspy_marker
+def test_chunking_saving_lazy_specify(tmp_path, file):
+    filename = tmp_path / file
+    s = hs.signals.Signal2D(da.zeros((50, 100, 100))).as_lazy()
+    # specify chunks
+    chunks = (50, 10, 10)
+    s.data = s.data.rechunk([50, 25, 25])
+    s.save(filename, chunks=chunks)
+    s1 = hs.load(filename, lazy=True)
+    assert tuple([c[0] for c in s1.data.chunks]) == chunks
+
+
+def test_lazy_then_reopen_with_truncate(tmp_path):
+    fname = tmp_path / "test_lazy_reopen.hspy"
+
+    s = hs.signals.Signal1D(np.zeros((5, 10)))
+    s.save(fname)
+
+    # keep reference to the file handle alive
+    # to make the regression test stronger
+    s2 = hs.load(fname, lazy=True, mode="a")  # noqa: F841
+
+    s3 = hs.signals.Signal1D(np.full((5, 10), 42))
+    s3.save(fname, overwrite=True)
+
+    s4 = hs.load(fname)
+    np.testing.assert_allclose(s4.data, np.full((5, 10), 42))
 
 
 @pytest.mark.parametrize("target_size", (1e6, 1e7))

--- a/upcoming_changes/533.bugfix.rst
+++ b/upcoming_changes/533.bugfix.rst
@@ -1,0 +1,1 @@
+Fix closing ``.hspy`` file when loaded lazily on free-threaded Python.


### PR DESCRIPTION

### Progress of the PR
- [x] Bump free-threaded test to python 3.14 - better support and consistent with the rest of the community,
- [x] Fix closing hspy file on free-threaded python, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/rosettasciio/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:rosettasciio` build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

