### PR TITLE
Fix two-dimensional MRCZ I/O

### DIFF
--- a/rsciio/mrcz/_api.py
+++ b/rsciio/mrcz/_api.py
@@ -233,8 +233,7 @@ def file_writer(
     # Get pixelsize and pixelunits from the axes
     pixelunits = signal["axes"][-1]["units"]
     pixelsize = [
-        signal["axes"][I_]["scale"]
-        for I_ in _WRITE_ORDER[: len(signal["axes"])]
+        signal["axes"][I_]["scale"] for I_ in _WRITE_ORDER[: len(signal["axes"])]
     ]
 
     # Strip out voltage from meta-data

--- a/rsciio/mrcz/_api.py
+++ b/rsciio/mrcz/_api.py
@@ -111,21 +111,40 @@ def file_reader(filename, lazy=False, mmap_mode="c", endianness="<", **kwds):
     )
 
     # Create the axis objects for each axis
-    names = ["y", "x", "z"]
-    navigate = [False, False, True]
-    axes = [
-        {
-            "size": data.shape[hsIndex],
-            "index_in_array": hsIndex,
-            "name": names[index],
-            "scale": mrcz_header["pixelsize"][hsIndex],
-            "offset": 0.0,
-            "units": mrcz_header["pixelunits"],
-            "navigate": nav,
-        }
-        for index, (hsIndex, nav) in enumerate(zip(_READ_ORDER, navigate))
-    ]
-    axes.insert(0, axes.pop(2))  # re-order the axes
+    if data.ndim == 3 and data.shape[0] == 1:
+        # MRC stores two-dimensional data with a singleton z dimension. The eager
+        # mrcz reader removes it, while the memory-mapped reader does not.
+        data = data[0]
+
+    if data.ndim == 2:
+        axes = [
+            {
+                "size": data.shape[index],
+                "index_in_array": index,
+                "name": name,
+                "scale": mrcz_header["pixelsize"][index + 1],
+                "offset": 0.0,
+                "units": mrcz_header["pixelunits"],
+                "navigate": False,
+            }
+            for index, name in enumerate(("y", "x"))
+        ]
+    else:
+        names = ["y", "x", "z"]
+        navigate = [False, False, True]
+        axes = [
+            {
+                "size": data.shape[hsIndex],
+                "index_in_array": hsIndex,
+                "name": names[index],
+                "scale": mrcz_header["pixelsize"][hsIndex],
+                "offset": 0.0,
+                "units": mrcz_header["pixelunits"],
+                "navigate": nav,
+            }
+            for index, (hsIndex, nav) in enumerate(zip(_READ_ORDER, navigate))
+        ]
+        axes.insert(0, axes.pop(2))  # re-order the axes
 
     metadata = mrcz_header.copy()
     # Remove non-standard fields
@@ -213,7 +232,10 @@ def file_writer(
 
     # Get pixelsize and pixelunits from the axes
     pixelunits = signal["axes"][-1]["units"]
-    pixelsize = [signal["axes"][I_]["scale"] for I_ in _WRITE_ORDER]
+    pixelsize = [
+        signal["axes"][I_]["scale"]
+        for I_ in _WRITE_ORDER[: len(signal["axes"])]
+    ]
 
     # Strip out voltage from meta-data
     voltage = md.get("Acquisition_instrument.TEM.beam_energy")

--- a/rsciio/tests/test_mrcz.py
+++ b/rsciio/tests/test_mrcz.py
@@ -211,6 +211,37 @@ class TestPythonMrcz:
                 lazy=lazy,
             )
 
+    @pytest.mark.parametrize("lazy_signal", [False, True])
+    def test_MRC_2d(self, tmp_path, lazy_signal):
+        data = np.arange(16 * 32, dtype=np.uint16).reshape(16, 32)
+        signal = hs.signals.Signal2D(data)
+        signal.axes_manager[0].name = "x"
+        signal.axes_manager[0].scale = 2.5
+        signal.axes_manager[0].units = "nm"
+        signal.axes_manager[1].name = "y"
+        signal.axes_manager[1].scale = 4.0
+        signal.axes_manager[1].units = "nm"
+        if lazy_signal:
+            signal = signal.as_lazy()
+
+        filename = tmp_path / "test_2d.mrcz"
+        signal.save(filename)
+        reloaded = hs.load(filename)
+
+        npt.assert_array_equal(reloaded.data, data)
+        assert reloaded.axes_manager.navigation_dimension == 0
+        assert reloaded.axes_manager.signal_dimension == 2
+        for axis_name in ("x", "y"):
+            npt.assert_equal(
+                reloaded.axes_manager[axis_name].size,
+                signal.axes_manager[axis_name].size,
+            )
+            npt.assert_allclose(
+                reloaded.axes_manager[axis_name].scale,
+                signal.axes_manager[axis_name].scale,
+            )
+            assert reloaded.axes_manager[axis_name].units == "nm"
+
     @pytest.mark.parametrize("dtype", dtype_list)
     def test_Async(self, dtype):
         _ = pytest.importorskip("blosc", reason="skipping test_async, requires blosc")

--- a/upcoming_changes/73.bugfix.rst
+++ b/upcoming_changes/73.bugfix.rst
@@ -1,0 +1,1 @@
+Fix reading and writing two-dimensional signals in the MRCZ format.


### PR DESCRIPTION
### Description of the change

- Fix writing two-dimensional signals in MRCZ format.
- Correctly handle the singleton z dimension used by MRC files.
- Add regression tests for eager and lazy-backed signals.

Fixes #73.

### Progress of the PR

- [x] Change implemented.
- [ ] Update docstring (not applicable: public API unchanged).
- [ ] Update user guide (not applicable: no new workflow).
- [x] Add a changelog entry.
- [ ] Check changelog formatting in the documentation build (waiting for CI).
- [x] Add tests.
- [ ] Ready for review (waiting for CI).

### Minimal example of the bug fix or the new feature

```python
import numpy as np
from hyperspy.signals import Signal2D

signal = Signal2D(np.arange(256, dtype=np.uint8).reshape(16, 16))
signal.save("test.mrcz")
```

### Validation

- MRCZ tests: 62 passed, 5 optional tests skipped.
- Ruff passed.

### AI assistance

OpenAI Codex was used to reproduce the issue, implement the focused fix,
and run the tests. No code was copied from another implementation.