### PR TITLE
Add CSR (dense buffer + offsets) encoding for uniform ragged arrays

### DIFF
--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -1010,8 +1010,13 @@ class HierarchicalWriter:
             else:
                 new_data, shapes = flatten_data(data, is_hdf5=cls._is_hdf5)
 
-            got_data = False
-            while not got_data:
+            # If the shape or dtype/etc of an existing dataset don't match,
+            # delete it and create a new one -- needed when the key previously
+            # held a CSR-encoded (dense) array, whose shape never matches the
+            # ragged one written here. Retry exactly once: a TypeError that
+            # survives the delete comes from the data itself, not from a
+            # conflicting dataset, and must propagate rather than spin.
+            for last_attempt in (False, True):
                 try:
                     dset = cls._get_object_dset(group, new_data, key, chunks, **kwds)
                     shape_dset = cls._get_object_dset(
@@ -1022,13 +1027,10 @@ class HierarchicalWriter:
                         dtype=int,
                         **kwds,
                     )
-                    got_data = True
+                    break
                 except TypeError:
-                    # Same as the concrete-dtype branch above: if the shape or
-                    # dtype/etc of an existing dataset don't match, delete it
-                    # and create a new one in the next loop run. Needed when
-                    # the key previously held a CSR-encoded (dense) array,
-                    # whose shape never matches the ragged one written here.
+                    if last_attempt:
+                        raise
                     for key_ in (key, f"_ragged_shapes_{key}"):
                         if key_ in group:
                             del group[key_]

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -29,7 +29,11 @@ from rsciio._docstrings import SHOW_PROGRESSBAR_DOC
 from rsciio.utils._array import is_dask_array
 from rsciio.utils._tools import ensure_unicode
 
-version = "3.3"
+# 3.4 adds the CSR (dense values + offsets) encoding for ragged arrays with a
+# uniform numeric per-position shape. Readers older than 3.4 don't know about
+# the `_ragged_encoding` attribute and would silently misread such a dataset as
+# a plain dense array, so the bump is what makes them warn.
+version = "3.4"
 
 default_version = Version(version)
 
@@ -843,6 +847,29 @@ class HierarchicalWriter:
     def _store_data(*arg):  # pragma: no cover
         raise NotImplementedError("This method must be implemented by subclasses.")
 
+    @staticmethod
+    def _clear_ragged_state(group, key):
+        """
+        Drop any ragged-array bookkeeping left over from a previous write of
+        ``key``: the CSR marker attributes and both flavours of sidecar
+        dataset.
+
+        Rewriting a key doesn't necessarily recreate its dataset -- when the
+        new shape and dtype happen to match, ``require_dataset`` reuses the
+        existing one -- so without this the old encoding's metadata can
+        survive and make the reader reconstruct the new data the wrong way
+        (e.g. a plain dense array read back as a ragged one). Sidecars from
+        the encoding *not* used by this write would also linger as dead
+        datasets in the file.
+        """
+        if key in group:
+            for attr in ("_ragged_encoding", "_ragged_nav_shape"):
+                if attr in group[key].attrs:
+                    del group[key].attrs[attr]
+        for sidecar in (f"_ragged_offsets_{key}", f"_ragged_shapes_{key}"):
+            if sidecar in group:
+                del group[sidecar]
+
     @classmethod
     def _write_ragged_csr(
         cls, group, data, key, trailing_shape, dtype, show_progressbar=True, **kwds
@@ -908,6 +935,9 @@ class HierarchicalWriter:
             :py:meth:`h5py.Group.require_dataset` or
             :py:meth:`zarr.hierarchy.Group.require_dataset` method.
         """ % SHOW_PROGRESSBAR_DOC
+        # Whatever encoding this write ends up using, any bookkeeping from a
+        # previous write of the same key is now stale and must not survive.
+        cls._clear_ragged_state(group, key)
         if chunks is None:
             if is_dask_array(data):
                 # For lazy dataset, by default, we use the current dask chunking
@@ -980,10 +1010,23 @@ class HierarchicalWriter:
             else:
                 new_data, shapes = flatten_data(data, is_hdf5=cls._is_hdf5)
 
-            dset = cls._get_object_dset(group, new_data, key, chunks, **kwds)
-            shape_dset = cls._get_object_dset(
-                group, shapes, f"_ragged_shapes_{key}", chunks, dtype=int, **kwds
-            )
+            got_data = False
+            while not got_data:
+                try:
+                    dset = cls._get_object_dset(group, new_data, key, chunks, **kwds)
+                    shape_dset = cls._get_object_dset(
+                        group, shapes, f"_ragged_shapes_{key}", chunks, dtype=int, **kwds
+                    )
+                    got_data = True
+                except TypeError:
+                    # Same as the concrete-dtype branch above: if the shape or
+                    # dtype/etc of an existing dataset don't match, delete it
+                    # and create a new one in the next loop run. Needed when
+                    # the key previously held a CSR-encoded (dense) array,
+                    # whose shape never matches the ragged one written here.
+                    for key_ in (key, f"_ragged_shapes_{key}"):
+                        if key_ in group:
+                            del group[key_]
 
             cls._store_data(
                 (new_data, shapes),

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -101,6 +101,11 @@ def unflatten_data(data, shape, is_hdf5=False):
 # for anything that doesn't fit (ragged strings, heterogeneous shapes, mixed
 # dtypes). See ZARR_V3_PLAN.md, "Phase 3b".
 
+# Rough number of dask blocks the CSR reader aims for when reconstructing a
+# ragged array. Only a performance knob -- it trades per-task overhead against
+# block size and read amplification.
+_CSR_TARGET_BLOCKS = 16
+
 
 def _csr_trailing_shape(x):
     """
@@ -378,13 +383,21 @@ class HierarchicalReader:
         # whole per block: since `offsets` is in flattened row-major (C)
         # order, this keeps each block's row range in `values` contiguous,
         # with no need to special-case partial rows of a multi-D nav grid.
-        # The block size itself is just a performance knob (any value is
-        # correct) chosen to roughly match one physical chunk of `values`.
+        # The block size itself is only a performance knob -- any value is
+        # correct -- but it wants to be at least one physical chunk of
+        # `values` (so a block doesn't straddle chunks needlessly) while
+        # still emitting few enough blocks that per-task overhead stays
+        # amortized. Sizing it purely from the physical chunk is not enough:
+        # h5py's automatic chunking picks far smaller chunks than zarr's, and
+        # the block size then collapses to a single outer index, i.e. one
+        # dask task per nav row.
         values_chunk_rows = values_da.chunks[0][0] if values_da.chunks[0] else 1
-        frames_per_chunk = max(
-            1, int(np.searchsorted(offsets, values_chunk_rows, side="right"))
+        total_rows = int(offsets[-1])
+        rows_per_block = max(values_chunk_rows, -(-total_rows // _CSR_TARGET_BLOCKS))
+        frames_per_block = max(
+            1, int(np.searchsorted(offsets, rows_per_block, side="right"))
         )
-        outer_chunk = max(1, frames_per_chunk // max(inner_size, 1))
+        outer_chunk = max(1, frames_per_block // max(inner_size, 1))
         outer_chunk = min(outer_chunk, n_outer) if n_outer else 1
 
         def _reconstruct(block_values, block_offsets, shape):
@@ -886,8 +899,29 @@ class HierarchicalWriter:
         """
         nav_shape = data.shape
         values, offsets = flatten_to_csr(data, trailing_shape, dtype)
+        # Chunk `values` explicitly rather than leaving it to the backend's
+        # automatic chunking, which has no idea this is a row-oriented buffer:
+        # h5py splits the trailing dimension (e.g. (2492, 1) for an (N, 2)
+        # array), so every row-range read has to touch one chunk per column.
+        # Keep whole rows together and size the chunk by the writer's usual
+        # target, as `get_signal_chunks` would for a normal dataset.
+        # An empty buffer keeps the backend's automatic chunking: h5py rejects
+        # an explicit chunk larger than the dataset in any dimension, which a
+        # zero-length one can never satisfy.
+        if values.shape[0] > 0:
+            row_bytes = values.dtype.itemsize * max(1, int(np.prod(trailing_shape)))
+            rows_per_chunk = max(1, int(cls.target_size // max(row_bytes, 1)))
+            rows_per_chunk = min(rows_per_chunk, values.shape[0])
+            values_chunks = (rows_per_chunk,) + trailing_shape
+        else:
+            values_chunks = None
         cls.overwrite_dataset(
-            group, values, key, show_progressbar=show_progressbar, **kwds
+            group,
+            values,
+            key,
+            chunks=values_chunks,
+            show_progressbar=show_progressbar,
+            **kwds,
         )
         cls.overwrite_dataset(
             group,

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -1015,7 +1015,12 @@ class HierarchicalWriter:
                 try:
                     dset = cls._get_object_dset(group, new_data, key, chunks, **kwds)
                     shape_dset = cls._get_object_dset(
-                        group, shapes, f"_ragged_shapes_{key}", chunks, dtype=int, **kwds
+                        group,
+                        shapes,
+                        f"_ragged_shapes_{key}",
+                        chunks,
+                        dtype=int,
+                        **kwds,
                     )
                     got_data = True
                 except TypeError:

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -86,6 +86,75 @@ def unflatten_data(data, shape, is_hdf5=False):
 
 
 # ---------------------------------
+# CSR (dense buffer + offsets) encoding for "vector-shaped" ragged arrays:
+# numeric ragged arrays where every cell shares the same trailing shape and
+# only the leading (count) dimension varies, e.g. one (N_i, 2) array of point
+# coordinates per navigation position. Stored as a single dense concatenation
+# of every cell ("values") plus a cumulative row-count index ("offsets"),
+# instead of one independent object-dtype/vlen blob per cell. This sidesteps
+# per-cell codec overhead entirely and lets `values` be chunked/compressed
+# like any ordinary array. Falls back to `flatten_data`/`unflatten_data` above
+# for anything that doesn't fit (ragged strings, heterogeneous shapes, mixed
+# dtypes). See ZARR_V3_PLAN.md, "Phase 3b".
+
+
+def _csr_trailing_shape(x):
+    """
+    Check whether ragged array ``x`` (dtype=object, arbitrary nav shape) fits
+    the CSR encoding: every cell must be a plain numeric array sharing the
+    same trailing shape, with only the leading dimension free to vary.
+
+    Returns the shared trailing shape (a tuple, empty for 1-D cells) and
+    common dtype on success, or ``(None, None)`` if ``x`` doesn't fit and
+    callers should fall back to the generic object-dtype encoding.
+    """
+    trailing_shape = None
+    common_dtype = None
+    for i in np.ndindex(x.shape):
+        cell = np.asarray(x[i])
+        if cell.dtype == object or cell.dtype.kind in "US":
+            return None, None
+        if cell.ndim == 0:
+            return None, None
+        if trailing_shape is None:
+            trailing_shape = cell.shape[1:]
+            common_dtype = cell.dtype
+        elif cell.shape[1:] != trailing_shape or cell.dtype != common_dtype:
+            return None, None
+    return trailing_shape, common_dtype
+
+
+def flatten_to_csr(x, trailing_shape, dtype):
+    """
+    Convert ragged array ``x`` into a CSR (values, offsets) pair: ``values``
+    is the dense concatenation of every cell along axis 0, in the same
+    flattened nav order ``np.ndindex`` walks (row-major/C order); ``offsets``
+    is the ``(x.size + 1,)`` cumulative row-count index into ``values``, so
+    cell ``i`` (in that flattened order) is ``values[offsets[i]:offsets[i + 1]]``.
+    """
+    cells = [np.asarray(x[i]) for i in np.ndindex(x.shape)]
+    counts = np.array([c.shape[0] for c in cells], dtype=np.int64)
+    offsets = np.zeros(len(cells) + 1, dtype=np.int64)
+    np.cumsum(counts, out=offsets[1:])
+    if offsets[-1] == 0:
+        values = np.empty((0,) + trailing_shape, dtype=dtype)
+    else:
+        values = np.concatenate(cells, axis=0)
+    return values, offsets
+
+
+def unflatten_from_csr(values, offsets, nav_shape):
+    """
+    Reconstruct a ragged (dtype=object) array of shape ``nav_shape`` from a
+    CSR encoding: ``values`` is the dense ``(N_total, *trailing)`` buffer,
+    ``offsets`` is the cumulative row-count index built by
+    :func:`flatten_to_csr`.
+    """
+    cells = np.split(np.asarray(values), offsets[1:-1], axis=0)
+    new_data = np.empty(shape=nav_shape, dtype=object)
+    for idx, i in enumerate(np.ndindex(nav_shape)):
+        new_data[i] = cells[idx]
+    return new_data
 
 
 def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
@@ -277,12 +346,74 @@ class HierarchicalReader:
 
         return exp_dict_list
 
+    def _read_csr_array(self, group, dataset_key):
+        """
+        Reconstruct a ragged (dtype=object) array from the dense CSR
+        (values + offsets) encoding written by
+        :meth:`HierarchicalWriter._write_ragged_csr`. Always returns a dask
+        array (mirroring the generic ragged path in :meth:`_read_array`) --
+        callers `.compute()` it when an eager result is wanted.
+        """
+        import dask
+        import dask.array as da
+
+        values = group[dataset_key]
+        offsets = np.asarray(group[f"_ragged_offsets_{dataset_key}"][:])
+        nav_shape = tuple(int(s) for s in values.attrs["_ragged_nav_shape"])
+        values_da = da.from_array(values, chunks=values.chunks)
+
+        if not nav_shape:
+            block = dask.delayed(unflatten_from_csr)(values_da[:], offsets, nav_shape)
+            return da.from_delayed(block, shape=nav_shape, dtype=object)
+
+        n_outer = nav_shape[0]
+        inner_shape = nav_shape[1:]
+        inner_size = int(np.prod(inner_shape)) if inner_shape else 1
+
+        # Chunk along the outermost nav axis only, keeping inner nav dims
+        # whole per block: since `offsets` is in flattened row-major (C)
+        # order, this keeps each block's row range in `values` contiguous,
+        # with no need to special-case partial rows of a multi-D nav grid.
+        # The block size itself is just a performance knob (any value is
+        # correct) chosen to roughly match one physical chunk of `values`.
+        values_chunk_rows = values_da.chunks[0][0] if values_da.chunks[0] else 1
+        frames_per_chunk = max(
+            1, int(np.searchsorted(offsets, values_chunk_rows, side="right"))
+        )
+        outer_chunk = max(1, frames_per_chunk // max(inner_size, 1))
+        outer_chunk = min(outer_chunk, n_outer) if n_outer else 1
+
+        def _reconstruct(block_values, block_offsets, shape):
+            local_offsets = block_offsets - block_offsets[0]
+            return unflatten_from_csr(block_values, local_offsets, shape)
+
+        blocks = []
+        for start in range(0, n_outer, outer_chunk):
+            stop = min(n_outer, start + outer_chunk)
+            frame_start = start * inner_size
+            frame_stop = stop * inner_size
+            s, e = int(offsets[frame_start]), int(offsets[frame_stop])
+            block_offsets = offsets[frame_start : frame_stop + 1]
+            block_shape = (stop - start,) + inner_shape
+            delayed_block = dask.delayed(_reconstruct)(
+                values_da[s:e], block_offsets, block_shape
+            )
+            blocks.append(
+                da.from_delayed(delayed_block, shape=block_shape, dtype=object)
+            )
+
+        if not blocks:
+            return da.from_array(np.empty(nav_shape, dtype=object), chunks=nav_shape)
+        return da.concatenate(blocks, axis=0)
+
     def _read_array(self, group, dataset_key):
         # This is a workaround for the lack of support for n-d ragged array
         # in h5py and zarr. There is work in progress for implementation in zarr:
         # https://github.com/zarr-developers/zarr-specs/issues/62 which may be
         # relevant to implement here when available
         data = group[dataset_key]
+        if data.attrs.get("_ragged_encoding") == "csr":
+            return self._read_csr_array(group, dataset_key)
         key = f"_ragged_shapes_{dataset_key}"
         if "ragged_shapes" in group:
             # For file saved with rosettaSciIO <= 0.1
@@ -599,9 +730,11 @@ class HierarchicalReader:
                 dictionary[key] = value
         if not isinstance(group, self.Dataset):
             for key in group.keys():
-                if key.startswith("_ragged_shapes_"):
-                    # array used to parse ragged array, need to skip it
-                    # otherwise, it will wrongly read kwargs when reading
+                if key.startswith("_ragged_shapes_") or key.startswith(
+                    "_ragged_offsets_"
+                ):
+                    # arrays used to parse ragged array, need to skip them
+                    # otherwise, they will wrongly read kwargs when reading
                     # variable length markers as they uses ragged arrays
                     pass
                 elif key.startswith("_sig_"):
@@ -711,6 +844,35 @@ class HierarchicalWriter:
         raise NotImplementedError("This method must be implemented by subclasses.")
 
     @classmethod
+    def _write_ragged_csr(
+        cls, group, data, key, trailing_shape, dtype, show_progressbar=True, **kwds
+    ):
+        """
+        Write ragged array ``data`` using the dense CSR (values + offsets)
+        encoding (see :func:`flatten_to_csr`) instead of the generic per-cell
+        object-dtype encoding. Only called for eager (non-dask), numeric,
+        uniform-trailing-shape ragged arrays -- the caller already checked
+        this via :func:`_csr_trailing_shape`. ``values``/``offsets`` are
+        concrete-dtype arrays, so they're written through the ordinary
+        (non-ragged) branch of `overwrite_dataset`, chunked and compressed
+        like any other dataset.
+        """
+        nav_shape = data.shape
+        values, offsets = flatten_to_csr(data, trailing_shape, dtype)
+        cls.overwrite_dataset(
+            group, values, key, show_progressbar=show_progressbar, **kwds
+        )
+        cls.overwrite_dataset(
+            group,
+            offsets,
+            f"_ragged_offsets_{key}",
+            show_progressbar=show_progressbar,
+            **kwds,
+        )
+        group[key].attrs["_ragged_encoding"] = "csr"
+        group[key].attrs["_ragged_nav_shape"] = list(nav_shape)
+
+    @classmethod
     def overwrite_dataset(
         cls,
         group,
@@ -785,6 +947,25 @@ class HierarchicalWriter:
 
         _logger.info(f"Chunks used for saving: {chunks}")
         if data.dtype == np.dtype("O"):
+            if not is_dask_array(data):
+                # Numeric ragged arrays with a uniform trailing shape (e.g.
+                # one (N_i, 2) array of vectors per navigation position) get a
+                # dense CSR (values + offsets) encoding instead -- see
+                # ZARR_V3_PLAN.md "Phase 3b". Lazy (dask-backed) ragged
+                # arrays keep using the generic per-cell encoding below; CSR
+                # write support for lazy input is a documented follow-up.
+                trailing_shape, common_dtype = _csr_trailing_shape(data)
+                if trailing_shape is not None:
+                    cls._write_ragged_csr(
+                        group,
+                        data,
+                        key,
+                        trailing_shape,
+                        common_dtype,
+                        show_progressbar=show_progressbar,
+                        **kwds,
+                    )
+                    return
             if is_dask_array(data):
                 import dask.array as da
 

--- a/rsciio/_hierarchical.py
+++ b/rsciio/_hierarchical.py
@@ -107,44 +107,62 @@ def unflatten_data(data, shape, is_hdf5=False):
 _CSR_TARGET_BLOCKS = 16
 
 
-def _csr_trailing_shape(x):
+def csr_cells(x):
     """
     Check whether ragged array ``x`` (dtype=object, arbitrary nav shape) fits
-    the CSR encoding: every cell must be a plain numeric array sharing the
-    same trailing shape, with only the leading dimension free to vary.
+    the CSR encoding, collecting its cells in the same pass.
 
-    Returns the shared trailing shape (a tuple, empty for 1-D cells) and
-    common dtype on success, or ``(None, None)`` if ``x`` doesn't fit and
+    To fit, every cell must be a plain numeric array sharing the same trailing
+    shape, with only the leading dimension free to vary.
+
+    Returns ``(cells, trailing_shape, dtype)`` -- the cells in flattened
+    row-major (C) order, the shared trailing shape (empty for 1-D cells) and
+    the common dtype -- or ``(None, None, None)`` if ``x`` doesn't fit and
     callers should fall back to the generic object-dtype encoding.
+
+    Inspecting a ``dtype=object`` array means touching every element, so some
+    Python-level iteration is unavoidable. Rather than a branchy per-cell
+    loop, reduce the cells to the set of their ``(dtype, ndim, trailing
+    shape)`` signatures: they fit exactly when that set has one element. That
+    is a single pass of cheap, uniform operations, and the per-cell
+    comparisons collapse into the set's hashing.
+
+    ``ndim`` has to be part of the signature, not just checked on one cell:
+    a 0-d cell has an empty trailing shape too, so it would otherwise be
+    indistinguishable from a 1-D one and blow up later with no leading
+    dimension to count.
     """
-    trailing_shape = None
-    common_dtype = None
-    for i in np.ndindex(x.shape):
-        cell = np.asarray(x[i])
-        if cell.dtype == object or cell.dtype.kind in "US":
-            return None, None
-        if cell.ndim == 0:
-            return None, None
-        if trailing_shape is None:
-            trailing_shape = cell.shape[1:]
-            common_dtype = cell.dtype
-        elif cell.shape[1:] != trailing_shape or cell.dtype != common_dtype:
-            return None, None
-    return trailing_shape, common_dtype
+    cells = list(x.flat)
+    if not cells:
+        return None, None, None
+    try:
+        signature = {(c.dtype, c.ndim, c.shape[1:]) for c in cells}
+    except AttributeError:
+        # A cell isn't an array (a list, say). Convert and retry, rather than
+        # paying a type check per cell on the overwhelmingly common path.
+        cells = [c if type(c) is np.ndarray else np.asarray(c) for c in cells]
+        signature = {(c.dtype, c.ndim, c.shape[1:]) for c in cells}
+    if len(signature) != 1:
+        return None, None, None
+    common_dtype, ndim, trailing_shape = signature.pop()
+    if ndim == 0 or common_dtype.hasobject or common_dtype.kind in "US":
+        return None, None, None
+    return cells, trailing_shape, common_dtype
 
 
-def flatten_to_csr(x, trailing_shape, dtype):
+def flatten_to_csr(cells, trailing_shape, dtype):
     """
-    Convert ragged array ``x`` into a CSR (values, offsets) pair: ``values``
-    is the dense concatenation of every cell along axis 0, in the same
-    flattened nav order ``np.ndindex`` walks (row-major/C order); ``offsets``
-    is the ``(x.size + 1,)`` cumulative row-count index into ``values``, so
-    cell ``i`` (in that flattened order) is ``values[offsets[i]:offsets[i + 1]]``.
+    Convert the cells collected by :func:`csr_cells` into a CSR
+    (values, offsets) pair: ``values`` is their dense concatenation along
+    axis 0, in flattened row-major (C) order; ``offsets`` is the
+    ``(len(cells) + 1,)`` cumulative row-count index into ``values``, so cell
+    ``i`` is ``values[offsets[i]:offsets[i + 1]]``.
     """
-    cells = [np.asarray(x[i]) for i in np.ndindex(x.shape)]
-    counts = np.array([c.shape[0] for c in cells], dtype=np.int64)
     offsets = np.zeros(len(cells) + 1, dtype=np.int64)
-    np.cumsum(counts, out=offsets[1:])
+    np.cumsum(
+        np.fromiter((c.shape[0] for c in cells), dtype=np.int64, count=len(cells)),
+        out=offsets[1:],
+    )
     if offsets[-1] == 0:
         values = np.empty((0,) + trailing_shape, dtype=dtype)
     else:
@@ -885,20 +903,27 @@ class HierarchicalWriter:
 
     @classmethod
     def _write_ragged_csr(
-        cls, group, data, key, trailing_shape, dtype, show_progressbar=True, **kwds
+        cls,
+        group,
+        nav_shape,
+        cells,
+        key,
+        trailing_shape,
+        dtype,
+        show_progressbar=True,
+        **kwds,
     ):
         """
-        Write ragged array ``data`` using the dense CSR (values + offsets)
-        encoding (see :func:`flatten_to_csr`) instead of the generic per-cell
-        object-dtype encoding. Only called for eager (non-dask), numeric,
-        uniform-trailing-shape ragged arrays -- the caller already checked
-        this via :func:`_csr_trailing_shape`. ``values``/``offsets`` are
-        concrete-dtype arrays, so they're written through the ordinary
-        (non-ragged) branch of `overwrite_dataset`, chunked and compressed
-        like any other dataset.
+        Write the cells of a ragged array using the dense CSR
+        (values + offsets) encoding (see :func:`flatten_to_csr`) instead of
+        the generic per-cell object-dtype encoding. Only called for eager
+        (non-dask), numeric, uniform-trailing-shape ragged arrays -- the
+        caller already established that, and collected ``cells``, via
+        :func:`csr_cells`. ``values``/``offsets`` are concrete-dtype arrays,
+        so they're written through the ordinary (non-ragged) branch of
+        `overwrite_dataset`, chunked and compressed like any other dataset.
         """
-        nav_shape = data.shape
-        values, offsets = flatten_to_csr(data, trailing_shape, dtype)
+        values, offsets = flatten_to_csr(cells, trailing_shape, dtype)
         # Chunk `values` explicitly rather than leaving it to the backend's
         # automatic chunking, which has no idea this is a row-oriented buffer:
         # h5py splits the trailing dimension (e.g. (2492, 1) for an (N, 2)
@@ -1018,11 +1043,12 @@ class HierarchicalWriter:
                 # ZARR_V3_PLAN.md "Phase 3b". Lazy (dask-backed) ragged
                 # arrays keep using the generic per-cell encoding below; CSR
                 # write support for lazy input is a documented follow-up.
-                trailing_shape, common_dtype = _csr_trailing_shape(data)
-                if trailing_shape is not None:
+                cells, trailing_shape, common_dtype = csr_cells(data)
+                if cells is not None:
                     cls._write_ragged_csr(
                         group,
-                        data,
+                        data.shape,
+                        cells,
                         key,
                         trailing_shape,
                         common_dtype,

--- a/rsciio/hspy/_api.py
+++ b/rsciio/hspy/_api.py
@@ -99,8 +99,12 @@ class HyperspyWriter(HierarchicalWriter):
                     )
                 # for performance reason, we write the data later, with all data
                 # at the same time in a single `dask.array.store` call
-            # "write_direct" doesn't play well with empty array
-            elif data_.flags.c_contiguous and data_.shape != (0,):
+            # "write_direct" doesn't play well with empty array -- on older
+            # h5py it divides by zero while broadcasting the selection. Any
+            # zero-size shape hits this, not just the 1-D `(0,)` case: the
+            # CSR encoding writes a `(0, D)` values buffer when every ragged
+            # cell is empty.
+            elif data_.flags.c_contiguous and data_.size != 0:
                 dset_.write_direct(data_)
             else:
                 dset_[:] = data_

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -1148,6 +1148,40 @@ def test_ragged_dataset_error_retry_is_bounded(tmp_path, file, monkeypatch):
     assert len(calls) <= 4
 
 
+@pytest.mark.parametrize(
+    ("cells", "fits"),
+    [
+        ([np.zeros((2, 2)), np.zeros((3, 2))], True),
+        ([[[1.0, 2.0]], [[3.0, 4.0], [5.0, 6.0]]], True),  # lists, not arrays
+        ([np.arange(2.0), np.arange(3.0)], True),  # 1-D cells, trailing ()
+        ([np.zeros((2, 2)), np.zeros((2, 3))], False),  # trailing shape differs
+        ([np.zeros((2, 2), "i4"), np.zeros((2, 2), "f8")], False),  # dtype differs
+        ([np.zeros((3, 2)), np.zeros((3, 2, 4))], False),  # ndim differs
+        ([np.float64(1.0), np.arange(3.0)], False),  # 0-d mixed with 1-D
+        ([np.float64(1.0), np.float64(2.0)], False),  # all 0-d
+        ([np.array(["a", "b"]), np.array(["c"])], False),  # strings
+    ],
+)
+def test_csr_cells_detection(cells, fits):
+    # csr_cells decides the encoding, so a wrong "fits" answer either loses
+    # the optimisation or, worse, sends data down a path that would coerce
+    # it. The 0-d cases matter in particular: a 0-d cell has an empty
+    # trailing shape just like a 1-D one, so it is only distinguishable by
+    # its ndim.
+    from rsciio._hierarchical import csr_cells
+
+    data = np.empty((len(cells),), dtype=object)
+    for i, cell in enumerate(cells):
+        data[i] = cell
+
+    collected, trailing_shape, dtype = csr_cells(data)
+    assert (collected is not None) is fits
+    if fits:
+        assert len(collected) == len(cells)
+        assert trailing_shape == np.asarray(cells[0]).shape[1:]
+        assert dtype == np.asarray(cells[0]).dtype
+
+
 def test_format_version_bumped_for_csr():
     # The CSR encoding is a new on-disk format: readers predating it would
     # silently misread such a dataset as a plain dense array, so the format

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -1022,21 +1022,21 @@ def test_save_ragged_array_csr_all_empty(tmp_path, file):
 
 
 @zspy_marker
-@pytest.mark.parametrize("heterogeneous", ["shape", "dtype"])
-def test_save_ragged_array_csr_fallback(tmp_path, file, heterogeneous):
-    # Ragged arrays that don't fit the CSR encoding's "uniform trailing
-    # shape, single dtype" requirement (heterogeneous per-cell shapes or
-    # mixed dtypes) must still round-trip correctly through the generic
-    # (per-cell object-dtype) fallback encoding.
+def test_save_ragged_array_csr_fallback(tmp_path, file):
+    # Ragged arrays with heterogeneous per-cell shapes don't fit the CSR
+    # encoding and must still round-trip through the generic (per-cell
+    # object-dtype) fallback encoding.
+    #
+    # Mixed *dtypes* are covered by the encoding-selection tests in
+    # test_zspy.py rather than here: the generic encoding stores a single
+    # dtype for the whole dataset, so it has never round-tripped mixed-dtype
+    # ragged data faithfully. What matters for the CSR path is only that it
+    # declines such data (otherwise its concatenation would silently coerce).
     rng = np.random.default_rng(0)
     data = np.empty((5,), dtype=object)
     for index in np.ndindex(data.shape):
         i = index[0]
-        if heterogeneous == "shape":
-            data[index] = rng.random((i + 1, 2 + (i % 2)))
-        else:
-            dtype = np.int32 if i % 2 else np.float64
-            data[index] = rng.random((i + 1, 2)).astype(dtype)
+        data[index] = rng.random((i + 1, 2 + (i % 2)))
 
     s = hs.signals.BaseSignal(data, ragged=True)
     filename = tmp_path / file

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -976,6 +976,76 @@ def test_save_ragged_dim(tmp_path, file, nav_dim, lazy):
             np.testing.assert_allclose(s.data[indices], s2.data[indices])
 
 
+@zspy_marker
+def test_save_ragged_array_csr_lazy_read(tmp_path, file):
+    # A uniform-trailing-shape numeric ragged array (e.g. one (N_i, 2) array
+    # of vectors per position) is written using the dense CSR encoding
+    # (see ZARR_V3_PLAN.md "Phase 3b"). Written eagerly, it must still be
+    # readable back lazily.
+    rng = np.random.default_rng(0)
+    nav_shape = (7, 5)
+    data = np.empty(nav_shape, dtype=object)
+    for ind in np.ndindex(data.shape):
+        num = rng.integers(0, 6)
+        data[ind] = rng.random((num, 2)).astype(np.float32)
+
+    s = hs.signals.BaseSignal(data, ragged=True)
+    filename = tmp_path / file
+    s.save(filename)
+
+    s2 = hs.load(filename, lazy=True)
+    assert isinstance(s2.data, da.Array)
+    assert s2.data.dtype == object
+    computed = s2.data.compute()
+    for ind in np.ndindex(data.shape):
+        np.testing.assert_allclose(data[ind], computed[ind])
+
+
+@zspy_marker
+def test_save_ragged_array_csr_all_empty(tmp_path, file):
+    # Every cell has zero vectors (N_total == 0 across the whole array) --
+    # an edge case the dense CSR encoding needs to handle explicitly since
+    # some backends can't chunk a zero-length axis with automatic guessing.
+    nav_shape = (4, 3)
+    data = np.empty(nav_shape, dtype=object)
+    for ind in np.ndindex(data.shape):
+        data[ind] = np.zeros((0, 2), dtype=np.float32)
+
+    s = hs.signals.BaseSignal(data, ragged=True)
+    filename = tmp_path / file
+    s.save(filename)
+
+    s2 = hs.load(filename)
+    for ind in np.ndindex(data.shape):
+        assert s2.data[ind].shape == (0, 2)
+
+
+@zspy_marker
+@pytest.mark.parametrize("heterogeneous", ["shape", "dtype"])
+def test_save_ragged_array_csr_fallback(tmp_path, file, heterogeneous):
+    # Ragged arrays that don't fit the CSR encoding's "uniform trailing
+    # shape, single dtype" requirement (heterogeneous per-cell shapes or
+    # mixed dtypes) must still round-trip correctly through the generic
+    # (per-cell object-dtype) fallback encoding.
+    rng = np.random.default_rng(0)
+    data = np.empty((5,), dtype=object)
+    for index in np.ndindex(data.shape):
+        i = index[0]
+        if heterogeneous == "shape":
+            data[index] = rng.random((i + 1, 2 + (i % 2)))
+        else:
+            dtype = np.int32 if i % 2 else np.float64
+            data[index] = rng.random((i + 1, 2)).astype(dtype)
+
+    s = hs.signals.BaseSignal(data, ragged=True)
+    filename = tmp_path / file
+    s.save(filename)
+
+    s2 = hs.load(filename)
+    for index in np.ndindex(data.shape):
+        np.testing.assert_allclose(data[index], s2.data[index])
+
+
 def test_load_missing_extension(caplog):
     path = TEST_DATA_PATH / "hspy_ext_missing.hspy"
     with pytest.warns(UserWarning):

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -1125,6 +1125,29 @@ def test_rewrite_csr_key_with_heterogeneous_ragged(tmp_path, file):
             np.testing.assert_allclose(heterogeneous[index], out[index])
 
 
+@zspy_marker
+def test_ragged_dataset_error_retry_is_bounded(tmp_path, file, monkeypatch):
+    # The ragged write retries dataset creation once, to clear a conflicting
+    # dataset left by the other encoding. A TypeError that a delete can't
+    # resolve -- one coming from the data itself -- must propagate rather than
+    # spin forever, which would hang the write instead of reporting the error.
+    calls = []
+
+    def always_raises(*args, **kwargs):
+        calls.append(1)
+        raise TypeError("unrelated to any existing dataset")
+
+    with _scratch_group(tmp_path / file, file) as (writer, _reader_cls, group):
+        monkeypatch.setattr(writer, "_get_object_dset", staticmethod(always_raises))
+        with pytest.raises(TypeError, match="unrelated"):
+            writer.overwrite_dataset(
+                group, _ragged([(1, 3), (2, 2)]), "data", show_progressbar=False
+            )
+
+    # At most two attempts, each creating at most the data and shapes datasets.
+    assert len(calls) <= 4
+
+
 def test_format_version_bumped_for_csr():
     # The CSR encoding is a new on-disk format: readers predating it would
     # silently misread such a dataset as a plain dense array, so the format

--- a/rsciio/tests/test_hspy.py
+++ b/rsciio/tests/test_hspy.py
@@ -20,6 +20,7 @@ import importlib
 import logging
 import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import dask.array as da
@@ -1044,6 +1045,95 @@ def test_save_ragged_array_csr_fallback(tmp_path, file, heterogeneous):
     s2 = hs.load(filename)
     for index in np.ndindex(data.shape):
         np.testing.assert_allclose(data[index], s2.data[index])
+
+
+def _ragged(shapes, dtype=np.float64):
+    data = np.empty((len(shapes),), dtype=object)
+    for i, shape in enumerate(shapes):
+        data[i] = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
+    return data
+
+
+@contextmanager
+def _scratch_group(path, file):
+    """Yield ``(writer_cls, reader_cls, group)`` for a .hspy or .zspy file.
+
+    These tests drive ``overwrite_dataset`` directly because rewriting an
+    existing key isn't reachable through ``save()`` -- a full-file save
+    recreates the signal group first.
+    """
+    if ".hspy" in file:
+        from rsciio.hspy._api import HyperspyReader, HyperspyWriter
+
+        with h5py.File(path, "w") as f:
+            yield HyperspyWriter, HyperspyReader, f.create_group("group")
+    else:
+        zarr = pytest.importorskip("zarr")
+        from rsciio.zspy._api import ZspyReader, ZspyWriter
+
+        yield ZspyWriter, ZspyReader, zarr.group()
+
+
+def _read_back(reader_cls, group, key):
+    # The readers' __init__ validates a whole hspy/zspy file; these tests only
+    # need the array-reconstruction half.
+    reader = object.__new__(reader_cls)
+    out = reader._read_array(group, key)
+    return out.compute() if hasattr(out, "compute") else np.asarray(out)
+
+
+@zspy_marker
+def test_rewrite_csr_key_clears_stale_state(tmp_path, file):
+    # Rewriting a key must not leave the previous encoding's bookkeeping
+    # behind: a dense array written over a CSR-encoded key used to keep the
+    # `_ragged_encoding` attribute (require_dataset reuses the dataset when
+    # shape and dtype match) and was then silently read back as ragged.
+    with _scratch_group(tmp_path / file, file) as (writer, reader_cls, group):
+        writer.overwrite_dataset(
+            group, _ragged([(1,), (2,), (3,)]), "data", show_progressbar=False
+        )
+        assert group["data"].attrs["_ragged_encoding"] == "csr"
+
+        # A dense array of exactly the CSR values' shape and dtype.
+        dense = np.arange(6, dtype=np.float64) * 10
+        writer.overwrite_dataset(group, dense, "data", show_progressbar=False)
+        assert "_ragged_encoding" not in group["data"].attrs
+        assert "_ragged_offsets_data" not in group
+
+        out = _read_back(reader_cls, group, "data")
+        assert out.dtype == np.float64
+        np.testing.assert_allclose(out, dense)
+
+
+@zspy_marker
+def test_rewrite_csr_key_with_heterogeneous_ragged(tmp_path, file):
+    # Overwriting a CSR-encoded key with ragged data that only the generic
+    # encoding can represent must succeed: the existing dense dataset has a
+    # different shape, so it has to be deleted and recreated.
+    heterogeneous = _ragged([(1, 3), (2, 2)])
+
+    with _scratch_group(tmp_path / file, file) as (writer, reader_cls, group):
+        writer.overwrite_dataset(
+            group, _ragged([(2, 2), (3, 2)]), "data", show_progressbar=False
+        )
+        writer.overwrite_dataset(group, heterogeneous, "data", show_progressbar=False)
+        assert "_ragged_encoding" not in group["data"].attrs
+        assert "_ragged_offsets_data" not in group
+
+        out = _read_back(reader_cls, group, "data")
+        for index in np.ndindex(heterogeneous.shape):
+            np.testing.assert_allclose(heterogeneous[index], out[index])
+
+
+def test_format_version_bumped_for_csr():
+    # The CSR encoding is a new on-disk format: readers predating it would
+    # silently misread such a dataset as a plain dense array, so the format
+    # version must be ahead of 3.3 for their "newer version" warning to fire.
+    from packaging.version import Version
+
+    from rsciio._hierarchical import version
+
+    assert Version(version) > Version("3.3")
 
 
 def test_load_missing_extension(caplog):

--- a/rsciio/tests/test_zspy.py
+++ b/rsciio/tests/test_zspy.py
@@ -132,15 +132,23 @@ class TestZspy:
         assert "_ragged_offsets_data" in f["Experiments/__unnamed__"]
         assert "_ragged_shapes_data" not in f["Experiments/__unnamed__"]
 
-    def test_ragged_heterogeneous_uses_generic_encoding(self, tmp_path):
-        # Heterogeneous per-cell shapes don't fit the CSR encoding and must
-        # fall back to the generic object-dtype/shapes-sidecar mechanism.
+    @pytest.mark.parametrize("heterogeneous", ["shape", "dtype"])
+    def test_ragged_heterogeneous_uses_generic_encoding(self, tmp_path, heterogeneous):
+        # Ragged data that doesn't fit the CSR encoding's "uniform trailing
+        # shape, single dtype" requirement must fall back to the generic
+        # object-dtype/shapes-sidecar mechanism. Mixed dtypes matter in
+        # particular: CSR concatenates all cells into one buffer, which would
+        # silently coerce them to a common dtype if the predicate accepted it.
         filename = tmp_path / "testfile.zspy"
         rng = np.random.default_rng(0)
         data = np.empty((5,), dtype=object)
         for index in np.ndindex(data.shape):
             i = index[0]
-            data[index] = rng.random((i + 1, 2 + (i % 2)))
+            if heterogeneous == "shape":
+                data[index] = rng.random((i + 1, 2 + (i % 2)))
+            else:
+                dtype = np.int32 if i % 2 else np.float64
+                data[index] = rng.random((i + 1, 2)).astype(dtype)
 
         hs.signals.BaseSignal(data, ragged=True).save(filename)
 

--- a/rsciio/tests/test_zspy.py
+++ b/rsciio/tests/test_zspy.py
@@ -111,6 +111,46 @@ class TestZspy:
         d = f["Experiments/__unnamed__/data"]
         assert d.compressor == comp
 
+    def test_ragged_vectors_use_csr_encoding(self, tmp_path):
+        # A numeric ragged array with a uniform trailing shape (e.g. one
+        # (N_i, 2) array of vectors per position) must be written with the
+        # dense CSR (values + offsets) encoding, not the generic per-cell
+        # object-dtype encoding -- see ZARR_V3_PLAN.md "Phase 3b".
+        filename = tmp_path / "testfile.zspy"
+        rng = np.random.default_rng(0)
+        data = np.empty((4, 3), dtype=object)
+        for ind in np.ndindex(data.shape):
+            data[ind] = rng.random((rng.integers(0, 5), 2)).astype(np.float32)
+
+        hs.signals.BaseSignal(data, ragged=True).save(filename)
+
+        f = zarr.open(filename.__str__(), mode="r")
+        d = f["Experiments/__unnamed__/data"]
+        assert d.dtype != object
+        assert d.attrs["_ragged_encoding"] == "csr"
+        assert d.attrs["_ragged_nav_shape"] == [4, 3]
+        assert "_ragged_offsets_data" in f["Experiments/__unnamed__"]
+        assert "_ragged_shapes_data" not in f["Experiments/__unnamed__"]
+
+    def test_ragged_heterogeneous_uses_generic_encoding(self, tmp_path):
+        # Heterogeneous per-cell shapes don't fit the CSR encoding and must
+        # fall back to the generic object-dtype/shapes-sidecar mechanism.
+        filename = tmp_path / "testfile.zspy"
+        rng = np.random.default_rng(0)
+        data = np.empty((5,), dtype=object)
+        for index in np.ndindex(data.shape):
+            i = index[0]
+            data[index] = rng.random((i + 1, 2 + (i % 2)))
+
+        hs.signals.BaseSignal(data, ragged=True).save(filename)
+
+        f = zarr.open(filename.__str__(), mode="r")
+        d = f["Experiments/__unnamed__/data"]
+        assert d.dtype == object
+        assert "_ragged_encoding" not in d.attrs
+        assert "_ragged_shapes_data" in f["Experiments/__unnamed__"]
+        assert "_ragged_offsets_data" not in f["Experiments/__unnamed__"]
+
     @pytest.mark.parametrize("compressor", (None, "default", "blosc"))
     def test_compression(self, compressor, tmp_path):
         if compressor == "blosc":

--- a/upcoming_changes/536.enhancements.rst
+++ b/upcoming_changes/536.enhancements.rst
@@ -1,0 +1,1 @@
+:ref:`hspy-format` and :ref:`zspy-format`: store ragged arrays with a uniform, numeric per-position shape (e.g. marker or diffraction-vector coordinates) as a single dense array with an offsets index instead of one blob per position, reducing file size and improving read/write performance. Ragged arrays that don't fit this case (e.g. ragged strings) are unaffected.


### PR DESCRIPTION
### Description of the change

Ragged arrays (`dtype=object`, one variable-length cell per navigation
position) are currently always written one independent object-dtype/vlen
blob per cell (`zarr`'s `VLenArray`/`MsgPack` object codec, or h5py's
`vlen_dtype`). That's necessary for genuinely heterogeneous data (ragged
strings, mixed dtypes, varying per-cell shapes), but it's overkill for the
very common case of *numeric ragged arrays where every cell shares the same
trailing shape and only the leading (count) dimension varies* — e.g. one
`(N_i, 2)` array of vector/point coordinates per position, which is exactly
what `Points`/`Lines`/`Rectangles` markers and diffraction-vector signals
store.

This PR adds an automatic, opt-in-by-shape alternative encoding for that
case:
- A single dense `values` array: every cell's rows concatenated along axis
  0, in the same flattened (row-major) nav order the existing
  `flatten_data` helper already walks. Since it's a concrete (non-object)
  dtype, it's chunked and compressed exactly like any ordinary dataset —
  no per-cell codec involved at all.
- A small `_ragged_offsets_<key>` sidecar: the cumulative per-cell row
  count (one `int64` per navigation position, not per vector), used to
  slice `values` back into cells on read.
- A per-dataset `_ragged_encoding="csr"` attribute so the reader knows
  which reconstruction path to use; datasets without it keep going through
  the existing generic path unchanged, so old files and non-conforming
  ragged data are unaffected.

The encoding is selected automatically from the actual data shape at write
time — no API change for callers (HyperSpy/pyxem don't need to opt in).
Detection and both write/read paths live entirely in
`rsciio/_hierarchical.py`, shared by both `hspy` (h5py) and `zspy` (zarr).

Because this is a new on-disk format, the hspy/zspy format version is
bumped to **3.4**. Readers predating it don't know about
`_ragged_encoding` and would otherwise silently misread a CSR-encoded
dataset as a plain dense array; the bump makes them emit the existing
"written using a newer version of the file format" warning.

Rewriting a key also clears any ragged bookkeeping from the previous
write (marker attributes and both sidecar flavours), so switching a key
between the two encodings — in either direction — is correct and doesn't
leave orphan sidecars behind.

**Known limitations / follow-ups**, flagged for discussion rather than
silently deferred:
- Lazy (dask-backed) ragged *writes* still go through the existing
  generic per-cell encoding; only eager writes take the new CSR path.
  Making the write itself lazy needs dask's "unknown chunk size" machinery
  and felt like a separate, larger piece of work.
- Read-side lazy reconstruction currently chunks along the outermost
  navigation axis only (each dask block = one or more whole "rows" of the
  nav grid). Correct for any navigation shape, just coarser-grained than
  optimal for very wide navigation grids with small physical `values`
  chunks.
Opening as a draft since this introduces a new (if narrowly-scoped and
backward-compatible) on-disk representation, and I'd like input on the
approach — in particular whether the encoding-selection heuristic and
attribute name are reasonable — before finishing off the follow-ups above.

---

### Measurements

Ragged diffraction-vector-shaped data: one `(N_i, 2)` float64 array per
navigation position, `N_i` uniform-random. Best of 3 runs, macOS, against
`upstream/main` at the same commit this branch is based on. Load is an
eager `hs.load()` of the whole ragged array.

| config | metric | main | this PR | |
|---|---|---|---|---|
| **zspy** 128×128, 318k vectors | size | 4749.9 KB | 4439.4 KB | −6.5% |
| | save | 57.2 ms | 27.4 ms | **2.09× faster** |
| | load | 47.1 ms | 19.2 ms | **2.46× faster** |
| **zspy** 64×64, 101k vectors | size | 1508.8 KB | 1412.8 KB | −6.4% |
| | save | 24.4 ms | 17.8 ms | 1.37× faster |
| | load | 16.8 ms | 9.8 ms | 1.72× faster |
| **hspy** 128×128, 318k vectors | size | 5873.4 KB | 4280.5 KB | **−27.1%** |
| | save | 57.9 ms | 116.1 ms | 2.00× slower |
| | load | 55.7 ms | 32.9 ms | **1.69× faster** |
| **hspy** 64×64, 101k vectors | size | 1840.2 KB | 1378.0 KB | −25.1% |
| | save | 15.1 ms | 37.1 ms | 2.47× slower |
| | load | 17.2 ms | 12.9 ms | 1.34× faster |

**On the hspy save regression** — it is compression cost, not encoding
cost. Isolating it on the 128×128 case:

| hspy 128×128 | main | this PR |
|---|---|---|
| save, `compression=None` | 53.4 ms | **16.5 ms** (3.2× faster) |
| save, `compression="gzip"` (default) | 56.7 ms | 117.1 ms |
| what gzip actually achieves | 6297 → 5873 KB (6.7%) | 6012 → 4280 KB (**29%**) |

Uncompressed, the CSR write path is 3.2× faster. With gzip it is slower
because the dense buffer gives gzip real cross-cell redundancy to exploit
— it removes 29% versus 6.7%, i.e. roughly 4× more compression work for a
27% smaller file. zspy shows the same effect without the penalty because
its default Blosc/zstd is a much faster codec, which is why zspy wins on
size *and* both directions of throughput.

So on hspy this is a genuine time/space trade, not a free win: a smaller
file for a slower save. Worth a maintainer opinion on whether that default
is the right one — it is easy to keep the current behaviour for hspy if
not.

### Forward-compatibility with zarr 3

This is the part I think matters most beyond the throughput numbers.
Because `values` and `offsets` are plain concrete-dtype arrays, CSR-encoded
data needs none of the object-codec machinery that blocks zarr 3 support
(see #352). Files written **here under zarr 2.18.7**, then opened under
**zarr 3.2.1**:

```
--- CSR encoding (this PR) ---
  OK  dtype=float64 shape=(1764, 2) sum=224525.2029
  offsets OK: shape=(257,) last=1764 (== rows: True)
  attrs: {'_ragged_encoding': 'csr', '_ragged_nav_shape': [16, 16]}

--- generic object-dtype (main) ---
  FAILED  ValueError: No Zarr data type found that matches
          {'name': '|O', 'object_codec_id': 'vlen-array'}
```

The ragged array reconstructs completely under zarr 3 with nothing but
numpy — no rsciio v3 port required for the data itself:

```python
values  = grp["data"][:]
offsets = grp["_ragged_offsets_data"][:]
nav     = tuple(grp["data"].attrs["_ragged_nav_shape"])
cells   = np.split(values, offsets[1:-1], axis=0)
# -> reconstructed ragged array (16, 16), 1764 vectors, cells intact
```

That is the practical significance: vector/marker data saved in this
encoding stays readable across the zarr 2 → 3 transition, whereas the same
data in the current encoding does not. It doesn't make rsciio zarr-3 ready
on its own — the writer still uses v2-only APIs — but it removes ragged
vector data from the set of things that transition has to solve.

### Progress of the PR
- [x] Change implemented
- [ ] update docstring (if appropriate)
- [ ] update user guide (if appropriate)
- [x] add a changelog entry in the `upcoming_changes` folder
- [ ] Check formatting of the changelog entry in the readthedocs build
- [x] add tests
- [ ] ready for review

### Minimal example of the new feature
```python
import numpy as np
import hyperspy.api as hs

data = np.empty((10, 10), dtype=object)
for index in np.ndindex(data.shape):
    n = np.random.randint(0, 8)
    data[index] = np.random.random((n, 2))  # e.g. per-position vectors

s = hs.signals.BaseSignal(data, ragged=True)
s.save("vectors.zspy")  # written via the new dense CSR encoding

s2 = hs.load("vectors.zspy", lazy=True)  # reconstructed lazily
```