### PR TITLE
Add gwyddion.net to the link check ignore list

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -143,6 +143,7 @@ linkcheck_ignore = [
     "https://doi.org/10.5281/zenodo",  # resolves to zenodo.org, also blocked
     "https://www.tofwerk.com/software/tofdaq",  # 403 blocked
     "https://microscopy.org",  # Time out, Max retries exceeded with url
+    "http://gwyddion.net",  # Intermittent, Network is unreachable from CI
 ]
 
 # https://github.com/sphinx-doc/sphinx/issues/12589#issuecomment-2229491106


### PR DESCRIPTION
### Description of the change

The `Build / Check links` job intermittently fails on the gwyddion.net
link in the Renishaw docs (`doc/supported_formats/renishaw.rst:37`):

```
(supported_formats/renishaw: line 37) broken    http://gwyddion.net -
HTTPConnectionPool(host='gwyddion.net', port=80): Max retries exceeded with url: /
(Caused by NewConnectionError("...: Failed to establish a new connection: [Errno 101] Network is unreachable"))
```

The site itself is fine — it responds `200` over both `http://` and
`https://` — so this is the runner failing to reach it rather than a dead
link, which is the same symptom as the `microscopy.org` entry already on
the list. It is intermittent: it failed on one PR, passed on a re-run of
the same PR, then failed again on an unrelated one.

Adding it to `linkcheck_ignore`, matching the existing entries' style and
with a comment explaining why.

Trade-off worth naming: this does mean the URL stops being link-checked,
so if it genuinely dies later we won't hear about it. The alternative is
to keep re-running the job on each spurious failure. Happy to close this
if you'd rather keep it monitored and just live with the flake.

### Progress of the PR
- [x] Change implemented
- [ ] update docstring (if appropriate) — n/a
- [ ] update user guide (if appropriate) — n/a
- [ ] add a changelog entry in the `upcoming_changes` folder — n/a, CI/docs-infrastructure only
- [ ] Check formatting of the changelog entry — n/a
- [ ] add tests — n/a
- [x] ready for review