### PR TITLE
Run the free-threaded test leg on Python 3.14t instead of 3.13t

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
             HYPERSPY_VERSION: 'release'
           - os: ubuntu
             os_version: latest
-            PYTHON_VERSION: '3.13t'
+            PYTHON_VERSION: '3.14t'
             LABEL: '-hyperspy-minimum'
             HYPERSPY_VERSION: 'dev'
 
@@ -131,31 +131,31 @@ jobs:
           echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
 
       - name: Display GIL information
-        if: ${{ contains(matrix.PYTHON_VERSION, '3.13') }}
+        if: ${{ contains(matrix.PYTHON_VERSION, '3.13') || endsWith(matrix.PYTHON_VERSION, 't') }}
         run: |
           # show if free-threaded build
           python -VV
           # show if GIL is enable
           python -c "import sys; print('GIL enabled:', sys._is_gil_enabled())"
 
-      - name: Install hyperspy (3.13t)
-        if: ${{ matrix.PYTHON_VERSION == '3.13t'}}
+      - name: Install hyperspy (3.14t)
+        if: ${{ matrix.PYTHON_VERSION == '3.14t'}}
         run: |
           # no freethreaded build available for h5py
-          # install other dependencies manually 
+          # install other dependencies manually
           pip install cloudpickle dask[array] importlib-metadata jinja2 matplotlib natsort numpy packaging pint prettytable pyyaml scikit-image scipy sympy tqdm pooch requests
           pip install traits
-          # with recent version of python3.13t, there are issue with installing from a git repository or source
+          # with recent version of free-threaded python, there are issue with installing from a git repository or source
           # for now, install from pypi, as this is working...
           pip install hyperspy --no-deps
 
       - name: Install hyperspy and exspy (release)
-        if: ${{ matrix.HYPERSPY_VERSION == 'release' && matrix.PYTHON_VERSION != '3.13t'}}
+        if: ${{ matrix.HYPERSPY_VERSION == 'release' && matrix.PYTHON_VERSION != '3.14t'}}
         run: |
           pip install hyperspy exspy
 
       - name: Install hyperspy and exspy (dev)
-        if: ${{ matrix.HYPERSPY_VERSION == 'dev' && matrix.PYTHON_VERSION != '3.13t' }}
+        if: ${{ matrix.HYPERSPY_VERSION == 'dev' && matrix.PYTHON_VERSION != '3.14t' }}
         run: |
           pip install git+https://github.com/hyperspy/hyperspy.git
           pip install git+https://github.com/hyperspy/exspy.git


### PR DESCRIPTION
### Description of the change

The `ubuntu-latest-py3.13t-hyperspy-minimum` leg has been failing on
`main` since around the end of June (last green run I found was
2026-06-09; failing from 2026-06-29 onwards). It fails during install,
before any test runs:

```
Collecting scipy
  Downloading scipy-1.18.0.tar.gz (30.8 MB)
...
../scipy/meson.build:296:11: ERROR: Dependency "OpenBLAS" not found (tried pkg-config and cmake)
error: metadata-generation-failed
```

**Cause:** the scientific Python stack has moved its free-threaded wheels
from `cp313t` to `cp314t`. scipy 1.17 shipped `cp313t` wheels, but 1.18.0
ships `cp314t` only — so on 3.13t there is no wheel, pip falls back to the
sdist, and the source build needs an OpenBLAS the runner doesn't have.

It isn't only scipy. Checking PyPI for the packages this leg installs:

| package | latest | `cp314t` wheels | `cp313t` wheels |
|---|---|---|---|
| numpy | 2.5.1 | 10 | **0** |
| scipy | 1.18.0 | 10 | **0** |
| PyYAML | 6.0.3 | 9 | **0** |
| traits | 7.1.0 | 6 | **0** |
| h5py | 3.16.0 | 8 | **0** |
| matplotlib | 3.11.1 | 7 | 7 |
| scikit-image | 0.26.0 | 8 | 8 |

So there are several more source builds queued up behind scipy; pinning
scipy would just move the failure to the next package.

This moves the leg to **3.14t**, where every dependency it installs has a
wheel (I checked the compiled transitive deps too — markupsafe, contourpy,
kiwisolver, pillow, fonttools, charset-normalizer all ship `cp314t`; the
rest are pure-Python).

The step conditions are keyed on the exact version string, so they all
have to move together — leaving one on `'3.13t'` would silently route the
leg into the generic "install hyperspy from git" step instead of the
free-threaded one. I also widened the "Display GIL information" condition
so it still fires for the free-threaded build.

**Note for a possible follow-up (not done here):** the special-cased
install step exists because "no freethreaded build available for h5py".
That is no longer true — h5py 3.16.0 ships 8 `cp314t` wheels. The manual
dependency list and `--no-deps` hyperspy install could likely be dropped
now, which would also let this leg use the normal `[all, tests]` selector
and actually exercise the hspy/zspy tests. I left that out to keep this
change to the minimum needed to make the leg build, since it would newly
enable a lot of tests on free-threaded Python and is better evaluated on
its own.

### Progress of the PR
- [x] Change implemented
- [ ] update docstring (if appropriate) — n/a
- [ ] update user guide (if appropriate) — n/a
- [ ] add a changelog entry in the `upcoming_changes` folder — n/a, CI-only change (consistent with previous workflow-only commits)
- [ ] Check formatting of the changelog entry — n/a
- [ ] add tests — n/a, this is the test configuration
- [x] ready for review