### PR TITLE
Fix date/serial conversion with numeric UTC offsets

### DIFF
--- a/rsciio/tests/utils/test_datetime.py
+++ b/rsciio/tests/utils/test_datetime.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import numpy as np
 from dateutil import parser, tz
 
@@ -61,13 +63,24 @@ def test_ISO_format_to_serial_date():
     )
     np.testing.assert_allclose(res1, serial1, atol=1e-5)
     res2 = dtt.ISO_format_to_serial_date(
-        dt2.date().isoformat(), dt2.time().isoformat(), timezone="-05:00"
+        dt2.date().isoformat(),
+        dt2.timetz().replace(tzinfo=None).isoformat(),
+        timezone="-05:00",
     )
     np.testing.assert_allclose(res2, serial2, atol=1e-5)
     res3 = dtt.ISO_format_to_serial_date(
         dt3.date().isoformat(), dt3.time().isoformat(), timezone=dt3.tzname()
     )
     np.testing.assert_allclose(res3, serial3, atol=1e-5)
+
+
+def test_ISO_format_to_serial_date_time_with_UTC_offset():
+    date = dt2.date().isoformat()
+    time = dt2.timetz().isoformat()
+    with patch.object(dtt.parser, "parse", wraps=dtt.parser.parse) as parse_mock:
+        res = dtt.ISO_format_to_serial_date(date, time, timezone="-05:00")
+    parse_mock.assert_called_once_with(f"{date}T{time}")
+    np.testing.assert_allclose(res, serial2, atol=1e-5)
 
 
 def test_datetime_to_serial_date():

--- a/rsciio/tests/utils/test_datetime.py
+++ b/rsciio/tests/utils/test_datetime.py
@@ -10,7 +10,11 @@ def _get_example(date, time, time_zone=None):
     if time_zone:
         md.set_item("General.time_zone", time_zone)
         dt = parser.parse("%sT%s" % (date, time))
-        dt = dt.replace(tzinfo=tz.gettz(time_zone))
+        tzinfo = tz.gettz(time_zone)
+        if tzinfo is None:
+            dt = parser.parse(f"{date}T{time}{time_zone}")
+        else:
+            dt = dt.replace(tzinfo=tzinfo)
         iso = dt.isoformat()
     else:
         iso = "%sT%s" % (date, time)
@@ -21,7 +25,7 @@ def _get_example(date, time, time_zone=None):
 md1, dt1, iso1 = _get_example("2014-12-27", "00:00:00", "UTC")
 serial1 = 42000.00
 
-md2, dt2, iso2 = _get_example("2124-03-25", "10:04:48", "EST")
+md2, dt2, iso2 = _get_example("2124-03-25", "10:04:48", "-05:00")
 serial2 = 81900.62833333334
 
 md3, dt3, iso3 = _get_example("2016-07-12", "22:57:32")
@@ -56,9 +60,8 @@ def test_ISO_format_to_serial_date():
         dt1.date().isoformat(), dt1.time().isoformat(), timezone=dt1.tzname()
     )
     np.testing.assert_allclose(res1, serial1, atol=1e-5)
-    dt = dt2.astimezone(tz.tzlocal())
     res2 = dtt.ISO_format_to_serial_date(
-        dt.date().isoformat(), dt.time().isoformat(), timezone=dt.tzname()
+        dt2.date().isoformat(), dt2.time().isoformat(), timezone="-05:00"
     )
     np.testing.assert_allclose(res2, serial2, atol=1e-5)
     res3 = dtt.ISO_format_to_serial_date(
@@ -78,7 +81,11 @@ def _get_example(date, time, time_zone=None):
     if time_zone:
         md["General"]["time_zone"] = time_zone
         dt = parser.parse(f"{date}T{time}")
-        dt = dt.replace(tzinfo=tz.gettz(time_zone))
+        tzinfo = tz.gettz(time_zone)
+        if tzinfo is None:
+            dt = parser.parse(f"{date}T{time}{time_zone}")
+        else:
+            dt = dt.replace(tzinfo=tzinfo)
         iso = dt.isoformat()
     else:
         iso = f"{date}T{time}"
@@ -89,7 +96,7 @@ def _get_example(date, time, time_zone=None):
 md1, dt1, iso1 = _get_example("2014-12-27", "00:00:00", "UTC")
 serial1 = 42000.00
 
-md2, dt2, iso2 = _get_example("2124-03-25", "10:04:48", "EST")
+md2, dt2, iso2 = _get_example("2124-03-25", "10:04:48", "-05:00")
 serial2 = 81900.62833333334
 
 md3, dt3, iso3 = _get_example("2016-07-12", "22:57:32")

--- a/rsciio/utils/_date_time.py
+++ b/rsciio/utils/_date_time.py
@@ -39,13 +39,20 @@ def ISO_format_to_serial_date(date, time, timezone="UTC"):
     """Convert ISO format to a serial date."""
     if timezone is None or timezone == "Coordinated Universal Time":
         timezone = "UTC"
-    dt = parser.parse("%sT%s" % (date, time)).replace(tzinfo=tz.gettz(timezone))
+    dt = parser.parse("%sT%s" % (date, time))
+    tzinfo = tz.gettz(timezone)
+    if tzinfo is None:
+        # Numeric UTC offsets such as ``-05:00`` are valid ISO 8601 timezone
+        # designators, but dateutil's gettz does not resolve them.
+        dt = parser.parse(f"{date}T{time}{timezone}")
+    else:
+        dt = dt.replace(tzinfo=tzinfo)
     return datetime_to_serial_date(dt)
 
 
 def datetime_to_serial_date(dt):
     """Convert datetime.datetime object to a serial date."""
-    if dt.tzname() is None:
+    if dt.tzinfo is None:
         dt = dt.replace(tzinfo=tz.tzutc())
     origin = datetime.datetime(1899, 12, 30, tzinfo=tz.tzutc())
     delta = dt - origin

--- a/rsciio/utils/_date_time.py
+++ b/rsciio/utils/_date_time.py
@@ -41,11 +41,11 @@ def ISO_format_to_serial_date(date, time, timezone="UTC"):
         timezone = "UTC"
     dt = parser.parse("%sT%s" % (date, time))
     tzinfo = tz.gettz(timezone)
-    if tzinfo is None:
+    if tzinfo is None and dt.tzinfo is None:
         # Numeric UTC offsets such as ``-05:00`` are valid ISO 8601 timezone
         # designators, but dateutil's gettz does not resolve them.
         dt = parser.parse(f"{date}T{time}{timezone}")
-    else:
+    elif tzinfo is not None:
         dt = dt.replace(tzinfo=tzinfo)
     return datetime_to_serial_date(dt)
 

--- a/upcoming_changes/341.bugfix.rst
+++ b/upcoming_changes/341.bugfix.rst
@@ -1,0 +1,1 @@
+Support ISO 8601 UTC-offset strings in serial-date conversion and make timezone tests platform independent.


### PR DESCRIPTION
### Description of the change

Fixes #341.

- Replace the platform-dependent `EST` timezone abbreviation in the date/time tests with the explicit ISO 8601 offset `-05:00`.
- Support numeric UTC offsets when `dateutil.tz.gettz` cannot resolve them as named timezones.
- Treat only datetimes without `tzinfo` as naive.

### Progress of the PR

- [x] Change implemented,
- [x] update docstring (not required),
- [x] update user guide (not required),
- [x] add a changelog entry in the `upcoming_changes` folder,
- [x] Check formatting of the changelog entry in the documentation build,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix

```python
from rsciio.utils._date_time import ISO_format_to_serial_date

serial_date = ISO_format_to_serial_date(
    "2124-03-25", "10:04:48", timezone="-05:00"
)
```

### Validation

- Relevant utility test suite: 44 passed.
- Ruff lint and formatting checks pass.
- Documentation build passes.

### AI assistance

OpenAI Codex was used to analyze the issue, implement and test the change, and prepare this pull request. I reviewed the changes and take responsibility for the contribution.